### PR TITLE
feat: 쿠키 기반 인증 + 세션 타임아웃

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.700.0",
+    "@fastify/cookie": "^11.0.2",
     "@fastify/helmet": "^13.0.2",
     "@fastify/multipart": "^9.4.0",
     "@fastify/static": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.700.0
         version: 3.1014.0
+      '@fastify/cookie':
+        specifier: ^11.0.2
+        version: 11.0.2
       '@fastify/helmet':
         specifier: ^13.0.2
         version: 13.0.2
@@ -768,6 +771,9 @@ packages:
 
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
 
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
@@ -4700,6 +4706,11 @@ snapshots:
       fast-uri: 3.1.0
 
   '@fastify/busboy@3.2.0': {}
+
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.1.1
+      fastify-plugin: 5.1.0
 
   '@fastify/cors@11.2.0':
     dependencies:

--- a/src/auth/auth.constants.ts
+++ b/src/auth/auth.constants.ts
@@ -1,0 +1,7 @@
+export const ACCESS_TOKEN_COOKIE = 'access_token';
+export const REFRESH_TOKEN_COOKIE = 'refresh_token';
+export const SESSION_TIMEOUT_COOKIE = 'session_timeout';
+
+export const ACCESS_TOKEN_MAX_AGE = 15 * 60; // 15 minutes
+export const REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60; // 7 days
+export const SESSION_TIMEOUT = 60 * 60; // 60 minutes

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,12 +1,24 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, Req } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post, Req, Res } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
-import type { FastifyRequest } from 'fastify';
+import type { FastifyReply, FastifyRequest } from 'fastify';
 import { Public } from '../common/decorators/public.decorator';
 import { SkipApiKey } from '../common/decorators/skip-api-key.decorator';
 import { ApiBadRequest, ApiUnauthorized } from '../common/swagger/error-responses';
+import {
+  ACCESS_TOKEN_COOKIE,
+  ACCESS_TOKEN_MAX_AGE,
+  REFRESH_TOKEN_COOKIE,
+  REFRESH_TOKEN_MAX_AGE,
+  SESSION_TIMEOUT,
+  SESSION_TIMEOUT_COOKIE,
+} from './auth.constants';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
-import { RefreshTokenDto } from './dto/refresh-token.dto';
+
+interface CookieRequest extends FastifyRequest {
+  cookies: Record<string, string>;
+  user: { username: string };
+}
 
 @ApiTags('auth')
 @Controller('api/auth')
@@ -19,8 +31,14 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   @ApiUnauthorized()
   @ApiBadRequest()
-  login(@Body() dto: LoginDto, @Req() req: FastifyRequest) {
-    return this.authService.login(dto.username, dto.password, req.ip);
+  async login(@Body() dto: LoginDto, @Req() req: FastifyRequest, @Res() reply: FastifyReply) {
+    const { accessToken, refreshToken } = await this.authService.login(
+      dto.username,
+      dto.password,
+      req.ip,
+    );
+    this.setTokenCookies(reply, accessToken, refreshToken);
+    return reply.send({ message: 'Login successful' });
   }
 
   @Public()
@@ -28,22 +46,90 @@ export class AuthController {
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
   @ApiUnauthorized()
-  refresh(@Body() dto: RefreshTokenDto, @Req() req: FastifyRequest) {
-    return this.authService.refresh(dto.refreshToken, req.ip);
+  async refresh(@Req() req: CookieRequest, @Res() reply: FastifyReply) {
+    const refreshToken = req.cookies[REFRESH_TOKEN_COOKIE];
+    if (!refreshToken) {
+      return reply.status(HttpStatus.UNAUTHORIZED).send({
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: 'No refresh token',
+      });
+    }
+
+    const tokens = await this.authService.refresh(refreshToken, req.ip);
+    this.setTokenCookies(reply, tokens.accessToken, tokens.refreshToken);
+    return reply.send({ message: 'Token refreshed' });
   }
 
   @Public()
   @SkipApiKey()
   @Post('logout')
   @HttpCode(HttpStatus.NO_CONTENT)
-  logout(@Body() dto: RefreshTokenDto) {
-    return this.authService.logout(dto.refreshToken);
+  async logout(@Req() req: CookieRequest, @Res() reply: FastifyReply) {
+    const refreshToken = req.cookies[REFRESH_TOKEN_COOKIE];
+    if (refreshToken) {
+      await this.authService.logout(refreshToken);
+    }
+    this.clearTokenCookies(reply);
+    return reply.status(HttpStatus.NO_CONTENT).send();
   }
 
   @ApiBearerAuth()
   @Post('logout-all')
   @HttpCode(HttpStatus.NO_CONTENT)
-  logoutAll(@Req() req: FastifyRequest & { user: { username: string } }) {
-    return this.authService.logoutAll(req.user.username);
+  async logoutAll(@Req() req: CookieRequest, @Res() reply: FastifyReply) {
+    await this.authService.logoutAll(req.user.username);
+    this.clearTokenCookies(reply);
+    return reply.status(HttpStatus.NO_CONTENT).send();
+  }
+
+  @ApiBearerAuth()
+  @Post('session/extend')
+  @HttpCode(HttpStatus.OK)
+  async extendSession(@Res() reply: FastifyReply) {
+    reply.setCookie(SESSION_TIMEOUT_COOKIE, String(Date.now()), {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      path: '/',
+      maxAge: SESSION_TIMEOUT,
+    });
+    return reply.send({ timeout: SESSION_TIMEOUT });
+  }
+
+  // ─── Private ──────────────────────────────────────────────────────────────
+
+  private setTokenCookies(reply: FastifyReply, accessToken: string, refreshToken: string): void {
+    const isProduction = process.env.NODE_ENV === 'production';
+
+    reply.setCookie(ACCESS_TOKEN_COOKIE, accessToken, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'strict',
+      path: '/',
+      maxAge: ACCESS_TOKEN_MAX_AGE,
+    });
+
+    reply.setCookie(REFRESH_TOKEN_COOKIE, refreshToken, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'strict',
+      path: '/api/auth',
+      maxAge: REFRESH_TOKEN_MAX_AGE,
+    });
+
+    reply.setCookie(SESSION_TIMEOUT_COOKIE, String(Date.now()), {
+      httpOnly: false,
+      secure: isProduction,
+      sameSite: 'strict',
+      path: '/',
+      maxAge: SESSION_TIMEOUT,
+    });
+  }
+
+  private clearTokenCookies(reply: FastifyReply): void {
+    reply.clearCookie(ACCESS_TOKEN_COOKIE, { path: '/' });
+    reply.clearCookie(REFRESH_TOKEN_COOKIE, { path: '/api/auth' });
+    reply.clearCookie(SESSION_TIMEOUT_COOKIE, { path: '/' });
   }
 }

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,17 +1,26 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
+import type { FastifyRequest } from 'fastify';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
 interface JwtPayload {
   sub: string;
 }
 
+function extractFromCookieOrHeader(req: FastifyRequest): string | null {
+  const cookieToken = (req as FastifyRequest & { cookies: Record<string, string> }).cookies
+    ?.access_token;
+  if (cookieToken) return cookieToken;
+
+  return ExtractJwt.fromAuthHeaderAsBearerToken()(req as never);
+}
+
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(config: ConfigService) {
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      jwtFromRequest: extractFromCookieOrHeader,
       ignoreExpiration: false,
       secretOrKey: config.getOrThrow<string>('JWT_SECRET'),
     });

--- a/src/common/guards/api-key.guard.ts
+++ b/src/common/guards/api-key.guard.ts
@@ -26,9 +26,12 @@ export class ApiKeyGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest<FastifyRequest>();
 
-    // JWT Bearer 토큰이 있으면 어드민 요청이므로 API Key 체크 건너뜀
+    // JWT 토큰이 있으면 어드민 요청이므로 API Key 체크 건너뜀
     const authHeader = request.headers.authorization;
     if (authHeader?.startsWith('Bearer ')) return true;
+    const cookieToken = (request as FastifyRequest & { cookies: Record<string, string> }).cookies
+      ?.access_token;
+    if (cookieToken) return true;
 
     const apiKey = request.headers['x-api-key'];
     const expectedKey = this.config.getOrThrow<string>('API_KEY');

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ async function bootstrap() {
     new FastifyAdapter({ logger: process.env.NODE_ENV !== 'production' }),
   );
 
+  await app.register(import('@fastify/cookie'));
   await app.register(helmet);
   await app.register(multipart, {
     limits: { fileSize: 5 * 1024 * 1024 },


### PR DESCRIPTION
## Summary
- 토큰을 Set-Cookie HttpOnly로 전달 (JSON body 대신)
- JWT Strategy에서 쿠키 + Bearer 헤더 둘 다 지원
- session_timeout 쿠키로 프론트 세션 타이머 지원 (60분)
- POST /api/auth/session/extend 세션 연장 엔드포인트