### PR TITLE
feat: locale CRUD + Swagger 에러 문서화

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,15 @@ model PostTag {
 
 // ─── Portfolio ───────────────────────────────────────────────────────────────
 
+model Locale {
+  id    Int    @id @default(autoincrement())
+  code  String @unique @db.VarChar(5)
+  label String @db.VarChar(50)
+
+  @@map("locales")
+  @@schema("portfolio")
+}
+
 model Profile {
   id           Int                  @id @default(autoincrement())
   name         String               @db.VarChar(100)

--- a/scripts/seed-portfolio.ts
+++ b/scripts/seed-portfolio.ts
@@ -18,6 +18,21 @@ async function main() {
   const prisma = new PrismaClient({ adapter });
 
   try {
+    // ─── Locales ──────────────────────────────────────────────────────────────
+    const locales = [
+      { code: 'ko', label: '한국어' },
+      { code: 'en', label: 'English' },
+      { code: 'jp', label: '日本語' },
+    ];
+    for (const locale of locales) {
+      await prisma.locale.upsert({
+        where: { code: locale.code },
+        create: locale,
+        update: {},
+      });
+    }
+    console.log(`Locales upserted: ${locales.length}`);
+
     // ─── Profile ──────────────────────────────────────────────────────────────
     const profile = await prisma.profile.create({
       data: {

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -14,6 +14,12 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiConsumes, ApiTags } from '@nestjs/swagger';
 import { Public } from '../common/decorators/public.decorator';
+import {
+  ApiBadRequest,
+  ApiConflict,
+  ApiNotFound,
+  ApiUnauthorized,
+} from '../common/swagger/error-responses';
 import type { MultipartRequest } from '../types/fastify.d';
 import { ALLOWED_MIME_TYPES } from './blog.constants';
 import { BlogService } from './blog.service';
@@ -26,9 +32,9 @@ import { UpdatePostDto } from './dto/update-post.dto';
 export class BlogController {
   constructor(private readonly blogService: BlogService) {}
 
-  // NOTE: /search must be registered before /:slug to avoid route conflict
   @Public()
   @Get('posts/search')
+  @ApiBadRequest('q must be at least 2 characters')
   search(@Query() query: SearchQueryDto) {
     return this.blogService.search(query);
   }
@@ -59,12 +65,14 @@ export class BlogController {
 
   @Public()
   @Get('posts/:slug')
+  @ApiNotFound('Post')
   findOne(@Param('slug') slug: string) {
     return this.blogService.findBySlug(slug);
   }
 
   @Public()
   @Get('posts/:slug/related')
+  @ApiNotFound('Post')
   getRelatedPosts(@Param('slug') slug: string) {
     return this.blogService.getRelatedPosts(slug);
   }
@@ -72,12 +80,17 @@ export class BlogController {
   @ApiBearerAuth()
   @Post('posts')
   @HttpCode(HttpStatus.CREATED)
+  @ApiUnauthorized()
+  @ApiBadRequest()
+  @ApiConflict('Slug already exists')
   create(@Body() dto: CreatePostDto) {
     return this.blogService.create(dto);
   }
 
   @ApiBearerAuth()
   @Put('posts/:slug')
+  @ApiUnauthorized()
+  @ApiNotFound('Post')
   update(@Param('slug') slug: string, @Body() dto: UpdatePostDto) {
     return this.blogService.update(slug, dto);
   }
@@ -85,6 +98,8 @@ export class BlogController {
   @ApiBearerAuth()
   @Delete('posts/:slug')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiUnauthorized()
+  @ApiNotFound('Post')
   remove(@Param('slug') slug: string) {
     return this.blogService.remove(slug);
   }
@@ -92,6 +107,9 @@ export class BlogController {
   @ApiBearerAuth()
   @Post('posts/:slug/thumbnail')
   @ApiConsumes('multipart/form-data')
+  @ApiUnauthorized()
+  @ApiNotFound('Post')
+  @ApiBadRequest('No file provided or invalid file type')
   async uploadThumbnail(@Param('slug') slug: string, @Req() request: MultipartRequest) {
     const data = await request.file();
     if (!data) throw new BadRequestException('No file provided');

--- a/src/common/swagger/error-responses.ts
+++ b/src/common/swagger/error-responses.ts
@@ -1,0 +1,55 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiResponse } from '@nestjs/swagger';
+
+const errorSchema = (statusCode: number, error: string, message: string) => ({
+  schema: {
+    properties: {
+      statusCode: { type: 'number', example: statusCode },
+      error: { type: 'string', example: error },
+      message: { type: 'string', example: message },
+      path: { type: 'string', example: '/api/...' },
+      timestamp: { type: 'string', example: '2026-01-01T00:00:00.000Z' },
+    },
+  },
+});
+
+export const ApiBadRequest = (message = 'Validation failed') =>
+  applyDecorators(
+    ApiResponse({
+      status: 400,
+      description: 'Bad Request',
+      ...errorSchema(400, 'Bad Request', message),
+    }),
+  );
+
+export const ApiUnauthorized = () =>
+  applyDecorators(
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+      ...errorSchema(401, 'Unauthorized', 'Invalid credentials'),
+    }),
+  );
+
+export const ApiNotFound = (entity = 'Resource') =>
+  applyDecorators(
+    ApiResponse({
+      status: 404,
+      description: 'Not Found',
+      ...errorSchema(404, 'Not Found', `${entity} not found`),
+    }),
+  );
+
+export const ApiConflict = (message = 'Resource already exists') =>
+  applyDecorators(
+    ApiResponse({ status: 409, description: 'Conflict', ...errorSchema(409, 'Conflict', message) }),
+  );
+
+export const ApiTooManyRequests = () =>
+  applyDecorators(
+    ApiResponse({
+      status: 429,
+      description: 'Too Many Requests',
+      ...errorSchema(429, 'Too Many Requests', 'Rate limit exceeded'),
+    }),
+  );

--- a/src/portfolio/dto/create-locale.dto.ts
+++ b/src/portfolio/dto/create-locale.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateLocaleDto {
+  @ApiProperty({ example: 'zh' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(5)
+  code: string;
+
+  @ApiProperty({ example: '中文' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  label: string;
+}

--- a/src/portfolio/dto/index.ts
+++ b/src/portfolio/dto/index.ts
@@ -1,5 +1,6 @@
 export { CreateEducationDto } from './create-education.dto';
 export { CreateExperienceDto } from './create-experience.dto';
+export { CreateLocaleDto } from './create-locale.dto';
 export { CreateProjectDto } from './create-project.dto';
 export { CreateSkillDto } from './create-skill.dto';
 export { GetProjectsQueryDto } from './get-projects-query.dto';

--- a/src/portfolio/dto/locale-query.dto.ts
+++ b/src/portfolio/dto/locale-query.dto.ts
@@ -1,11 +1,10 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsIn, IsOptional, IsString } from 'class-validator';
-import { LOCALE_CODES } from '../portfolio.constants';
+import { IsOptional, IsString } from 'class-validator';
+import { DEFAULT_LOCALE } from '../portfolio.constants';
 
 export class LocaleQueryDto {
-  @ApiPropertyOptional({ default: 'ko', enum: LOCALE_CODES })
+  @ApiPropertyOptional({ default: DEFAULT_LOCALE })
   @IsOptional()
   @IsString()
-  @IsIn(LOCALE_CODES)
-  locale?: string = 'ko';
+  locale?: string = DEFAULT_LOCALE;
 }

--- a/src/portfolio/portfolio.constants.ts
+++ b/src/portfolio/portfolio.constants.ts
@@ -1,7 +1,1 @@
-export const SUPPORTED_LOCALES = [
-  { code: 'ko', label: '한국어' },
-  { code: 'en', label: 'English' },
-  { code: 'jp', label: '日本語' },
-] as const;
-
-export const LOCALE_CODES = SUPPORTED_LOCALES.map(l => l.code);
+export const DEFAULT_LOCALE = 'ko';

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -14,8 +14,15 @@ import {
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Public } from '../common/decorators/public.decorator';
 import {
+  ApiBadRequest,
+  ApiConflict,
+  ApiNotFound,
+  ApiUnauthorized,
+} from '../common/swagger/error-responses';
+import {
   CreateEducationDto,
   CreateExperienceDto,
+  CreateLocaleDto,
   CreateProjectDto,
   CreateSkillDto,
   GetProjectsQueryDto,
@@ -26,7 +33,6 @@ import {
   UpdateProjectDto,
   UpdateSkillDto,
 } from './dto';
-import { SUPPORTED_LOCALES } from './portfolio.constants';
 import { PortfolioService } from './portfolio.service';
 
 @ApiTags('portfolio')
@@ -39,11 +45,12 @@ export class PortfolioController {
   @Public()
   @Get('locales')
   getLocales() {
-    return SUPPORTED_LOCALES;
+    return this.portfolioService.getLocales();
   }
 
   @Public()
   @Get('profile')
+  @ApiNotFound('Profile')
   getProfile(@Query() query: LocaleQueryDto) {
     return this.portfolioService.getProfile(query.locale ?? 'ko');
   }
@@ -75,7 +82,27 @@ export class PortfolioController {
   // ─── Admin ──────────────────────────────────────────────────────────────────
 
   @ApiBearerAuth()
+  @Post('locales')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiUnauthorized()
+  @ApiBadRequest()
+  @ApiConflict('Locale already exists')
+  createLocale(@Body() dto: CreateLocaleDto) {
+    return this.portfolioService.createLocale(dto);
+  }
+
+  @ApiBearerAuth()
+  @Delete('locales/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiUnauthorized()
+  @ApiNotFound('Locale')
+  deleteLocale(@Param('id', ParseIntPipe) id: number) {
+    return this.portfolioService.deleteLocale(id);
+  }
+
+  @ApiBearerAuth()
   @Put('profile')
+  @ApiUnauthorized()
   updateProfile(@Body() dto: UpdateProfileDto) {
     return this.portfolioService.updateProfile(dto);
   }
@@ -83,12 +110,16 @@ export class PortfolioController {
   @ApiBearerAuth()
   @Post('experiences')
   @HttpCode(HttpStatus.CREATED)
+  @ApiUnauthorized()
+  @ApiBadRequest()
   createExperience(@Body() dto: CreateExperienceDto) {
     return this.portfolioService.createExperience(dto);
   }
 
   @ApiBearerAuth()
   @Put('experiences/:id')
+  @ApiUnauthorized()
+  @ApiNotFound('Experience')
   updateExperience(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateExperienceDto) {
     return this.portfolioService.updateExperience(id, dto);
   }
@@ -96,6 +127,8 @@ export class PortfolioController {
   @ApiBearerAuth()
   @Delete('experiences/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiUnauthorized()
+  @ApiNotFound('Experience')
   deleteExperience(@Param('id', ParseIntPipe) id: number) {
     return this.portfolioService.deleteExperience(id);
   }
@@ -103,12 +136,16 @@ export class PortfolioController {
   @ApiBearerAuth()
   @Post('projects')
   @HttpCode(HttpStatus.CREATED)
+  @ApiUnauthorized()
+  @ApiBadRequest()
   createProject(@Body() dto: CreateProjectDto) {
     return this.portfolioService.createProject(dto);
   }
 
   @ApiBearerAuth()
   @Put('projects/:id')
+  @ApiUnauthorized()
+  @ApiNotFound('Project')
   updateProject(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateProjectDto) {
     return this.portfolioService.updateProject(id, dto);
   }
@@ -116,6 +153,8 @@ export class PortfolioController {
   @ApiBearerAuth()
   @Delete('projects/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiUnauthorized()
+  @ApiNotFound('Project')
   deleteProject(@Param('id', ParseIntPipe) id: number) {
     return this.portfolioService.deleteProject(id);
   }
@@ -123,12 +162,16 @@ export class PortfolioController {
   @ApiBearerAuth()
   @Post('skills')
   @HttpCode(HttpStatus.CREATED)
+  @ApiUnauthorized()
+  @ApiBadRequest()
   createSkill(@Body() dto: CreateSkillDto) {
     return this.portfolioService.createSkill(dto);
   }
 
   @ApiBearerAuth()
   @Put('skills/:id')
+  @ApiUnauthorized()
+  @ApiNotFound('Skill')
   updateSkill(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateSkillDto) {
     return this.portfolioService.updateSkill(id, dto);
   }
@@ -136,6 +179,8 @@ export class PortfolioController {
   @ApiBearerAuth()
   @Delete('skills/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiUnauthorized()
+  @ApiNotFound('Skill')
   deleteSkill(@Param('id', ParseIntPipe) id: number) {
     return this.portfolioService.deleteSkill(id);
   }
@@ -143,12 +188,16 @@ export class PortfolioController {
   @ApiBearerAuth()
   @Post('education')
   @HttpCode(HttpStatus.CREATED)
+  @ApiUnauthorized()
+  @ApiBadRequest()
   createEducation(@Body() dto: CreateEducationDto) {
     return this.portfolioService.createEducation(dto);
   }
 
   @ApiBearerAuth()
   @Put('education/:id')
+  @ApiUnauthorized()
+  @ApiNotFound('Education')
   updateEducation(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateEducationDto) {
     return this.portfolioService.updateEducation(id, dto);
   }
@@ -156,6 +205,8 @@ export class PortfolioController {
   @ApiBearerAuth()
   @Delete('education/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiUnauthorized()
+  @ApiNotFound('Education')
   deleteEducation(@Param('id', ParseIntPipe) id: number) {
     return this.portfolioService.deleteEducation(id);
   }

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -1,5 +1,5 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 
 interface CacheStore {
@@ -15,6 +15,7 @@ import { StorageService } from '../storage/storage.service';
 import type {
   CreateEducationDto,
   CreateExperienceDto,
+  CreateLocaleDto,
   CreateProjectDto,
   CreateSkillDto,
   UpdateEducationDto,
@@ -44,6 +45,33 @@ export class PortfolioService {
 
   private async invalidateCache(): Promise<void> {
     await this.cache.clear();
+  }
+
+  // ─── Locales ────────────────────────────────────────────────────────────────
+
+  async getLocales() {
+    return this.prisma.locale.findMany({ orderBy: { id: 'asc' } });
+  }
+
+  async createLocale(dto: CreateLocaleDto) {
+    try {
+      return await this.prisma.locale.create({
+        data: { code: dto.code, label: dto.label },
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictException('Locale already exists');
+      }
+      throw error;
+    }
+  }
+
+  async deleteLocale(id: number): Promise<void> {
+    try {
+      await this.prisma.locale.delete({ where: { id } });
+    } catch (error) {
+      this.handleNotFound(error, 'Locale');
+    }
   }
 
   private handleNotFound(error: unknown, entity: string): never {


### PR DESCRIPTION
## Summary
- Locale DB 테이블 추가, 어드민에서 locale 추가/삭제 가능
- 모든 엔드포인트에 Swagger 에러 응답 데코레이터 적용
- 에러 응답 헬퍼 유틸 (ApiBadRequest, ApiNotFound, ApiConflict 등)