### PR TITLE
feat: Category 아이콘 관리 API

### DIFF
--- a/prisma/migrations/20260322010000_add_category_table/migration.sql
+++ b/prisma/migrations/20260322010000_add_category_table/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable (독립 메타데이터 테이블, Post.category 문자열과 name으로 매칭)
+CREATE TABLE IF NOT EXISTS "blog"."categories" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(200) NOT NULL,
+    "icon" VARCHAR(100) NOT NULL DEFAULT 'LayoutGrid',
+    "sort_order" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "categories_name_key" ON "blog"."categories"("name");
+CREATE INDEX IF NOT EXISTS "categories_sort_order_idx" ON "blog"."categories"("sort_order");
+
+-- Seed initial categories
+INSERT INTO "blog"."categories" ("name", "icon", "sort_order")
+VALUES
+  ('Frontend', 'Monitor', 1),
+  ('Programming', 'Code', 2),
+  ('DevOps', 'Container', 3),
+  ('Career', 'Briefcase', 4),
+  ('Backend', 'Server', 5)
+ON CONFLICT ("name") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,17 @@ model RefreshToken {
 
 // ─── Blog ────────────────────────────────────────────────────────────────────
 
+model Category {
+  id        Int    @id @default(autoincrement())
+  name      String @unique @db.VarChar(200)
+  icon      String @default("LayoutGrid") @db.VarChar(100)
+  sortOrder Int    @default(0) @map("sort_order")
+
+  @@index([sortOrder])
+  @@map("categories")
+  @@schema("blog")
+}
+
 model Post {
   id           Int       @id @default(autoincrement())
   title        String    @db.VarChar(500)

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseIntPipe,
   Post,
   Put,
   Query,
@@ -26,6 +27,7 @@ import type { MultipartRequest } from '../types/fastify.d';
 import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from './blog.constants';
 import { BlogService } from './blog.service';
 import { safeExtension } from './blog.utils';
+import { CreateCategoryDto } from './dto/create-category.dto';
 import { CreatePostDto } from './dto/create-post.dto';
 import { PostQueryDto, RecentQueryDto, SearchQueryDto, TagQueryDto } from './dto/post-query.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
@@ -61,6 +63,26 @@ export class BlogController {
   @Get('categories')
   getCategories() {
     return this.blogService.getCategories();
+  }
+
+  @ApiBearerAuth()
+  @Post('categories')
+  @HttpCode(HttpStatus.CREATED)
+  createCategory(@Body() dto: CreateCategoryDto) {
+    return this.blogService.createCategory(dto);
+  }
+
+  @ApiBearerAuth()
+  @Put('categories/:id')
+  updateCategory(@Param('id', ParseIntPipe) id: number, @Body() dto: CreateCategoryDto) {
+    return this.blogService.updateCategory(id, dto);
+  }
+
+  @ApiBearerAuth()
+  @Delete('categories/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  deleteCategory(@Param('id', ParseIntPipe) id: number) {
+    return this.blogService.deleteCategory(id);
   }
 
   @Public()

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -151,7 +151,7 @@ export class BlogService {
     recentThreshold.setDate(recentThreshold.getDate() - RECENT_DAYS);
 
     // 카테고리별 카운트 + 최근 여부를 2개 쿼리로 분리 (메모리 집계 최소화)
-    const [categoryCounts, recentCategories, tagCounts] = await Promise.all([
+    const [categoryCounts, recentCategories, tagCounts, categoryMeta] = await Promise.all([
       this.prisma.post.groupBy({
         by: ['category'],
         where: { published: true, category: { not: null } },
@@ -169,9 +169,11 @@ export class BlogService {
           post: { select: { category: true } },
         },
       }),
+      this.prisma.category.findMany(),
     ]);
 
     const recentSet = new Set(recentCategories.map(r => r.category));
+    const iconMap = new Map(categoryMeta.map(c => [c.name, c.icon]));
 
     // 태그 카운트 집계
     const tagMap = new Map<string, Map<string, { name: string; slug: string; count: number }>>();
@@ -193,6 +195,7 @@ export class BlogService {
     const result = categoryCounts
       .map(c => ({
         category: c.category as string,
+        icon: iconMap.get(c.category as string) ?? 'LayoutGrid',
         count: c._count,
         recent: recentSet.has(c.category),
         tags: Array.from(tagMap.get(c.category as string)?.values() ?? []).sort(
@@ -312,6 +315,43 @@ export class BlogService {
     const result = { related, recommended };
     await this.cache.set(key, result, CACHE_TTL);
     return result;
+  }
+
+  // ─── Category CRUD ─────────────────────────────────────────────────────────
+
+  async createCategory(dto: { name: string; icon?: string; sortOrder?: number }) {
+    return this.prisma.category.create({
+      data: { name: dto.name, icon: dto.icon ?? 'LayoutGrid', sortOrder: dto.sortOrder ?? 0 },
+    });
+  }
+
+  async updateCategory(id: number, dto: { name?: string; icon?: string; sortOrder?: number }) {
+    try {
+      return await this.prisma.category.update({
+        where: { id },
+        data: {
+          ...(dto.name !== undefined && { name: dto.name }),
+          ...(dto.icon !== undefined && { icon: dto.icon }),
+          ...(dto.sortOrder !== undefined && { sortOrder: dto.sortOrder }),
+        },
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+        throw new NotFoundException('Category not found');
+      }
+      throw error;
+    }
+  }
+
+  async deleteCategory(id: number): Promise<void> {
+    try {
+      await this.prisma.category.delete({ where: { id } });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+        throw new NotFoundException('Category not found');
+      }
+      throw error;
+    }
   }
 
   // ─── Write ────────────────────────────────────────────────────────────────

--- a/src/blog/dto/create-category.dto.ts
+++ b/src/blog/dto/create-category.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+
+export class CreateCategoryDto {
+  @ApiProperty({ example: 'Frontend' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  name: string;
+
+  @ApiPropertyOptional({ example: 'Monitor', description: 'lucide-react 아이콘 이름' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  icon?: string = 'LayoutGrid';
+
+  @ApiPropertyOptional({ default: 0 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  sortOrder?: number = 0;
+}


### PR DESCRIPTION
## Summary
- Category 독립 테이블 (lucide-react 아이콘 + 정렬)
- GET /categories 응답에 icon 필드 추가
- Category CRUD API (JWT 필요)
- P2025 에러 핸들링