### PR TITLE
feat: API Key Guard 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,8 @@ R2_SECRET_ACCESS_KEY=your_secret_key
 R2_BUCKET_NAME=hyunwoo-assets
 R2_PUBLIC_URL=https://assets.chahyunwoo.dev
 
+# API Key - generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+API_KEY=your_api_key_here
+
 # CORS (comma-separated)
 ALLOWED_ORIGINS=https://chahyunwoo.dev,https://www.chahyunwoo.dev

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 
 import { Public } from '../common/decorators/public.decorator';
+import { SkipApiKey } from '../common/decorators/skip-api-key.decorator';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 
@@ -11,6 +12,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Public()
+  @SkipApiKey()
   @Post('login')
   @HttpCode(HttpStatus.OK)
   @ApiOkResponse({ schema: { properties: { accessToken: { type: 'string' } } } })

--- a/src/common/decorators/skip-api-key.decorator.ts
+++ b/src/common/decorators/skip-api-key.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const SKIP_API_KEY = 'skipApiKey';
+export const SkipApiKey = () => SetMetadata(SKIP_API_KEY, true);

--- a/src/common/guards/api-key.guard.ts
+++ b/src/common/guards/api-key.guard.ts
@@ -1,0 +1,37 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+import type { FastifyRequest } from 'fastify';
+import { SKIP_API_KEY } from '../decorators/skip-api-key.decorator';
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly config: ConfigService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const skipApiKey = this.reflector.getAllAndOverride<boolean>(SKIP_API_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (skipApiKey) return true;
+
+    const request = context.switchToHttp().getRequest<FastifyRequest>();
+    const apiKey = request.headers['x-api-key'];
+    const expectedKey = this.config.getOrThrow<string>('API_KEY');
+
+    if (apiKey !== expectedKey) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    return true;
+  }
+}

--- a/src/common/http.module.ts
+++ b/src/common/http.module.ts
@@ -3,11 +3,13 @@ import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { ThrottlerGuard } from '@nestjs/throttler';
 
 import { HttpExceptionFilter } from './filters/http-exception.filter';
+import { ApiKeyGuard } from './guards/api-key.guard';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @Module({
   providers: [
     { provide: APP_FILTER, useClass: HttpExceptionFilter },
+    { provide: APP_GUARD, useClass: ApiKeyGuard },
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],

--- a/src/health.controller.ts
+++ b/src/health.controller.ts
@@ -2,11 +2,13 @@ import { Controller, Get } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
 import { Public } from './common/decorators/public.decorator';
+import { SkipApiKey } from './common/decorators/skip-api-key.decorator';
 
 @ApiTags('health')
 @Controller()
 export class HealthController {
   @Public()
+  @SkipApiKey()
   @Get('health')
   check() {
     return { status: 'ok', timestamp: new Date().toISOString() };


### PR DESCRIPTION
## Summary
- 모든 API 요청에 x-api-key 헤더 검증 Guard 추가
- health, login 엔드포인트는 @SkipApiKey()로 예외 처리
- 어드민 API는 기존 JWT 인증 그대로 유지