### PR TITLE
feat: 포스트 작성 UX 개선 + 프리뷰 + 이미지 보안

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cache-manager": "^7.2.8",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "file-type": "^21.3.3",
     "keyv": "^5.6.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       class-validator:
         specifier: ^0.14.1
         version: 0.14.4
+      file-type:
+        specifier: ^21.3.3
+        version: 21.3.3
       keyv:
         specifier: ^5.6.0
         version: 5.6.0
@@ -2399,6 +2402,10 @@ packages:
 
   file-type@21.3.2:
     resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
+    engines: {node: '>=20'}
+
+  file-type@21.3.3:
+    resolution: {integrity: sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==}
     engines: {node: '>=20'}
 
   fill-range@7.1.1:
@@ -6657,6 +6664,15 @@ snapshots:
       bser: 2.1.1
 
   file-type@21.3.2:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  file-type@21.3.3:
     dependencies:
       '@tokenizer/inflate': 0.4.1
       strtok3: 10.3.4

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -19,5 +19,6 @@ import { JwtStrategy } from './jwt.strategy';
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -65,10 +65,12 @@ export class AuthService {
   async logout(refreshToken: string): Promise<void> {
     const tokenHash = this.hashToken(refreshToken);
     await this.prisma.refreshToken.deleteMany({ where: { tokenHash } });
+    this.revokeAllPreviewTokens();
   }
 
   async logoutAll(username: string): Promise<void> {
     await this.prisma.refreshToken.deleteMany({ where: { username } });
+    this.revokeAllPreviewTokens();
   }
 
   async cleanupExpiredTokens(): Promise<number> {
@@ -81,8 +83,7 @@ export class AuthService {
   // ─── Preview Token ────────────────────────────────────────────────────────
 
   private readonly previewTokens = new Map<string, number>();
-  private static readonly PREVIEW_TOKEN_TTL = 5 * 60 * 1000; // 5 minutes
-
+  private static readonly PREVIEW_TOKEN_TTL = 30 * 60 * 1000; // 30 minutes
   private static readonly MAX_PREVIEW_TOKENS = 10;
 
   createPreviewToken(): { token: string; expiresIn: number } {
@@ -96,7 +97,7 @@ export class AuthService {
     const token = randomBytes(32).toString('hex');
     this.previewTokens.set(token, Date.now() + AuthService.PREVIEW_TOKEN_TTL);
 
-    return { token, expiresIn: 300 };
+    return { token, expiresIn: 1800 };
   }
 
   verifyPreviewToken(token: string): boolean {
@@ -105,9 +106,11 @@ export class AuthService {
       this.previewTokens.delete(token);
       return false;
     }
-    // 일회용: 검증 성공 시 즉시 삭제
-    this.previewTokens.delete(token);
     return true;
+  }
+
+  revokeAllPreviewTokens(): void {
+    this.previewTokens.clear();
   }
 
   private cleanupPreviewTokens(): void {

--- a/src/blog/blog.constants.ts
+++ b/src/blog/blog.constants.ts
@@ -1,3 +1,4 @@
 export const RECENT_DAYS = 5;
 export const RELATED_POST_COUNT = 3;
 export const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -11,8 +11,10 @@ import {
   Put,
   Query,
   Req,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiConsumes, ApiTags } from '@nestjs/swagger';
+import { AuthService } from '../auth/auth.service';
 import { Public } from '../common/decorators/public.decorator';
 import {
   ApiBadRequest,
@@ -21,8 +23,9 @@ import {
   ApiUnauthorized,
 } from '../common/swagger/error-responses';
 import type { MultipartRequest } from '../types/fastify.d';
-import { ALLOWED_MIME_TYPES } from './blog.constants';
+import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from './blog.constants';
 import { BlogService } from './blog.service';
+import { safeExtension } from './blog.utils';
 import { CreatePostDto } from './dto/create-post.dto';
 import { PostQueryDto, RecentQueryDto, SearchQueryDto, TagQueryDto } from './dto/post-query.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
@@ -30,7 +33,10 @@ import { UpdatePostDto } from './dto/update-post.dto';
 @ApiTags('blog')
 @Controller('api/blog')
 export class BlogController {
-  constructor(private readonly blogService: BlogService) {}
+  constructor(
+    private readonly blogService: BlogService,
+    private readonly authService: AuthService,
+  ) {}
 
   @Public()
   @Get('posts/search')
@@ -68,6 +74,17 @@ export class BlogController {
   @ApiNotFound('Post')
   findOne(@Param('slug') slug: string) {
     return this.blogService.findBySlug(slug);
+  }
+
+  @Public()
+  @Get('posts/:slug/preview')
+  @ApiNotFound('Post')
+  @ApiUnauthorized()
+  async findOnePreview(@Param('slug') slug: string, @Query('token') token: string) {
+    if (!token || !this.authService.verifyPreviewToken(token)) {
+      throw new UnauthorizedException('Invalid or expired preview token');
+    }
+    return this.blogService.findBySlug(slug, true);
   }
 
   @Public()
@@ -111,13 +128,41 @@ export class BlogController {
   @ApiNotFound('Post')
   @ApiBadRequest('No file provided or invalid file type')
   async uploadThumbnail(@Param('slug') slug: string, @Req() request: MultipartRequest) {
+    const { buffer, mimeType } = await this.validateAndReadFile(request);
+    return this.blogService.updateThumbnail(
+      slug,
+      buffer,
+      `thumbnail${safeExtension(mimeType)}`,
+      mimeType,
+    );
+  }
+
+  @ApiBearerAuth()
+  @Post('images')
+  @ApiConsumes('multipart/form-data')
+  @ApiUnauthorized()
+  @ApiBadRequest('No file provided or invalid file type')
+  async uploadImage(@Req() request: MultipartRequest) {
+    const { buffer, mimeType } = await this.validateAndReadFile(request);
+    return this.blogService.uploadContentImage(buffer, `image${safeExtension(mimeType)}`, mimeType);
+  }
+
+  private async validateAndReadFile(request: MultipartRequest) {
     const data = await request.file();
     if (!data) throw new BadRequestException('No file provided');
-    if (!ALLOWED_MIME_TYPES.has(data.mimetype)) {
+
+    const buffer = await data.toBuffer();
+
+    if (buffer.length > MAX_FILE_SIZE) {
+      throw new BadRequestException('File too large (max 10 MB)');
+    }
+
+    const { fileTypeFromBuffer } = await import('file-type');
+    const detected = await fileTypeFromBuffer(buffer);
+    if (!detected || !ALLOWED_MIME_TYPES.has(detected.mime)) {
       throw new BadRequestException('Only JPEG, PNG, WebP, GIF are allowed');
     }
 
-    const buffer = await data.toBuffer();
-    return this.blogService.updateThumbnail(slug, buffer, data.filename, data.mimetype);
+    return { buffer, mimeType: detected.mime };
   }
 }

--- a/src/blog/blog.module.ts
+++ b/src/blog/blog.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
-
+import { AuthModule } from '../auth/auth.module';
 import { BlogController } from './blog.controller';
 import { BlogService } from './blog.service';
 
 @Module({
+  imports: [AuthModule],
   controllers: [BlogController],
   providers: [BlogService],
 })

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -8,6 +8,7 @@ import { RevalidationService } from '../revalidation/revalidation.service';
 import { StorageService } from '../storage/storage.service';
 import { type CacheStore, NamespacedCache } from '../types/cache-store';
 import { RECENT_DAYS, RELATED_POST_COUNT } from './blog.constants';
+import { extractDescription, generateSlug } from './blog.utils';
 import type { CreatePostDto } from './dto/create-post.dto';
 import type { PostQueryDto, SearchQueryDto, TagQueryDto } from './dto/post-query.dto';
 import type { UpdatePostDto } from './dto/update-post.dto';
@@ -316,38 +317,46 @@ export class BlogService {
   // ─── Write ────────────────────────────────────────────────────────────────
 
   async create(dto: CreatePostDto) {
-    const existing = await this.prisma.post.findUnique({ where: { slug: dto.slug } });
-    if (existing) throw new ConflictException('Slug already exists');
+    const slug = generateSlug(dto.title);
+    const description = dto.description || extractDescription(dto.content);
 
-    const post = (await this.prisma.post.create({
-      data: {
-        title: dto.title,
-        slug: dto.slug,
-        description: dto.description,
-        content: dto.content,
-        thumbnailUrl: dto.thumbnailUrl,
-        category: dto.category,
-        published: dto.published ?? false,
-        postTags: dto.tags?.length
-          ? { create: await this.resolveTagConnections(dto.tags) }
-          : undefined,
-      },
-      include: { postTags: { include: { tag: true } } },
-    })) as PostWithTags;
+    try {
+      const post = (await this.prisma.post.create({
+        data: {
+          title: dto.title,
+          slug,
+          description,
+          content: dto.content,
+          category: dto.category,
+          published: dto.published ?? false,
+          postTags: dto.tags?.length
+            ? { create: await this.resolveTagConnections(dto.tags) }
+            : undefined,
+        },
+        include: { postTags: { include: { tag: true } } },
+      })) as PostWithTags;
 
-    const result = this.formatPost(post, true);
-    await this.cache.invalidate();
-    this.revalidation
-      .trigger('blog', post.slug)
-      .catch(err => this.logger.warn('revalidation failed', err));
-    this.adminLog.log({
-      action: 'create',
-      entity: 'post',
-      entityId: post.slug,
-      detail: post.title,
-      username: 'admin',
-    });
-    return result;
+      const result = this.formatPost(post, true);
+      await this.cache.invalidate();
+      this.revalidation
+        .trigger('blog', post.slug)
+        .catch(err => this.logger.warn('revalidation failed', err));
+      this.adminLog
+        .log({
+          action: 'create',
+          entity: 'post',
+          entityId: post.slug,
+          detail: post.title,
+          username: 'admin',
+        })
+        .catch(err => this.logger.warn('admin log failed', err));
+      return result;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictException('Slug collision. Please retry.');
+      }
+      throw error;
+    }
   }
 
   async update(slug: string, dto: UpdatePostDto) {
@@ -358,7 +367,6 @@ export class BlogService {
           ...(dto.title !== undefined && { title: dto.title }),
           ...(dto.description !== undefined && { description: dto.description }),
           ...(dto.content !== undefined && { content: dto.content }),
-          ...(dto.thumbnailUrl !== undefined && { thumbnailUrl: dto.thumbnailUrl }),
           ...(dto.category !== undefined && { category: dto.category }),
           ...(dto.published !== undefined && { published: dto.published }),
           ...(dto.tags !== undefined && {
@@ -414,11 +422,8 @@ export class BlogService {
     const existing = await this.prisma.post.findUnique({ where: { slug } });
     if (!existing) throw new NotFoundException('Post not found');
 
-    if (existing.thumbnailUrl) {
-      await this.storage.delete(existing.thumbnailUrl);
-    }
-
     const url = await this.storage.upload(buffer, filename, mimeType, 'blog/thumbnails');
+    const oldUrl = existing.thumbnailUrl;
 
     const post = (await this.prisma.post.update({
       where: { slug },
@@ -426,8 +431,20 @@ export class BlogService {
       include: { postTags: { include: { tag: true } } },
     })) as PostWithTags;
 
+    // DB 업데이트 성공 후 이전 썸네일 삭제
+    if (oldUrl) {
+      this.storage
+        .delete(oldUrl)
+        .catch(err => this.logger.warn('old thumbnail delete failed', err));
+    }
+
     await this.cache.invalidate();
     return this.formatPost(post, true);
+  }
+
+  async uploadContentImage(buffer: Buffer, filename: string, mimeType: string) {
+    const url = await this.storage.upload(buffer, filename, mimeType, 'blog/images');
+    return { url };
   }
 
   // ─── Private ──────────────────────────────────────────────────────────────

--- a/src/blog/blog.utils.ts
+++ b/src/blog/blog.utils.ts
@@ -1,0 +1,69 @@
+import { randomBytes } from 'node:crypto';
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * 한글/영어 제목에서 URL-safe slug 생성
+ * 중복 방지를 위해 4자리 랜덤 suffix 추가
+ */
+export function generateSlug(title: string): string {
+  const base = title
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s가-힣-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 80);
+
+  if (!base) {
+    throw new BadRequestException('Title must contain at least one valid character for slug');
+  }
+
+  const suffix = randomBytes(2).toString('hex');
+  return `${base}-${suffix}`;
+}
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+};
+
+/**
+ * MIME 타입에서 안전한 확장자 추출
+ */
+export function safeExtension(mimeType: string): string {
+  return MIME_TO_EXT[mimeType] ?? '.bin';
+}
+
+/**
+ * content 앞부분에서 description 자동 추출
+ * MDX 태그/코드블록 제거 후 첫 문장 추출 (최대 100자)
+ */
+export function extractDescription(content: string, maxLength = 100): string {
+  // 코드블록을 안전하게 제거 (ReDoS 방지: 수동 파싱)
+  let cleaned = '';
+  let inCodeBlock = false;
+
+  for (const line of content.split('\n')) {
+    if (line.startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (!inCodeBlock) cleaned += `${line} `;
+  }
+
+  cleaned = cleaned
+    .replace(/<[^>]{0,1000}>/g, '')
+    .replace(/`[^`]+`/g, '')
+    .replace(/#{1,6}\s+/g, '')
+    .replace(/!\[.*?\]\(.*?\)/g, '')
+    .replace(/\[([^\]]+)\]\(.*?\)/g, '$1')
+    .replace(/[*_~]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (cleaned.length <= maxLength) return cleaned;
+  return `${cleaned.slice(0, maxLength).trimEnd()}...`;
+}

--- a/src/blog/dto/create-post.dto.ts
+++ b/src/blog/dto/create-post.dto.ts
@@ -1,14 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  IsArray,
-  IsBoolean,
-  IsOptional,
-  IsString,
-  IsUrl,
-  Matches,
-  MaxLength,
-  MinLength,
-} from 'class-validator';
+import { IsArray, IsBoolean, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class CreatePostDto {
   @ApiProperty({ example: 'Next.js 15 App Router 완전 정복' })
@@ -17,29 +8,17 @@ export class CreatePostDto {
   @MaxLength(500)
   title: string;
 
-  @ApiProperty({ example: 'nextjs-15-app-router', description: 'URL-safe slug' })
-  @IsString()
-  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
-    message: 'slug must be lowercase letters, numbers, and hyphens',
-  })
-  @MaxLength(500)
-  slug: string;
-
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ description: '미입력 시 제목에서 자동 생성' })
   @IsOptional()
   @IsString()
-  @MaxLength(500)
+  @MaxLength(200)
   description?: string;
 
   @ApiProperty({ description: 'MDX content' })
   @IsString()
   @MinLength(1)
+  @MaxLength(500_000)
   content: string;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsUrl({}, { message: 'thumbnailUrl must be a valid URL' })
-  thumbnailUrl?: string;
 
   @ApiPropertyOptional({ example: 'Frontend' })
   @IsOptional()

--- a/src/blog/dto/update-post.dto.ts
+++ b/src/blog/dto/update-post.dto.ts
@@ -1,5 +1,4 @@
-import { OmitType, PartialType } from '@nestjs/swagger';
-
+import { PartialType } from '@nestjs/swagger';
 import { CreatePostDto } from './create-post.dto';
 
-export class UpdatePostDto extends PartialType(OmitType(CreatePostDto, ['slug'] as const)) {}
+export class UpdatePostDto extends PartialType(CreatePostDto) {}


### PR DESCRIPTION
## Summary
- slug 자동 생성, description 자동 추출
- 본문 이미지 업로드 API, 프리뷰 포스트 조회 API
- 프리뷰 토큰 30분 재사용 가능
- magic byte 파일 검증, 10MB 제한, 안전한 확장자
- 썸네일 교체 순서 수정 (데이터 무결성)