### PR TITLE
feat: 어드민 대시보드 analytics API

### DIFF
--- a/prisma/migrations/20260321142236_add_analytics_viewcount/migration.sql
+++ b/prisma/migrations/20260321142236_add_analytics_viewcount/migration.sql
@@ -1,0 +1,47 @@
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "analytics";
+
+-- AlterTable
+ALTER TABLE "blog"."posts" ADD COLUMN     "view_count" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "analytics"."page_views" (
+    "id" SERIAL NOT NULL,
+    "path" VARCHAR(500) NOT NULL,
+    "app_name" VARCHAR(50) NOT NULL,
+    "referrer" VARCHAR(1000),
+    "user_agent" VARCHAR(1000),
+    "ip_address" VARCHAR(45),
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "page_views_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "analytics"."admin_logs" (
+    "id" SERIAL NOT NULL,
+    "action" VARCHAR(50) NOT NULL,
+    "entity" VARCHAR(50) NOT NULL,
+    "entity_id" VARCHAR(100),
+    "detail" TEXT,
+    "username" VARCHAR(200) NOT NULL,
+    "ip_address" VARCHAR(45),
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "admin_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "page_views_app_name_created_at_idx" ON "analytics"."page_views"("app_name", "created_at" DESC);
+
+-- CreateIndex
+CREATE INDEX "page_views_path_idx" ON "analytics"."page_views"("path");
+
+-- CreateIndex
+CREATE INDEX "page_views_created_at_idx" ON "analytics"."page_views"("created_at" DESC);
+
+-- CreateIndex
+CREATE INDEX "admin_logs_created_at_idx" ON "analytics"."admin_logs"("created_at" DESC);
+
+-- CreateIndex
+CREATE INDEX "admin_logs_entity_idx" ON "analytics"."admin_logs"("entity");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  schemas  = ["auth", "blog", "portfolio"]
+  schemas  = ["analytics", "auth", "blog", "portfolio"]
 }
 
 // ─── Auth ────────────────────────────────────────────────────────────────────
@@ -34,6 +34,7 @@ model Post {
   thumbnailUrl String?   @map("thumbnail_url") @db.VarChar(1000)
   category     String?   @db.VarChar(200)
   published    Boolean   @default(false)
+  viewCount    Int       @default(0) @map("view_count")
   createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt    DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
   postTags     PostTag[]
@@ -192,4 +193,38 @@ model EducationTranslation {
   @@unique([educationId, locale])
   @@map("education_translations")
   @@schema("portfolio")
+}
+
+// ─── Analytics ──────────────────────────────────────────────────────────────
+
+model PageView {
+  id        Int      @id @default(autoincrement())
+  path      String   @db.VarChar(500)
+  appName   String   @map("app_name") @db.VarChar(50)
+  referrer  String?  @db.VarChar(1000)
+  userAgent String?  @map("user_agent") @db.VarChar(1000)
+  ipAddress String?  @map("ip_address") @db.VarChar(45)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@index([appName, createdAt(sort: Desc)])
+  @@index([path])
+  @@index([createdAt(sort: Desc)])
+  @@map("page_views")
+  @@schema("analytics")
+}
+
+model AdminLog {
+  id        Int      @id @default(autoincrement())
+  action    String   @db.VarChar(50)
+  entity    String   @db.VarChar(50)
+  entityId  String?  @map("entity_id") @db.VarChar(100)
+  detail    String?  @db.Text
+  username  String   @db.VarChar(200)
+  ipAddress String?  @map("ip_address") @db.VarChar(45)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@index([createdAt(sort: Desc)])
+  @@index([entity])
+  @@map("admin_logs")
+  @@schema("analytics")
 }

--- a/scripts/seed-analytics.ts
+++ b/scripts/seed-analytics.ts
@@ -1,0 +1,118 @@
+/**
+ * 테스트용 analytics 데이터 시딩
+ *
+ * Usage: npx tsx scripts/seed-analytics.ts
+ */
+import 'dotenv/config';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@prisma/client';
+
+function getEnvOrThrow(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`${key} is not defined`);
+  return value;
+}
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randomItem<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+async function main() {
+  const adapter = new PrismaPg({ connectionString: getEnvOrThrow('DATABASE_URL') });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    // ─── 포스트 viewCount 랜덤 부여 ──────────────────────────────────────────
+    const posts = await prisma.post.findMany({ select: { id: true, slug: true } });
+    for (const post of posts) {
+      await prisma.post.update({
+        where: { id: post.id },
+        data: { viewCount: randomInt(10, 500) },
+      });
+    }
+    console.log(`Updated viewCount for ${posts.length} posts`);
+
+    // ─── Page Views (최근 30일) ──────────────────────────────────────────────
+    const apps = ['blog', 'portfolio', 'admin'];
+    const blogPaths = posts.map(p => `/blog/${p.slug}`);
+    const portfolioPaths = ['/about', '/projects', '/experience'];
+    const adminPaths = ['/admin/dashboard', '/admin/posts', '/admin/settings'];
+    const referrers = [
+      'https://google.com',
+      'https://www.google.com',
+      'https://github.com',
+      'https://twitter.com',
+      'https://linkedin.com',
+      null,
+      null,
+      null,
+    ];
+
+    const pageViews = [];
+    for (let daysAgo = 0; daysAgo < 30; daysAgo++) {
+      const dailyCount = randomInt(5, 50);
+      for (let i = 0; i < dailyCount; i++) {
+        const app = randomItem(apps);
+        const paths = app === 'blog' ? blogPaths : app === 'portfolio' ? portfolioPaths : adminPaths;
+        const date = new Date();
+        date.setDate(date.getDate() - daysAgo);
+        date.setHours(randomInt(0, 23), randomInt(0, 59), randomInt(0, 59));
+
+        pageViews.push({
+          path: randomItem(paths),
+          appName: app,
+          referrer: randomItem(referrers),
+          userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+          ipAddress: `192.168.1.${randomInt(1, 254)}`,
+          createdAt: date,
+        });
+      }
+    }
+
+    await prisma.pageView.createMany({ data: pageViews });
+    console.log(`Created ${pageViews.length} page views`);
+
+    // ─── Admin Logs ─────────────────────────────────────────────────────────
+    const actions = ['create', 'update', 'delete'];
+    const entities = ['post', 'experience', 'project', 'skill'];
+    const adminLogs = [];
+
+    for (let daysAgo = 0; daysAgo < 14; daysAgo++) {
+      const dailyCount = randomInt(0, 3);
+      for (let i = 0; i < dailyCount; i++) {
+        const date = new Date();
+        date.setDate(date.getDate() - daysAgo);
+        date.setHours(randomInt(9, 18), randomInt(0, 59));
+
+        const action = randomItem(actions);
+        const entity = randomItem(entities);
+
+        adminLogs.push({
+          action,
+          entity,
+          entityId: entity === 'post' ? randomItem(posts).slug : String(randomInt(1, 10)),
+          detail: `${action} ${entity}`,
+          username: 'chwzp',
+          ipAddress: '127.0.0.1',
+          createdAt: date,
+        });
+      }
+    }
+
+    await prisma.adminLog.createMany({ data: adminLogs });
+    console.log(`Created ${adminLogs.length} admin logs`);
+
+    console.log('\nAnalytics seed complete!');
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/analytics/admin-log.service.ts
+++ b/src/analytics/admin-log.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+interface LogActionDto {
+  action: string;
+  entity: string;
+  entityId?: string;
+  detail?: string;
+  username: string;
+  ipAddress?: string;
+}
+
+@Injectable()
+export class AdminLogService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async log(dto: LogActionDto): Promise<void> {
+    await this.prisma.adminLog.create({
+      data: {
+        action: dto.action,
+        entity: dto.entity,
+        entityId: dto.entityId ?? null,
+        detail: dto.detail ?? null,
+        username: dto.username,
+        ipAddress: dto.ipAddress ?? null,
+      },
+    });
+  }
+
+  async getRecent(limit = 20) {
+    return this.prisma.adminLog.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+  }
+}

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -1,0 +1,85 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Query, Req } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import type { FastifyRequest } from 'fastify';
+import { Public } from '../common/decorators/public.decorator';
+import { AdminLogService } from './admin-log.service';
+import { AnalyticsService } from './analytics.service';
+import { TrackPageViewDto } from './dto/track-pageview.dto';
+import { PageViewService } from './page-view.service';
+
+@ApiTags('analytics')
+@Controller('api/analytics')
+export class AnalyticsController {
+  constructor(
+    private readonly analytics: AnalyticsService,
+    private readonly pageView: PageViewService,
+    private readonly adminLog: AdminLogService,
+  ) {}
+
+  // ─── Public (프론트에서 호출) ──────────────────────────────────────────────
+
+  @Public()
+  @Post('pageview')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  trackPageView(@Body() dto: TrackPageViewDto, @Req() req: FastifyRequest) {
+    this.pageView.track({
+      path: dto.path,
+      appName: dto.appName,
+      referrer: dto.referrer,
+      userAgent: req.headers['user-agent'],
+      ipAddress: req.ip,
+    });
+  }
+
+  // ─── Admin (JWT 필요) ──────────────────────────────────────────────────────
+
+  @ApiBearerAuth()
+  @Get('dashboard')
+  getDashboard() {
+    return this.analytics.getDashboardStats();
+  }
+
+  @ApiBearerAuth()
+  @Get('popular-posts')
+  getPopularPosts(@Query('limit') limit?: string) {
+    return this.analytics.getPopularPosts(limit ? Number(limit) : undefined);
+  }
+
+  @ApiBearerAuth()
+  @Get('visitors')
+  getVisitors(@Query('days') days?: string, @Query('app') app?: string) {
+    return this.analytics.getVisitorStats(days ? Number(days) : undefined, app);
+  }
+
+  @ApiBearerAuth()
+  @Get('referrers')
+  getReferrers(@Query('days') days?: string, @Query('app') app?: string) {
+    return this.analytics.getReferrerStats(days ? Number(days) : undefined, app);
+  }
+
+  @ApiBearerAuth()
+  @Get('popular-pages')
+  getPopularPages(
+    @Query('days') days?: string,
+    @Query('app') app?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.analytics.getPopularPages(
+      days ? Number(days) : undefined,
+      app,
+      limit ? Number(limit) : undefined,
+    );
+  }
+
+  @ApiBearerAuth()
+  @Get('system')
+  getSystem() {
+    return this.analytics.getSystemStatus();
+  }
+
+  @ApiBearerAuth()
+  @Get('admin-logs')
+  getAdminLogs(@Query('limit') limit?: string) {
+    return this.adminLog.getRecent(limit ? Number(limit) : undefined);
+  }
+}

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { AdminLogService } from './admin-log.service';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+import { PageViewService } from './page-view.service';
+
+@Global()
+@Module({
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService, PageViewService, AdminLogService],
+  exports: [PageViewService, AdminLogService],
+})
+export class AnalyticsModule {}

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -1,0 +1,182 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class AnalyticsService {
+  private readonly startTime = Date.now();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ─── Dashboard Stats ──────────────────────────────────────────────────────
+
+  async getDashboardStats() {
+    const [postStats, categoryStats, recentPosts, recentlyUpdated] = await Promise.all([
+      this.getPostStats(),
+      this.getCategoryDistribution(),
+      this.getRecentPosts(),
+      this.getRecentlyUpdatedPosts(),
+    ]);
+
+    return { postStats, categoryStats, recentPosts, recentlyUpdated };
+  }
+
+  // ─── Post Stats ───────────────────────────────────────────────────────────
+
+  private async getPostStats() {
+    const [total, published, draft] = await Promise.all([
+      this.prisma.post.count(),
+      this.prisma.post.count({ where: { published: true } }),
+      this.prisma.post.count({ where: { published: false } }),
+    ]);
+    return { total, published, draft };
+  }
+
+  private async getCategoryDistribution() {
+    const result = await this.prisma.post.groupBy({
+      by: ['category'],
+      where: { published: true, category: { not: null } },
+      _count: true,
+      orderBy: { _count: { category: 'desc' } },
+    });
+
+    return result.map(r => ({ category: r.category as string, count: r._count }));
+  }
+
+  private async getRecentPosts() {
+    return this.prisma.post.findMany({
+      where: { published: true },
+      select: { slug: true, title: true, category: true, viewCount: true, createdAt: true },
+      orderBy: { createdAt: 'desc' },
+      take: 5,
+    });
+  }
+
+  private async getRecentlyUpdatedPosts() {
+    return this.prisma.post.findMany({
+      select: { slug: true, title: true, updatedAt: true },
+      orderBy: { updatedAt: 'desc' },
+      take: 5,
+    });
+  }
+
+  // ─── Popular Posts ────────────────────────────────────────────────────────
+
+  async getPopularPosts(limit = 10) {
+    return this.prisma.post.findMany({
+      where: { published: true },
+      select: { slug: true, title: true, category: true, viewCount: true, createdAt: true },
+      orderBy: { viewCount: 'desc' },
+      take: limit,
+    });
+  }
+
+  // ─── Visitor Stats ────────────────────────────────────────────────────────
+
+  async getVisitorStats(days = 30, appName?: string) {
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+
+    const where = {
+      createdAt: { gte: since },
+      ...(appName && { appName }),
+    };
+
+    const [totalViews, uniqueIps, dailyViews] = await Promise.all([
+      this.prisma.pageView.count({ where }),
+      this.prisma.pageView.groupBy({ by: ['ipAddress'], where }).then(r => r.length),
+      this.prisma.pageView.groupBy({
+        by: ['createdAt'],
+        where,
+        _count: true,
+        orderBy: { createdAt: 'asc' },
+      }),
+    ]);
+
+    // 일별 집계
+    const dailyMap = new Map<string, number>();
+    for (const row of dailyViews) {
+      const date = row.createdAt.toISOString().split('T')[0];
+      dailyMap.set(date, (dailyMap.get(date) ?? 0) + row._count);
+    }
+
+    return {
+      totalViews,
+      uniqueVisitors: uniqueIps,
+      daily: Array.from(dailyMap.entries()).map(([date, count]) => ({ date, count })),
+    };
+  }
+
+  // ─── Referrer Stats ───────────────────────────────────────────────────────
+
+  async getReferrerStats(days = 30, appName?: string) {
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+
+    const views = await this.prisma.pageView.groupBy({
+      by: ['referrer'],
+      where: {
+        createdAt: { gte: since },
+        referrer: { not: null },
+        ...(appName && { appName }),
+      },
+      _count: true,
+      orderBy: { _count: { referrer: 'desc' } },
+      take: 20,
+    });
+
+    return views.map(v => ({ referrer: v.referrer as string, count: v._count }));
+  }
+
+  // ─── Popular Pages ────────────────────────────────────────────────────────
+
+  async getPopularPages(days = 30, appName?: string, limit = 20) {
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+
+    const views = await this.prisma.pageView.groupBy({
+      by: ['path'],
+      where: {
+        createdAt: { gte: since },
+        ...(appName && { appName }),
+      },
+      _count: true,
+      orderBy: { _count: { path: 'desc' } },
+      take: limit,
+    });
+
+    return views.map(v => ({ path: v.path, count: v._count }));
+  }
+
+  // ─── System Status ────────────────────────────────────────────────────────
+
+  async getSystemStatus() {
+    const uptimeMs = Date.now() - this.startTime;
+
+    let dbStatus = 'ok';
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+    } catch {
+      dbStatus = 'error';
+    }
+
+    return {
+      uptime: Math.floor(uptimeMs / 1000),
+      uptimeFormatted: this.formatUptime(uptimeMs),
+      database: dbStatus,
+      memory: {
+        heapUsed: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
+        heapTotal: Math.round(process.memoryUsage().heapTotal / 1024 / 1024),
+        rss: Math.round(process.memoryUsage().rss / 1024 / 1024),
+      },
+      nodeVersion: process.version,
+    };
+  }
+
+  private formatUptime(ms: number): string {
+    const seconds = Math.floor(ms / 1000);
+    const days = Math.floor(seconds / 86400);
+    const hours = Math.floor((seconds % 86400) / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    return `${days}d ${hours}h ${minutes}m`;
+  }
+}

--- a/src/analytics/dto/track-pageview.dto.ts
+++ b/src/analytics/dto/track-pageview.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class TrackPageViewDto {
+  @ApiProperty({ example: '/blog/my-post' })
+  @IsString()
+  @IsNotEmpty()
+  path: string;
+
+  @ApiProperty({ enum: ['blog', 'portfolio', 'admin'], example: 'blog' })
+  @IsString()
+  @IsIn(['blog', 'portfolio', 'admin'])
+  appName: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  referrer?: string;
+}

--- a/src/analytics/page-view.service.ts
+++ b/src/analytics/page-view.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+interface TrackPageViewDto {
+  path: string;
+  appName: string;
+  referrer?: string;
+  userAgent?: string;
+  ipAddress?: string;
+}
+
+@Injectable()
+export class PageViewService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async track(dto: TrackPageViewDto): Promise<void> {
+    await this.prisma.pageView.create({
+      data: {
+        path: dto.path,
+        appName: dto.appName,
+        referrer: dto.referrer ?? null,
+        userAgent: dto.userAgent ?? null,
+        ipAddress: dto.ipAddress ?? null,
+      },
+    });
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ThrottlerModule } from '@nestjs/throttler';
 
+import { AnalyticsModule } from './analytics/analytics.module';
 import { AuthModule } from './auth/auth.module';
 import { BlogModule } from './blog/blog.module';
 import { HttpModule } from './common/http.module';
@@ -20,6 +21,7 @@ import { StorageModule } from './storage/storage.module';
     PrismaModule,
     StorageModule,
     RevalidationModule,
+    AnalyticsModule,
     AuthModule,
     BlogModule,
     PortfolioModule,

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -2,6 +2,7 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import type { Post, PostTag, Tag } from '@prisma/client';
 import { Prisma } from '@prisma/client';
+import { AdminLogService } from '../analytics/admin-log.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { RevalidationService } from '../revalidation/revalidation.service';
 import { StorageService } from '../storage/storage.service';
@@ -30,6 +31,7 @@ export class BlogService {
     private readonly prisma: PrismaService,
     private readonly storage: StorageService,
     private readonly revalidation: RevalidationService,
+    private readonly adminLog: AdminLogService,
     @Inject(CACHE_MANAGER) private readonly cache: CacheStore,
   ) {}
 
@@ -97,6 +99,13 @@ export class BlogService {
 
     if (!post || (!isAdmin && !post.published)) {
       throw new NotFoundException('Post not found');
+    }
+
+    // 조회수 증가 (fire-and-forget, 어드민 조회 제외)
+    if (!isAdmin) {
+      this.prisma.post
+        .update({ where: { slug }, data: { viewCount: { increment: 1 } } })
+        .catch(() => {});
     }
 
     const result = this.formatPost(post, true);
@@ -340,6 +349,13 @@ export class BlogService {
     const result = this.formatPost(post, true);
     await this.invalidateCache();
     this.revalidation.trigger('blog', post.slug);
+    this.adminLog.log({
+      action: 'create',
+      entity: 'post',
+      entityId: post.slug,
+      detail: post.title,
+      username: 'admin',
+    });
     return result;
   }
 
@@ -367,6 +383,13 @@ export class BlogService {
       const result = this.formatPost(post, true);
       await this.invalidateCache();
       this.revalidation.trigger('blog', post.slug);
+      this.adminLog.log({
+        action: 'update',
+        entity: 'post',
+        entityId: post.slug,
+        detail: post.title,
+        username: 'admin',
+      });
       return result;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
@@ -381,6 +404,7 @@ export class BlogService {
       await this.prisma.post.delete({ where: { slug } });
       await this.invalidateCache();
       this.revalidation.trigger('blog', slug);
+      this.adminLog.log({ action: 'delete', entity: 'post', entityId: slug, username: 'admin' });
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
         throw new NotFoundException('Post not found');


### PR DESCRIPTION
## Summary
- Post viewCount + 상세 조회 시 자동 증가
- PageView 방문자 추적 (앱별 분리: blog/portfolio/admin)
- AdminLog 어드민 활동 이력
- 대시보드 통계 API 전체 구현
- 테스트 데이터 시드 스크립트