### PR TITLE
feat: locale 목록 API 추가

### DIFF
--- a/src/portfolio/dto/locale-query.dto.ts
+++ b/src/portfolio/dto/locale-query.dto.ts
@@ -1,12 +1,11 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional, IsString } from 'class-validator';
-
-const SUPPORTED_LOCALES = ['ko', 'en', 'jp'] as const;
+import { LOCALE_CODES } from '../portfolio.constants';
 
 export class LocaleQueryDto {
-  @ApiPropertyOptional({ default: 'ko', enum: SUPPORTED_LOCALES })
+  @ApiPropertyOptional({ default: 'ko', enum: LOCALE_CODES })
   @IsOptional()
   @IsString()
-  @IsIn(SUPPORTED_LOCALES)
+  @IsIn(LOCALE_CODES)
   locale?: string = 'ko';
 }

--- a/src/portfolio/portfolio.constants.ts
+++ b/src/portfolio/portfolio.constants.ts
@@ -1,0 +1,7 @@
+export const SUPPORTED_LOCALES = [
+  { code: 'ko', label: '한국어' },
+  { code: 'en', label: 'English' },
+  { code: 'jp', label: '日本語' },
+] as const;
+
+export const LOCALE_CODES = SUPPORTED_LOCALES.map(l => l.code);

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -26,6 +26,7 @@ import {
   UpdateProjectDto,
   UpdateSkillDto,
 } from './dto';
+import { SUPPORTED_LOCALES } from './portfolio.constants';
 import { PortfolioService } from './portfolio.service';
 
 @ApiTags('portfolio')
@@ -34,6 +35,12 @@ export class PortfolioController {
   constructor(private readonly portfolioService: PortfolioService) {}
 
   // ─── Public ─────────────────────────────────────────────────────────────────
+
+  @Public()
+  @Get('locales')
+  getLocales() {
+    return SUPPORTED_LOCALES;
+  }
 
   @Public()
   @Get('profile')


### PR DESCRIPTION
## Summary
- GET /api/portfolio/locales 엔드포인트 추가
- 응답: [{ code: "ko", label: "한국어" }, { code: "en", label: "English" }, ...]
- locale 상수를 portfolio.constants.ts로 분리, DTO에서 재사용