### PR TITLE
feat: 프로필 이미지/아이콘 관리 + 어드민 API Key 바이패스

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ model Profile {
   name         String               @db.VarChar(100)
   location     String               @db.VarChar(200)
   imageUrl     String?              @map("image_url") @db.VarChar(1000)
+  iconUrl      String?              @map("icon_url") @db.VarChar(1000)
   socialLinks  Json?                @map("social_links")
   translations ProfileTranslation[]
 

--- a/src/common/guards/api-key.guard.ts
+++ b/src/common/guards/api-key.guard.ts
@@ -25,6 +25,11 @@ export class ApiKeyGuard implements CanActivate {
     if (skipApiKey) return true;
 
     const request = context.switchToHttp().getRequest<FastifyRequest>();
+
+    // JWT Bearer 토큰이 있으면 어드민 요청이므로 API Key 체크 건너뜀
+    const authHeader = request.headers.authorization;
+    if (authHeader?.startsWith('Bearer ')) return true;
+
     const apiKey = request.headers['x-api-key'];
     const expectedKey = this.config.getOrThrow<string>('API_KEY');
 

--- a/src/portfolio/dto/update-profile.dto.ts
+++ b/src/portfolio/dto/update-profile.dto.ts
@@ -54,6 +54,16 @@ export class UpdateProfileDto {
   @IsString()
   location?: string;
 
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl({}, { message: 'imageUrl must be a valid URL' })
+  imageUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl({}, { message: 'iconUrl must be a valid URL' })
+  iconUrl?: string;
+
   @ApiPropertyOptional({ type: [SocialLinkDto] })
   @IsOptional()
   @IsArray()

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -11,6 +11,7 @@ interface CacheStore {
 
 import { PrismaService } from '../prisma/prisma.service';
 import { RevalidationService } from '../revalidation/revalidation.service';
+import { StorageService } from '../storage/storage.service';
 import type {
   CreateEducationDto,
   CreateExperienceDto,
@@ -31,6 +32,7 @@ export class PortfolioService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly revalidation: RevalidationService,
+    private readonly storage: StorageService,
     @Inject(CACHE_MANAGER) private readonly cache: CacheStore,
   ) {}
 
@@ -69,6 +71,7 @@ export class PortfolioService {
       name: profile.name,
       location: profile.location,
       imageUrl: profile.imageUrl,
+      iconUrl: profile.iconUrl,
       socialLinks: profile.socialLinks,
       jobTitle: t?.jobTitle ?? '',
       introduction: t?.introduction ?? [],
@@ -86,15 +89,26 @@ export class PortfolioService {
         data: {
           name: dto.name ?? '',
           location: dto.location ?? '',
+          imageUrl: dto.imageUrl,
+          iconUrl: dto.iconUrl,
           socialLinks: (dto.socialLinks ?? undefined) as unknown as Prisma.InputJsonValue,
         },
       });
     } else {
+      if (dto.imageUrl !== undefined && profile.imageUrl) {
+        await this.storage.delete(profile.imageUrl);
+      }
+      if (dto.iconUrl !== undefined && profile.iconUrl) {
+        await this.storage.delete(profile.iconUrl);
+      }
+
       profile = await this.prisma.profile.update({
         where: { id: profile.id },
         data: {
           ...(dto.name !== undefined && { name: dto.name }),
           ...(dto.location !== undefined && { location: dto.location }),
+          ...(dto.imageUrl !== undefined && { imageUrl: dto.imageUrl }),
+          ...(dto.iconUrl !== undefined && { iconUrl: dto.iconUrl }),
           ...(dto.socialLinks !== undefined && {
             socialLinks: dto.socialLinks as unknown as Prisma.InputJsonValue,
           }),


### PR DESCRIPTION
## Summary
- Profile에 iconUrl 필드 추가 (이미지/아이콘 분리 관리)
- 프로필 수정 시 기존 이미지/아이콘 R2 자동 삭제 후 교체
- JWT Bearer 토큰 있으면 API Key 검증 건너뜀 (어드민 요청)