### PR TITLE
feat: 이미지 temp 플로우 + publishedAt + cron

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-fastify": "^11.1.17",
+    "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/throttler": "^6.5.0",
     "@prisma/adapter-pg": "^7.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@nestjs/platform-fastify':
         specifier: ^11.1.17
         version: 11.1.17(@fastify/static@9.0.0)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@nestjs/schedule':
+        specifier: ^6.1.1
+        version: 6.1.1(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
       '@nestjs/swagger':
         specifier: ^11.2.6
         version: 11.2.6(@fastify/static@9.0.0)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
@@ -1193,6 +1196,12 @@ packages:
       '@fastify/view':
         optional: true
 
+  '@nestjs/schedule@6.1.1':
+    resolution: {integrity: sha512-kQl1RRgi02GJ0uaUGCrXHCcwISsCsJDciCKe38ykJZgnAeeoeVWs8luWtBo4AqAAXm4nS5K8RlV0smHUJ4+2FA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
   '@nestjs/schematics@11.0.9':
     resolution: {integrity: sha512-0NfPbPlEaGwIT8/TCThxLzrlz3yzDNkfRNpbL7FiplKq3w4qXpJg0JYwqgMEJnLQZm3L/L/5XjoyfJHUO3qX9g==}
     peerDependencies:
@@ -1632,6 +1641,9 @@ packages:
 
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/luxon@3.7.1':
+    resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -2178,6 +2190,10 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cron@4.4.0:
+    resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
+    engines: {node: '>=18.x'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2924,6 +2940,10 @@ packages:
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -5273,6 +5293,12 @@ snapshots:
     optionalDependencies:
       '@fastify/static': 9.0.0
 
+  '@nestjs/schedule@6.1.1(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+    dependencies:
+      '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron: 4.4.0
+
   '@nestjs/schematics@11.0.9(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/core': 19.2.17(chokidar@4.0.3)
@@ -5881,6 +5907,8 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 22.19.15
 
+  '@types/luxon@3.7.1': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/node@22.19.15':
@@ -6428,6 +6456,11 @@ snapshots:
       typescript: 5.9.3
 
   create-require@1.1.1: {}
+
+  cron@4.4.0:
+    dependencies:
+      '@types/luxon': 3.7.1
+      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7376,6 +7409,8 @@ snapshots:
       yallist: 3.1.1
 
   lru.min@1.1.4: {}
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.17:
     dependencies:

--- a/prisma/migrations/20260321163835_add_published_at/migration.sql
+++ b/prisma/migrations/20260321163835_add_published_at/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+DROP INDEX "blog"."posts_published_created_at_idx";
+
+-- AlterTable
+ALTER TABLE "blog"."posts" ADD COLUMN     "published_at" TIMESTAMPTZ(6);
+
+-- CreateIndex
+CREATE INDEX "posts_published_published_at_idx" ON "blog"."posts"("published", "published_at" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,12 +34,13 @@ model Post {
   thumbnailUrl String?   @map("thumbnail_url") @db.VarChar(1000)
   category     String?   @db.VarChar(200)
   published    Boolean   @default(false)
+  publishedAt  DateTime? @map("published_at") @db.Timestamptz(6)
   viewCount    Int       @default(0) @map("view_count")
   createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt    DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
   postTags     PostTag[]
 
-  @@index([published, createdAt(sort: Desc)])
+  @@index([published, publishedAt(sort: Desc)])
   @@index([category])
   @@map("posts")
   @@schema("blog")

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerModule } from '@nestjs/throttler';
 
 import { AnalyticsModule } from './analytics/analytics.module';
@@ -17,6 +18,7 @@ import { StorageModule } from './storage/storage.module';
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     CacheModule.register({ isGlobal: true, ttl: 60_000 }),
+    ScheduleModule.forRoot(),
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 100 }]),
     PrismaModule,
     StorageModule,

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -122,29 +122,13 @@ export class BlogController {
   }
 
   @ApiBearerAuth()
-  @Post('posts/:slug/thumbnail')
-  @ApiConsumes('multipart/form-data')
-  @ApiUnauthorized()
-  @ApiNotFound('Post')
-  @ApiBadRequest('No file provided or invalid file type')
-  async uploadThumbnail(@Param('slug') slug: string, @Req() request: MultipartRequest) {
-    const { buffer, mimeType } = await this.validateAndReadFile(request);
-    return this.blogService.updateThumbnail(
-      slug,
-      buffer,
-      `thumbnail${safeExtension(mimeType)}`,
-      mimeType,
-    );
-  }
-
-  @ApiBearerAuth()
   @Post('images')
   @ApiConsumes('multipart/form-data')
   @ApiUnauthorized()
   @ApiBadRequest('No file provided or invalid file type')
   async uploadImage(@Req() request: MultipartRequest) {
     const { buffer, mimeType } = await this.validateAndReadFile(request);
-    return this.blogService.uploadContentImage(buffer, `image${safeExtension(mimeType)}`, mimeType);
+    return this.blogService.uploadTempImage(buffer, `image${safeExtension(mimeType)}`, mimeType);
   }
 
   private async validateAndReadFile(request: MultipartRequest) {

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -56,7 +56,7 @@ export class BlogService {
       this.prisma.post.findMany({
         where,
         include,
-        orderBy: { createdAt: 'desc' },
+        orderBy: { publishedAt: 'desc' },
         skip,
         take: limit,
       }),
@@ -213,7 +213,7 @@ export class BlogService {
     const posts = await this.prisma.post.findMany({
       where: { published: true },
       include: { postTags: { include: { tag: true } } },
-      orderBy: { createdAt: 'desc' },
+      orderBy: { publishedAt: 'desc' },
       take: limit,
     });
 
@@ -321,14 +321,21 @@ export class BlogService {
     const description = dto.description || extractDescription(dto.content);
 
     try {
+      // DB에 먼저 저장 (temp URL 그대로)
       const post = (await this.prisma.post.create({
         data: {
           title: dto.title,
           slug,
           description,
           content: dto.content,
+          thumbnailUrl: dto.thumbnailUrl,
           category: dto.category,
           published: dto.published ?? false,
+          publishedAt: dto.publishedAt
+            ? new Date(dto.publishedAt)
+            : dto.published
+              ? new Date()
+              : null,
           postTags: dto.tags?.length
             ? { create: await this.resolveTagConnections(dto.tags) }
             : undefined,
@@ -336,7 +343,22 @@ export class BlogService {
         include: { postTags: { include: { tag: true } } },
       })) as PostWithTags;
 
-      const result = this.formatPost(post, true);
+      // DB 성공 후 temp 이미지를 확정 경로로 이동
+      let updated = post;
+      try {
+        const finalized = await this.finalizeImages(slug, post.content, post.thumbnailUrl);
+        updated = (await this.prisma.post.update({
+          where: { slug },
+          data: { content: finalized.content, thumbnailUrl: finalized.thumbnailUrl },
+          include: { postTags: { include: { tag: true } } },
+        })) as PostWithTags;
+      } catch (moveError) {
+        this.logger.error('Image finalization failed, rolling back post', moveError);
+        await this.prisma.post.delete({ where: { slug } }).catch(() => {});
+        throw moveError;
+      }
+
+      const result = this.formatPost(updated, true);
       await this.cache.invalidate();
       this.revalidation
         .trigger('blog', post.slug)
@@ -361,14 +383,19 @@ export class BlogService {
 
   async update(slug: string, dto: UpdatePostDto) {
     try {
+      // DB에 먼저 저장 (temp URL 그대로)
       const post = (await this.prisma.post.update({
         where: { slug },
         data: {
           ...(dto.title !== undefined && { title: dto.title }),
           ...(dto.description !== undefined && { description: dto.description }),
           ...(dto.content !== undefined && { content: dto.content }),
+          ...(dto.thumbnailUrl !== undefined && { thumbnailUrl: dto.thumbnailUrl }),
           ...(dto.category !== undefined && { category: dto.category }),
           ...(dto.published !== undefined && { published: dto.published }),
+          ...(dto.publishedAt !== undefined && { publishedAt: new Date(dto.publishedAt) }),
+          // published=true로 변경 시 publishedAt 자동 세팅
+          ...(dto.published === true && !dto.publishedAt && { publishedAt: new Date() }),
           ...(dto.tags !== undefined && {
             postTags: {
               deleteMany: {},
@@ -379,18 +406,39 @@ export class BlogService {
         include: { postTags: { include: { tag: true } } },
       })) as PostWithTags;
 
-      const result = this.formatPost(post, true);
+      // DB 성공 후 temp 이미지 확정 경로로 이동
+      if (dto.content || dto.thumbnailUrl) {
+        try {
+          const finalized = await this.finalizeImages(slug, post.content, post.thumbnailUrl);
+          await this.prisma.post.update({
+            where: { slug },
+            data: { content: finalized.content, thumbnailUrl: finalized.thumbnailUrl },
+          });
+        } catch (moveError) {
+          this.logger.error('Image finalization failed during update', moveError);
+          // DB에는 temp URL이 남지만, temp 파일은 유지되므로 24시간 내 재시도 가능
+        }
+      }
+
+      const updated = (await this.prisma.post.findUniqueOrThrow({
+        where: { slug },
+        include: { postTags: { include: { tag: true } } },
+      })) as PostWithTags;
+
+      const result = this.formatPost(updated, true);
       await this.cache.invalidate();
       this.revalidation
-        .trigger('blog', post.slug)
+        .trigger('blog', slug)
         .catch(err => this.logger.warn('revalidation failed', err));
-      this.adminLog.log({
-        action: 'update',
-        entity: 'post',
-        entityId: post.slug,
-        detail: post.title,
-        username: 'admin',
-      });
+      this.adminLog
+        .log({
+          action: 'update',
+          entity: 'post',
+          entityId: slug,
+          detail: updated.title,
+          username: 'admin',
+        })
+        .catch(err => this.logger.warn('admin log failed', err));
       return result;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
@@ -418,36 +466,45 @@ export class BlogService {
     }
   }
 
-  async updateThumbnail(slug: string, buffer: Buffer, filename: string, mimeType: string) {
-    const existing = await this.prisma.post.findUnique({ where: { slug } });
-    if (!existing) throw new NotFoundException('Post not found');
-
-    const url = await this.storage.upload(buffer, filename, mimeType, 'blog/thumbnails');
-    const oldUrl = existing.thumbnailUrl;
-
-    const post = (await this.prisma.post.update({
-      where: { slug },
-      data: { thumbnailUrl: url },
-      include: { postTags: { include: { tag: true } } },
-    })) as PostWithTags;
-
-    // DB 업데이트 성공 후 이전 썸네일 삭제
-    if (oldUrl) {
-      this.storage
-        .delete(oldUrl)
-        .catch(err => this.logger.warn('old thumbnail delete failed', err));
-    }
-
-    await this.cache.invalidate();
-    return this.formatPost(post, true);
-  }
-
-  async uploadContentImage(buffer: Buffer, filename: string, mimeType: string) {
-    const url = await this.storage.upload(buffer, filename, mimeType, 'blog/images');
+  async uploadTempImage(buffer: Buffer, filename: string, mimeType: string) {
+    const url = await this.storage.upload(buffer, filename, mimeType, 'blog/temp');
     return { url };
   }
 
   // ─── Private ──────────────────────────────────────────────────────────────
+
+  /**
+   * content + thumbnailUrl에서 temp URL을 찾아서 확정 경로로 이동
+   * blog/temp/xxx.png → blog/posts/{slug}/xxx.png
+   * blog/temp/xxx.jpg (thumbnail) → blog/thumbnails/{slug}.ext
+   */
+  private async finalizeImages(slug: string, content: string, thumbnailUrl?: string | null) {
+    const publicUrl = this.storage.getPublicUrl();
+    const tempPrefix = `${publicUrl}/blog/temp/`;
+    let finalContent = content;
+
+    // content 내 temp 이미지 이동
+    const tempUrls =
+      content.match(
+        new RegExp(`${tempPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"\\s)]+`, 'g'),
+      ) ?? [];
+    for (const tempUrl of tempUrls) {
+      const filename = tempUrl.slice(tempPrefix.length);
+      const destKey = `blog/posts/${slug}/${filename}`;
+      const newUrl = await this.storage.move(tempUrl, destKey);
+      finalContent = finalContent.replace(tempUrl, newUrl);
+    }
+
+    // 썸네일 temp → 확정 경로
+    let finalThumbnail = thumbnailUrl;
+    if (thumbnailUrl?.startsWith(tempPrefix)) {
+      const ext = thumbnailUrl.slice(thumbnailUrl.lastIndexOf('.'));
+      const destKey = `blog/thumbnails/${slug}${ext}`;
+      finalThumbnail = await this.storage.move(thumbnailUrl, destKey);
+    }
+
+    return { content: finalContent, thumbnailUrl: finalThumbnail };
+  }
 
   private async resolveTagConnections(tagNames: string[]) {
     return Promise.all(

--- a/src/blog/dto/create-post.dto.ts
+++ b/src/blog/dto/create-post.dto.ts
@@ -1,5 +1,14 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsArray, IsBoolean, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class CreatePostDto {
   @ApiProperty({ example: 'Next.js 15 App Router 완전 정복' })
@@ -26,10 +35,21 @@ export class CreatePostDto {
   @MaxLength(200)
   category?: string;
 
+  @ApiPropertyOptional({ description: '이미지 업로드 API에서 받은 URL' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^https?:\/\//, { message: 'thumbnailUrl must be a valid HTTP URL' })
+  thumbnailUrl?: string;
+
   @ApiPropertyOptional({ default: false })
   @IsOptional()
   @IsBoolean()
   published?: boolean = false;
+
+  @ApiPropertyOptional({ example: '2026-03-21', description: '발행일 (미입력 시 발행 시점 자동)' })
+  @IsOptional()
+  @IsDateString()
+  publishedAt?: string;
 
   @ApiPropertyOptional({ type: [String], example: ['React', 'TypeScript'] })
   @IsOptional()

--- a/src/storage/storage-cleanup.task.ts
+++ b/src/storage/storage-cleanup.task.ts
@@ -1,0 +1,17 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { StorageService } from './storage.service';
+
+@Injectable()
+export class StorageCleanupTask {
+  private readonly logger = new Logger(StorageCleanupTask.name);
+
+  constructor(private readonly storage: StorageService) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async handleCleanup() {
+    this.logger.log('Starting temp file cleanup...');
+    const deleted = await this.storage.cleanupTempFiles();
+    this.logger.log(`Temp cleanup complete: ${deleted} files deleted`);
+  }
+}

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -1,10 +1,10 @@
 import { Global, Module } from '@nestjs/common';
-
 import { StorageService } from './storage.service';
+import { StorageCleanupTask } from './storage-cleanup.task';
 
 @Global()
 @Module({
-  providers: [StorageService],
+  providers: [StorageService, StorageCleanupTask],
   exports: [StorageService],
 })
 export class StorageModule {}

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -1,11 +1,18 @@
 import { randomUUID } from 'node:crypto';
-import { extname } from 'node:path';
-import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { Injectable } from '@nestjs/common';
+import {
+  CopyObjectCommand,
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class StorageService {
+  private readonly logger = new Logger(StorageService.name);
   private readonly client: S3Client;
   private readonly bucket: string;
   private readonly publicUrl: string;
@@ -26,9 +33,12 @@ export class StorageService {
     this.publicUrl = config.getOrThrow<string>('R2_PUBLIC_URL');
   }
 
+  getPublicUrl(): string {
+    return this.publicUrl;
+  }
+
   async upload(buffer: Buffer, filename: string, mimeType: string, prefix = ''): Promise<string> {
-    const ext = extname(filename);
-    const key = [prefix, `${randomUUID()}${ext}`].filter(Boolean).join('/');
+    const key = [prefix, `${randomUUID()}-${filename}`].filter(Boolean).join('/');
 
     await this.client.send(
       new PutObjectCommand({
@@ -42,10 +52,62 @@ export class StorageService {
     return `${this.publicUrl}/${key}`;
   }
 
+  async move(sourceUrl: string, destKey: string): Promise<string> {
+    const sourceKey = this.urlToKey(sourceUrl);
+    if (!sourceKey) return sourceUrl;
+
+    await this.client.send(
+      new CopyObjectCommand({
+        Bucket: this.bucket,
+        CopySource: `${this.bucket}/${sourceKey}`,
+        Key: destKey,
+      }),
+    );
+
+    // copy 성공 확인 후 원본 삭제
+    await this.client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: destKey }));
+    await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: sourceKey }));
+
+    return `${this.publicUrl}/${destKey}`;
+  }
+
   async delete(url: string): Promise<void> {
-    const prefix = `${this.publicUrl}/`;
-    if (!url.startsWith(prefix)) return;
-    const key = url.slice(prefix.length);
+    const key = this.urlToKey(url);
+    if (!key) return;
     await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
+  }
+
+  async cleanupTempFiles(maxAgeMs = 24 * 60 * 60 * 1000): Promise<number> {
+    const cutoff = new Date(Date.now() - maxAgeMs);
+    let deleted = 0;
+
+    let continuationToken: string | undefined;
+    do {
+      const response = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: 'blog/temp/',
+          ContinuationToken: continuationToken,
+        }),
+      );
+
+      for (const obj of response.Contents ?? []) {
+        if (obj.Key && obj.LastModified && obj.LastModified < cutoff) {
+          await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: obj.Key }));
+          deleted++;
+        }
+      }
+
+      continuationToken = response.NextContinuationToken;
+    } while (continuationToken);
+
+    if (deleted > 0) this.logger.log(`Cleaned up ${deleted} temp files`);
+    return deleted;
+  }
+
+  private urlToKey(url: string): string | null {
+    const prefix = `${this.publicUrl}/`;
+    if (!url.startsWith(prefix)) return null;
+    return url.slice(prefix.length);
   }
 }


### PR DESCRIPTION
## Summary
- 이미지 temp→확정 경로 플로우 (DB 성공 후 이동, 실패 시 롤백)
- publishedAt 필드 + 수동 발행일 조정
- 썸네일 별도 API 제거, DTO 통합
- 매일 3AM temp 파일 자동 정리