### PR TITLE
fix: 포트폴리오 locale 검증 일관성 수정

### DIFF
--- a/src/portfolio/pipes/validate-locale.pipe.ts
+++ b/src/portfolio/pipes/validate-locale.pipe.ts
@@ -1,0 +1,24 @@
+import {
+  type ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  type PipeTransform,
+} from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { DEFAULT_LOCALE } from '../portfolio.constants';
+
+@Injectable()
+export class ValidateLocalePipe implements PipeTransform {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async transform(value: { locale?: string }, _metadata: ArgumentMetadata) {
+    const locale = value?.locale ?? DEFAULT_LOCALE;
+
+    const exists = await this.prisma.locale.findUnique({ where: { code: locale } });
+    if (!exists) {
+      throw new BadRequestException(`Unsupported locale: ${locale}`);
+    }
+
+    return { ...value, locale };
+  }
+}

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -33,6 +33,7 @@ import {
   UpdateProjectDto,
   UpdateSkillDto,
 } from './dto';
+import { ValidateLocalePipe } from './pipes/validate-locale.pipe';
 import { PortfolioService } from './portfolio.service';
 
 @ApiTags('portfolio')
@@ -51,19 +52,22 @@ export class PortfolioController {
   @Public()
   @Get('profile')
   @ApiNotFound('Profile')
-  getProfile(@Query() query: LocaleQueryDto) {
+  @ApiBadRequest('Unsupported locale')
+  getProfile(@Query(ValidateLocalePipe) query: LocaleQueryDto) {
     return this.portfolioService.getProfile(query.locale ?? 'ko');
   }
 
   @Public()
   @Get('experiences')
-  getExperiences(@Query() query: LocaleQueryDto) {
+  @ApiBadRequest('Unsupported locale')
+  getExperiences(@Query(ValidateLocalePipe) query: LocaleQueryDto) {
     return this.portfolioService.getExperiences(query.locale ?? 'ko');
   }
 
   @Public()
   @Get('projects')
-  getProjects(@Query() query: GetProjectsQueryDto) {
+  @ApiBadRequest('Unsupported locale')
+  getProjects(@Query(ValidateLocalePipe) query: GetProjectsQueryDto) {
     return this.portfolioService.getProjects(query.locale ?? 'ko', query.featured);
   }
 
@@ -75,7 +79,8 @@ export class PortfolioController {
 
   @Public()
   @Get('education')
-  getEducation(@Query() query: LocaleQueryDto) {
+  @ApiBadRequest('Unsupported locale')
+  getEducation(@Query(ValidateLocalePipe) query: LocaleQueryDto) {
     return this.portfolioService.getEducation(query.locale ?? 'ko');
   }
 


### PR DESCRIPTION
## Summary
- ValidateLocalePipe 추가 (DB 기반 locale 검증)
- profile, experiences, projects, education 모든 조회에 일관 적용
- 지원하지 않는 locale 요청 시 400 반환