### PR TITLE
feat: Refresh Token + IP Whitelist 인증 보안 강화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,5 +28,8 @@ BLOG_REVALIDATE_URL=https://chahyunwoo.dev
 PORTFOLIO_REVALIDATE_URL=https://portfolio.chahyunwoo.dev
 REVALIDATE_SECRET=your_revalidate_secret_here
 
+# Admin IP Whitelist (comma-separated, empty = allow all)
+ADMIN_IP_WHITELIST=
+
 # CORS (comma-separated)
 ALLOWED_ORIGINS=https://chahyunwoo.dev,https://www.chahyunwoo.dev

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,23 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  schemas  = ["blog", "portfolio"]
+  schemas  = ["auth", "blog", "portfolio"]
+}
+
+// ─── Auth ────────────────────────────────────────────────────────────────────
+
+model RefreshToken {
+  id        Int      @id @default(autoincrement())
+  tokenHash String   @unique @map("token_hash") @db.VarChar(128)
+  username  String   @db.VarChar(200)
+  ipAddress String?  @map("ip_address") @db.VarChar(45)
+  expiresAt DateTime @map("expires_at") @db.Timestamptz(6)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@index([username])
+  @@index([expiresAt])
+  @@map("refresh_tokens")
+  @@schema("auth")
 }
 
 // ─── Blog ────────────────────────────────────────────────────────────────────

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,10 +1,12 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
-
+import { Body, Controller, HttpCode, HttpStatus, Post, Req } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import type { FastifyRequest } from 'fastify';
 import { Public } from '../common/decorators/public.decorator';
 import { SkipApiKey } from '../common/decorators/skip-api-key.decorator';
+import { ApiBadRequest, ApiUnauthorized } from '../common/swagger/error-responses';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
 
 @ApiTags('auth')
 @Controller('api/auth')
@@ -15,8 +17,33 @@ export class AuthController {
   @SkipApiKey()
   @Post('login')
   @HttpCode(HttpStatus.OK)
-  @ApiOkResponse({ schema: { properties: { accessToken: { type: 'string' } } } })
-  login(@Body() dto: LoginDto) {
-    return this.authService.login(dto.username, dto.password);
+  @ApiUnauthorized()
+  @ApiBadRequest()
+  login(@Body() dto: LoginDto, @Req() req: FastifyRequest) {
+    return this.authService.login(dto.username, dto.password, req.ip);
+  }
+
+  @Public()
+  @SkipApiKey()
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  @ApiUnauthorized()
+  refresh(@Body() dto: RefreshTokenDto, @Req() req: FastifyRequest) {
+    return this.authService.refresh(dto.refreshToken, req.ip);
+  }
+
+  @Public()
+  @SkipApiKey()
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  logout(@Body() dto: RefreshTokenDto) {
+    return this.authService.logout(dto.refreshToken);
+  }
+
+  @ApiBearerAuth()
+  @Post('logout-all')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  logoutAll(@Req() req: FastifyRequest & { user: { username: string } }) {
+    return this.authService.logoutAll(req.user.username);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -14,7 +14,6 @@ import { JwtStrategy } from './jwt.strategy';
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({
         secret: config.getOrThrow<string>('JWT_SECRET'),
-        signOptions: { expiresIn: config.get('JWT_EXPIRES_IN', '7d') },
       }),
     }),
   ],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,16 +1,22 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { createHash, randomBytes } from 'node:crypto';
+import { ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcryptjs';
+import { PrismaService } from '../prisma/prisma.service';
+
+const ACCESS_TOKEN_EXPIRES = '15m';
+const REFRESH_TOKEN_EXPIRES_DAYS = 7;
 
 @Injectable()
 export class AuthService {
   constructor(
     private readonly config: ConfigService,
     private readonly jwtService: JwtService,
+    private readonly prisma: PrismaService,
   ) {}
 
-  async login(username: string, password: string): Promise<{ accessToken: string }> {
+  async login(username: string, password: string, ipAddress?: string) {
     const adminUsername = this.config.getOrThrow<string>('ADMIN_USERNAME');
     const adminPasswordHash = this.config.getOrThrow<string>('ADMIN_PASSWORD_HASH');
 
@@ -23,7 +29,75 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
-    const accessToken = this.jwtService.sign({ sub: username });
-    return { accessToken };
+    const accessToken = this.generateAccessToken(username);
+    const refreshToken = await this.createRefreshToken(username, ipAddress);
+
+    return { accessToken, refreshToken };
+  }
+
+  async refresh(refreshToken: string, ipAddress?: string) {
+    const tokenHash = this.hashToken(refreshToken);
+
+    const stored = await this.prisma.refreshToken.findUnique({ where: { tokenHash } });
+    if (!stored) throw new UnauthorizedException('Invalid refresh token');
+
+    if (stored.expiresAt < new Date()) {
+      await this.prisma.refreshToken.delete({ where: { id: stored.id } });
+      throw new UnauthorizedException('Refresh token expired');
+    }
+
+    // IP 변경 감지 → 전체 세션 폐기
+    if (stored.ipAddress && stored.ipAddress !== ipAddress) {
+      await this.prisma.refreshToken.deleteMany({ where: { username: stored.username } });
+      throw new ForbiddenException('Token used from different IP. All sessions revoked.');
+    }
+
+    // Token Rotation: 기존 폐기 + 새 발급
+    await this.prisma.refreshToken.delete({ where: { id: stored.id } });
+
+    const accessToken = this.generateAccessToken(stored.username);
+    const newRefreshToken = await this.createRefreshToken(stored.username, ipAddress);
+
+    return { accessToken, refreshToken: newRefreshToken };
+  }
+
+  async logout(refreshToken: string): Promise<void> {
+    const tokenHash = this.hashToken(refreshToken);
+    await this.prisma.refreshToken.deleteMany({ where: { tokenHash } });
+  }
+
+  async logoutAll(username: string): Promise<void> {
+    await this.prisma.refreshToken.deleteMany({ where: { username } });
+  }
+
+  async cleanupExpiredTokens(): Promise<number> {
+    const result = await this.prisma.refreshToken.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
+    return result.count;
+  }
+
+  // ─── Private ──────────────────────────────────────────────────────────────
+
+  private generateAccessToken(username: string): string {
+    return this.jwtService.sign({ sub: username }, { expiresIn: ACCESS_TOKEN_EXPIRES });
+  }
+
+  private async createRefreshToken(username: string, ipAddress?: string): Promise<string> {
+    const token = randomBytes(64).toString('hex');
+    const tokenHash = this.hashToken(token);
+
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + REFRESH_TOKEN_EXPIRES_DAYS);
+
+    await this.prisma.refreshToken.create({
+      data: { tokenHash, username, ipAddress: ipAddress ?? null, expiresAt },
+    });
+
+    return token;
+  }
+
+  private hashToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
   }
 }

--- a/src/auth/dto/refresh-token.dto.ts
+++ b/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class RefreshTokenDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  refreshToken: string;
+}

--- a/src/common/guards/admin-ip.guard.ts
+++ b/src/common/guards/admin-ip.guard.ts
@@ -1,0 +1,42 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+import type { FastifyRequest } from 'fastify';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+
+@Injectable()
+export class AdminIpGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly config: ConfigService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // 공개 API는 IP 제한 없음
+    if (isPublic) return true;
+
+    const whitelist = this.config.get<string>('ADMIN_IP_WHITELIST', '');
+    // whitelist 미설정이면 제한 안 함 (개발 환경)
+    if (!whitelist) return true;
+
+    const allowedIps = whitelist.split(',').map(ip => ip.trim());
+    const request = context.switchToHttp().getRequest<FastifyRequest>();
+    const clientIp = request.ip;
+
+    if (!allowedIps.includes(clientIp)) {
+      throw new ForbiddenException('Access denied from this IP');
+    }
+
+    return true;
+  }
+}

--- a/src/common/http.module.ts
+++ b/src/common/http.module.ts
@@ -3,6 +3,7 @@ import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { ThrottlerGuard } from '@nestjs/throttler';
 
 import { HttpExceptionFilter } from './filters/http-exception.filter';
+import { AdminIpGuard } from './guards/admin-ip.guard';
 import { ApiKeyGuard } from './guards/api-key.guard';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
@@ -11,6 +12,7 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
     { provide: APP_FILTER, useClass: HttpExceptionFilter },
     { provide: APP_GUARD, useClass: ApiKeyGuard },
     { provide: APP_GUARD, useClass: JwtAuthGuard },
+    { provide: APP_GUARD, useClass: AdminIpGuard },
     { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],
 })


### PR DESCRIPTION
## Summary
- Refresh Token 구현 (DB 해시 저장, Token Rotation, 7일 만료)
- Access Token 15분 만료로 단축
- IP 바인딩 (다른 IP에서 refresh 시도 시 전체 세션 폐기)
- 어드민 IP Whitelist Guard (ADMIN_IP_WHITELIST 환경변수)
- logout / logout-all 엔드포인트 추가
- auth 전용 DB 스키마 분리