### PR TITLE
feat: Swagger API Key + Cookie 인증 추가

### DIFF
--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -9,7 +9,7 @@ import {
   Query,
   Req,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import type { FastifyRequest } from 'fastify';
 import { Public } from '../common/decorators/public.decorator';
 import { AdminLogService } from './admin-log.service';
@@ -31,6 +31,7 @@ export class AnalyticsController {
   // ─── Public (프론트에서 호출) ──────────────────────────────────────────────
 
   @Public()
+  @ApiSecurity('api-key')
   @Post('pageview')
   @HttpCode(HttpStatus.NO_CONTENT)
   trackPageView(@Body() dto: TrackPageViewDto, @Req() req: FastifyRequest) {
@@ -48,36 +49,42 @@ export class AnalyticsController {
   // ─── Admin (JWT 필요) ──────────────────────────────────────────────────────
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Get('dashboard')
   getDashboard() {
     return this.analytics.getDashboardStats();
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Get('popular-posts')
   getPopularPosts(@Query('limit') limit?: string) {
     return this.analytics.getPopularPosts(limit ? Number(limit) : undefined);
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Get('visitors')
   getVisitors(@Query('days') days?: string, @Query('app') app?: string) {
     return this.analytics.getVisitorStats(days ? Number(days) : undefined, app);
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Get('referrers')
   getReferrers(@Query('days') days?: string, @Query('app') app?: string) {
     return this.analytics.getReferrerStats(days ? Number(days) : undefined, app);
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Get('system')
   getSystem() {
     return this.analytics.getSystemStatus();
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Get('admin-logs')
   getAdminLogs(@Query('limit') limit?: string) {
     return this.adminLog.getRecent(limit ? Number(limit) : undefined);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Post, Query, Req, Res } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiTags } from '@nestjs/swagger';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { Public } from '../common/decorators/public.decorator';
 import { SkipApiKey } from '../common/decorators/skip-api-key.decorator';
@@ -71,6 +71,7 @@ export class AuthController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('logout-all')
   @HttpCode(HttpStatus.NO_CONTENT)
   async logoutAll(@Req() req: CookieRequest, @Res() reply: FastifyReply) {
@@ -80,6 +81,7 @@ export class AuthController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('session/extend')
   @HttpCode(HttpStatus.OK)
   async extendSession(@Res() reply: FastifyReply) {
@@ -96,6 +98,7 @@ export class AuthController {
   // ─── Preview ──────────────────────────────────────────────────────────────
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('preview-token')
   @HttpCode(HttpStatus.OK)
   createPreviewToken() {

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -14,7 +14,7 @@ import {
   Req,
   UnauthorizedException,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiConsumes, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiConsumes, ApiCookieAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { AuthService } from '../auth/auth.service';
 import { Public } from '../common/decorators/public.decorator';
 import {
@@ -41,6 +41,7 @@ export class BlogController {
   ) {}
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('posts/search')
   @ApiBadRequest('q must be at least 2 characters')
   search(@Query() query: SearchQueryDto) {
@@ -48,24 +49,28 @@ export class BlogController {
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('posts')
   findAll(@Query() query: PostQueryDto) {
     return this.blogService.findAll(query);
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('posts/recent')
   getRecentPosts(@Query() query: RecentQueryDto) {
     return this.blogService.getRecentPosts(query.limit);
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('categories')
   getCategories() {
     return this.blogService.getCategories();
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('categories')
   @HttpCode(HttpStatus.CREATED)
   createCategory(@Body() dto: CreateCategoryDto) {
@@ -73,12 +78,14 @@ export class BlogController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Put('categories/:id')
   updateCategory(@Param('id', ParseIntPipe) id: number, @Body() dto: CreateCategoryDto) {
     return this.blogService.updateCategory(id, dto);
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Delete('categories/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   deleteCategory(@Param('id', ParseIntPipe) id: number) {
@@ -86,12 +93,14 @@ export class BlogController {
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('tags')
   getTags(@Query() query: TagQueryDto) {
     return this.blogService.getTags(query);
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('posts/:slug')
   @ApiNotFound('Post')
   findOne(@Param('slug') slug: string) {
@@ -99,6 +108,7 @@ export class BlogController {
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('posts/:slug/preview')
   @ApiNotFound('Post')
   @ApiUnauthorized()
@@ -110,6 +120,7 @@ export class BlogController {
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('posts/:slug/related')
   @ApiNotFound('Post')
   getRelatedPosts(@Param('slug') slug: string) {
@@ -117,6 +128,7 @@ export class BlogController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('posts')
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
@@ -127,6 +139,7 @@ export class BlogController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Put('posts/:slug')
   @ApiUnauthorized()
   @ApiNotFound('Post')
@@ -135,6 +148,7 @@ export class BlogController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Delete('posts/:slug')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiUnauthorized()
@@ -144,6 +158,7 @@ export class BlogController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('images')
   @ApiConsumes('multipart/form-data')
   @ApiUnauthorized()

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,8 @@ async function bootstrap() {
       .setDescription('chahyunwoo.dev blog & portfolio API')
       .setVersion('1.0')
       .addBearerAuth()
+      .addCookieAuth('access_token')
+      .addApiKey({ type: 'apiKey', name: 'x-api-key', in: 'header' }, 'api-key')
       .build();
     const document = SwaggerModule.createDocument(app, swaggerConfig);
     SwaggerModule.setup('docs', app, document);

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -11,7 +11,7 @@ import {
   Put,
   Query,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { Public } from '../common/decorators/public.decorator';
 import {
   ApiBadRequest,
@@ -44,12 +44,14 @@ export class PortfolioController {
   // ─── Public ─────────────────────────────────────────────────────────────────
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('locales')
   getLocales() {
     return this.portfolioService.getLocales();
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('profile')
   @ApiNotFound('Profile')
   @ApiBadRequest('Unsupported locale')
@@ -58,6 +60,7 @@ export class PortfolioController {
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('experiences')
   @ApiBadRequest('Unsupported locale')
   getExperiences(@Query(ValidateLocalePipe) query: LocaleQueryDto) {
@@ -65,6 +68,7 @@ export class PortfolioController {
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('projects')
   @ApiBadRequest('Unsupported locale')
   getProjects(@Query(ValidateLocalePipe) query: GetProjectsQueryDto) {
@@ -72,12 +76,14 @@ export class PortfolioController {
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('skills')
   getSkills() {
     return this.portfolioService.getSkills();
   }
 
   @Public()
+  @ApiSecurity('api-key')
   @Get('education')
   @ApiBadRequest('Unsupported locale')
   getEducation(@Query(ValidateLocalePipe) query: LocaleQueryDto) {
@@ -87,6 +93,7 @@ export class PortfolioController {
   // ─── Admin ──────────────────────────────────────────────────────────────────
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('locales')
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
@@ -97,6 +104,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Delete('locales/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiUnauthorized()
@@ -106,6 +114,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Put('profile')
   @ApiUnauthorized()
   updateProfile(@Body() dto: UpdateProfileDto) {
@@ -113,6 +122,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('experiences')
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
@@ -122,6 +132,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Put('experiences/:id')
   @ApiUnauthorized()
   @ApiNotFound('Experience')
@@ -130,6 +141,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Delete('experiences/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiUnauthorized()
@@ -139,6 +151,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('projects')
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
@@ -148,6 +161,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Put('projects/:id')
   @ApiUnauthorized()
   @ApiNotFound('Project')
@@ -156,6 +170,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Delete('projects/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiUnauthorized()
@@ -165,6 +180,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('skills')
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
@@ -174,6 +190,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Put('skills/:id')
   @ApiUnauthorized()
   @ApiNotFound('Skill')
@@ -182,6 +199,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Delete('skills/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiUnauthorized()
@@ -191,6 +209,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Post('education')
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
@@ -200,6 +219,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Put('education/:id')
   @ApiUnauthorized()
   @ApiNotFound('Education')
@@ -208,6 +228,7 @@ export class PortfolioController {
   }
 
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @Delete('education/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiUnauthorized()


### PR DESCRIPTION
## Summary
- Swagger DocumentBuilder에 `addCookieAuth('access_token')`, `addApiKey(x-api-key)` 추가
- 공개 API(`@Public()`)에 `@ApiSecurity('api-key')` 적용 — Swagger에서 API Key 필수 표시
- 어드민 API에 `@ApiCookieAuth()` 추가 — Swagger에서 로그인 후 cookie 기반 테스트 가능
- 기존 `@ApiBearerAuth()`는 유지 — Bearer + Cookie 둘 다 사용 가능

## Test plan
- [ ] `pnpm start:dev` 후 `/docs` 접속
- [ ] Swagger UI에서 API Key, Bearer, Cookie Auth 3가지 인증 방식 확인
- [ ] 공개 API에 API Key 입력 후 요청 테스트
- [ ] 로그인 API 호출 후 cookie 자동 설정 확인
- [ ] 어드민 API cookie 인증으로 요청 테스트