### PR TITLE
feat: 프리뷰 토큰 엔드포인트

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, Req, Res } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Query, Req, Res } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { Public } from '../common/decorators/public.decorator';
@@ -91,6 +91,29 @@ export class AuthController {
       maxAge: SESSION_TIMEOUT,
     });
     return reply.send({ timeout: SESSION_TIMEOUT });
+  }
+
+  // ─── Preview ──────────────────────────────────────────────────────────────
+
+  @ApiBearerAuth()
+  @Post('preview-token')
+  @HttpCode(HttpStatus.OK)
+  createPreviewToken() {
+    return this.authService.createPreviewToken();
+  }
+
+  @Public()
+  @Get('verify-preview')
+  verifyPreview(@Query('token') token: string, @Res() reply: FastifyReply) {
+    const valid = this.authService.verifyPreviewToken(token);
+    if (!valid) {
+      return reply.status(HttpStatus.UNAUTHORIZED).send({
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: 'Invalid or expired preview token',
+      });
+    }
+    return reply.send({ valid: true });
   }
 
   // ─── Private ──────────────────────────────────────────────────────────────

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -78,6 +78,45 @@ export class AuthService {
     return result.count;
   }
 
+  // ─── Preview Token ────────────────────────────────────────────────────────
+
+  private readonly previewTokens = new Map<string, number>();
+  private static readonly PREVIEW_TOKEN_TTL = 5 * 60 * 1000; // 5 minutes
+
+  private static readonly MAX_PREVIEW_TOKENS = 10;
+
+  createPreviewToken(): { token: string; expiresIn: number } {
+    this.cleanupPreviewTokens();
+
+    if (this.previewTokens.size >= AuthService.MAX_PREVIEW_TOKENS) {
+      const oldest = this.previewTokens.keys().next().value;
+      if (oldest) this.previewTokens.delete(oldest);
+    }
+
+    const token = randomBytes(32).toString('hex');
+    this.previewTokens.set(token, Date.now() + AuthService.PREVIEW_TOKEN_TTL);
+
+    return { token, expiresIn: 300 };
+  }
+
+  verifyPreviewToken(token: string): boolean {
+    const expiresAt = this.previewTokens.get(token);
+    if (!expiresAt || expiresAt < Date.now()) {
+      this.previewTokens.delete(token);
+      return false;
+    }
+    // 일회용: 검증 성공 시 즉시 삭제
+    this.previewTokens.delete(token);
+    return true;
+  }
+
+  private cleanupPreviewTokens(): void {
+    const now = Date.now();
+    for (const [token, expiresAt] of this.previewTokens) {
+      if (expiresAt < now) this.previewTokens.delete(token);
+    }
+  }
+
   // ─── Private ──────────────────────────────────────────────────────────────
 
   private generateAccessToken(username: string): string {


### PR DESCRIPTION
## Summary
- POST /api/auth/preview-token (JWT 필요) → 일회용 프리뷰 토큰 발급
- GET /api/auth/verify-preview?token=xxx (Public) → 토큰 검증
- 보안: 일회용(검증 후 즉시 삭제), 5분 만료, 최대 10개 제한, 인메모리