### PR TITLE
feat: 크롤러 필터링 + 총 누적 방문자

### DIFF
--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -79,25 +79,38 @@ export class AnalyticsService {
   // ─── Visitor Stats ────────────────────────────────────────────────────────
 
   async getVisitorStats(days?: number, appName?: string) {
-    const d = clamp(days, 30, MAX_DAYS);
-    const since = new Date();
-    since.setDate(since.getDate() - d);
+    const dateFilter = days
+      ? (() => {
+          const d = clamp(days, 1, MAX_DAYS);
+          const since = new Date();
+          since.setDate(since.getDate() - d);
+          return since;
+        })()
+      : undefined;
 
     const appFilter = appName ? Prisma.sql`AND app_name = ${appName}` : Prisma.empty;
+    const dateWhere = dateFilter
+      ? Prisma.sql`WHERE created_at >= ${dateFilter} ${appFilter}`
+      : appName
+        ? Prisma.sql`WHERE app_name = ${appName}`
+        : Prisma.sql`WHERE 1=1`;
 
     const [totalViews, uniqueResult, dailyResult] = await Promise.all([
       this.prisma.pageView.count({
-        where: { createdAt: { gte: since }, ...(appName && { appName }) },
+        where: {
+          ...(dateFilter && { createdAt: { gte: dateFilter } }),
+          ...(appName && { appName }),
+        },
       }),
       this.prisma.$queryRaw<[{ count: bigint }]>`
         SELECT COUNT(DISTINCT ip_address) as count
         FROM analytics.page_views
-        WHERE created_at >= ${since} ${appFilter}
+        ${dateWhere}
       `,
       this.prisma.$queryRaw<{ date: string; count: bigint }[]>`
         SELECT DATE(created_at) as date, COUNT(*) as count
         FROM analytics.page_views
-        WHERE created_at >= ${since} ${appFilter}
+        ${dateWhere}
         GROUP BY DATE(created_at)
         ORDER BY date ASC
       `,

--- a/src/analytics/page-view.service.ts
+++ b/src/analytics/page-view.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
-interface TrackPageViewDto {
+interface TrackPageViewInput {
   path: string;
   appName: string;
   referrer?: string;
@@ -9,11 +9,44 @@ interface TrackPageViewDto {
   ipAddress?: string;
 }
 
+const BOT_PATTERNS = [
+  /bot/i,
+  /crawl/i,
+  /spider/i,
+  /slurp/i,
+  /mediapartners/i,
+  /googlebot/i,
+  /bingbot/i,
+  /yandex/i,
+  /baidu/i,
+  /duckduck/i,
+  /facebookexternalhit/i,
+  /twitterbot/i,
+  /linkedinbot/i,
+  /whatsapp/i,
+  /telegrambot/i,
+  /discordbot/i,
+  /semrush/i,
+  /ahref/i,
+  /mj12bot/i,
+  /dotbot/i,
+  /headlesschrome/i,
+  /phantomjs/i,
+  /puppeteer/i,
+];
+
+function isBot(userAgent?: string): boolean {
+  if (!userAgent) return false;
+  return BOT_PATTERNS.some(pattern => pattern.test(userAgent));
+}
+
 @Injectable()
 export class PageViewService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async track(dto: TrackPageViewDto): Promise<void> {
+  async track(dto: TrackPageViewInput): Promise<void> {
+    if (isBot(dto.userAgent)) return;
+
     await this.prisma.pageView.create({
       data: {
         path: dto.path,


### PR DESCRIPTION
## Summary
- pageview 저장 시 봇/크롤러 자동 필터링 (Googlebot, Bingbot 등 23개 패턴)
- visitors API에서 days 없으면 전체 기간 누적 조회