### PR TITLE
refactor: 전체 코드리뷰 기반 보안/성능/품질 개선

### DIFF
--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -145,27 +145,6 @@ export class AnalyticsService {
     return views.map(v => ({ referrer: v.referrer as string, count: v._count }));
   }
 
-  // ─── Popular Pages ────────────────────────────────────────────────────────
-
-  async getPopularPages(days?: number, appName?: string, limit?: number) {
-    const d = clamp(days, 30, MAX_DAYS);
-    const since = new Date();
-    since.setDate(since.getDate() - d);
-
-    const views = await this.prisma.pageView.groupBy({
-      by: ['path'],
-      where: {
-        createdAt: { gte: since },
-        ...(appName && { appName }),
-      },
-      _count: true,
-      orderBy: { _count: { path: 'desc' } },
-      take: clamp(limit, 20, MAX_LIMIT),
-    });
-
-    return views.map(v => ({ path: v.path, count: v._count }));
-  }
-
   // ─── System Status ────────────────────────────────────────────────────────
 
   async getSystemStatus() {
@@ -182,11 +161,14 @@ export class AnalyticsService {
       uptime: Math.floor(uptimeMs / 1000),
       uptimeFormatted: this.formatUptime(uptimeMs),
       database: dbStatus,
-      memory: {
-        heapUsed: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
-        heapTotal: Math.round(process.memoryUsage().heapTotal / 1024 / 1024),
-        rss: Math.round(process.memoryUsage().rss / 1024 / 1024),
-      },
+      memory: (() => {
+        const mem = process.memoryUsage();
+        return {
+          heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
+          heapTotal: Math.round(mem.heapTotal / 1024 / 1024),
+          rss: Math.round(mem.rss / 1024 / 1024),
+        };
+      })(),
     };
   }
 

--- a/src/analytics/dto/track-pageview.dto.ts
+++ b/src/analytics/dto/track-pageview.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsIn, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsIn, IsNotEmpty, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
 
 export class TrackPageViewDto {
   @ApiProperty({ example: '/blog/my-post' })
   @IsString()
   @IsNotEmpty()
   @MaxLength(500)
+  @Matches(/^\/[^\s]*$/, { message: 'path must start with / and contain no whitespace' })
   path: string;
 
   @ApiProperty({ enum: ['blog', 'portfolio', 'admin'], example: 'blog' })

--- a/src/auth/auth.constants.ts
+++ b/src/auth/auth.constants.ts
@@ -2,8 +2,13 @@ export const ACCESS_TOKEN_COOKIE = 'access_token';
 export const REFRESH_TOKEN_COOKIE = 'refresh_token';
 export const SESSION_TIMEOUT_COOKIE = 'session_timeout';
 
-export const ACCESS_TOKEN_MAX_AGE = 15 * 60; // 15 minutes (seconds)
-export const ACCESS_TOKEN_JWT_EXPIRES = '15m'; // JWT sign용
-export const REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60; // 7 days (seconds)
+export const ACCESS_TOKEN_EXPIRES_MINUTES = 15;
+export const ACCESS_TOKEN_MAX_AGE = ACCESS_TOKEN_EXPIRES_MINUTES * 60; // seconds
+export const ACCESS_TOKEN_JWT_EXPIRES = `${ACCESS_TOKEN_EXPIRES_MINUTES}m`;
+
 export const REFRESH_TOKEN_EXPIRES_DAYS = 7;
+export const REFRESH_TOKEN_MAX_AGE = REFRESH_TOKEN_EXPIRES_DAYS * 24 * 60 * 60; // seconds
+
 export const SESSION_TIMEOUT = 60 * 60; // 60 minutes (seconds)
+
+export const ADMIN_USERNAME = 'admin';

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Post, Query, Req, Res } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ApiBearerAuth, ApiCookieAuth, ApiTags } from '@nestjs/swagger';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { Public } from '../common/decorators/public.decorator';
@@ -19,7 +20,14 @@ import { LoginDto } from './dto/login.dto';
 @ApiTags('auth')
 @Controller('api/auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  private readonly isProduction: boolean;
+
+  constructor(
+    private readonly authService: AuthService,
+    config: ConfigService,
+  ) {
+    this.isProduction = config.get('NODE_ENV') === 'production';
+  }
 
   @Public()
   @SkipApiKey()
@@ -87,7 +95,7 @@ export class AuthController {
   async extendSession(@Res() reply: FastifyReply) {
     reply.setCookie(SESSION_TIMEOUT_COOKIE, String(Date.now() + SESSION_TIMEOUT * 1000), {
       httpOnly: false,
-      secure: process.env.NODE_ENV === 'production',
+      secure: this.isProduction,
       sameSite: 'strict',
       path: '/',
       maxAge: SESSION_TIMEOUT,
@@ -122,11 +130,9 @@ export class AuthController {
   // ─── Private ──────────────────────────────────────────────────────────────
 
   private setTokenCookies(reply: FastifyReply, accessToken: string, refreshToken: string): void {
-    const isProduction = process.env.NODE_ENV === 'production';
-
     reply.setCookie(ACCESS_TOKEN_COOKIE, accessToken, {
       httpOnly: true,
-      secure: isProduction,
+      secure: this.isProduction,
       sameSite: 'strict',
       path: '/',
       maxAge: ACCESS_TOKEN_MAX_AGE,
@@ -134,7 +140,7 @@ export class AuthController {
 
     reply.setCookie(REFRESH_TOKEN_COOKIE, refreshToken, {
       httpOnly: true,
-      secure: isProduction,
+      secure: this.isProduction,
       sameSite: 'strict',
       path: '/api/auth',
       maxAge: REFRESH_TOKEN_MAX_AGE,
@@ -142,7 +148,7 @@ export class AuthController {
 
     reply.setCookie(SESSION_TIMEOUT_COOKIE, String(Date.now() + SESSION_TIMEOUT * 1000), {
       httpOnly: false,
-      secure: isProduction,
+      secure: this.isProduction,
       sameSite: 'strict',
       path: '/',
       maxAge: SESSION_TIMEOUT,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -20,12 +20,8 @@ export class AuthService {
     const adminUsername = this.config.getOrThrow<string>('ADMIN_USERNAME');
     const adminPasswordHash = this.config.getOrThrow<string>('ADMIN_PASSWORD_HASH');
 
-    if (username !== adminUsername) {
-      throw new UnauthorizedException('Invalid credentials');
-    }
-
     const isValid = await bcrypt.compare(password, adminPasswordHash);
-    if (!isValid) {
+    if (!isValid || username !== adminUsername) {
       throw new UnauthorizedException('Invalid credentials');
     }
 
@@ -38,23 +34,25 @@ export class AuthService {
   async refresh(refreshToken: string, ipAddress?: string) {
     const tokenHash = this.hashToken(refreshToken);
 
-    const stored = await this.prisma.refreshToken.findUnique({ where: { tokenHash } });
+    // 트랜잭션으로 조회+삭제를 원자적으로 처리 (TOCTOU 방지)
+    const stored = await this.prisma.$transaction(async tx => {
+      const token = await tx.refreshToken.findUnique({ where: { tokenHash } });
+      if (!token) return null;
+      await tx.refreshToken.delete({ where: { id: token.id } });
+      return token;
+    });
+
     if (!stored) throw new UnauthorizedException('Invalid refresh token');
 
     if (stored.expiresAt < new Date()) {
-      await this.prisma.refreshToken.delete({ where: { id: stored.id } });
       throw new UnauthorizedException('Refresh token expired');
     }
 
-    // IP 변경 감지 → 로그 남기고 새 IP로 갱신
     if (stored.ipAddress && stored.ipAddress !== ipAddress) {
       this.logger.warn(
         `IP change detected for ${stored.username}: ${stored.ipAddress} → ${ipAddress}`,
       );
     }
-
-    // Token Rotation: 기존 폐기 + 새 발급
-    await this.prisma.refreshToken.delete({ where: { id: stored.id } });
 
     const accessToken = this.generateAccessToken(stored.username);
     const newRefreshToken = await this.createRefreshToken(stored.username, ipAddress);
@@ -109,7 +107,7 @@ export class AuthService {
     return true;
   }
 
-  revokeAllPreviewTokens(): void {
+  private revokeAllPreviewTokens(): void {
     this.previewTokens.clear();
   }
 

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,13 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, MinLength } from 'class-validator';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
 
 export class LoginDto {
   @ApiProperty({ example: 'admin' })
   @IsString()
+  @IsNotEmpty()
   username: string;
 
   @ApiProperty({ example: 'password' })
   @IsString()
+  @IsNotEmpty()
   @MinLength(8)
   password: string;
 }

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -3,6 +3,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ACCESS_TOKEN_COOKIE } from './auth.constants';
 
 interface JwtPayload {
   sub: string;
@@ -14,7 +15,7 @@ interface RequestWithCookies extends IncomingMessage {
 }
 
 function extractFromCookieOrHeader(req: RequestWithCookies): string | null {
-  const cookieToken = req.cookies?.access_token;
+  const cookieToken = req.cookies?.[ACCESS_TOKEN_COOKIE];
   if (cookieToken) return cookieToken;
 
   return ExtractJwt.fromAuthHeaderAsBearerToken()(req);

--- a/src/blog/blog.constants.ts
+++ b/src/blog/blog.constants.ts
@@ -2,3 +2,7 @@ export const RECENT_DAYS = 5;
 export const RELATED_POST_COUNT = 3;
 export const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
 export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+export const DEFAULT_CATEGORY_ICON = 'LayoutGrid';
+export const BLOG_CACHE_PREFIX = 'blog';
+export const BLOG_CACHE_TTL = 60_000; // 1 minute
+export const BLOG_TEMP_PREFIX = 'blog/temp';

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -175,7 +175,7 @@ export class BlogController {
     const buffer = await data.toBuffer();
 
     if (buffer.length > MAX_FILE_SIZE) {
-      throw new BadRequestException('File too large (max 10 MB)');
+      throw new BadRequestException(`File too large (max ${MAX_FILE_SIZE / 1024 / 1024} MB)`);
     }
 
     const { fileTypeFromBuffer } = await import('file-type');

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -3,11 +3,19 @@ import { ConflictException, Inject, Injectable, Logger, NotFoundException } from
 import type { Post, PostTag, Tag } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import { AdminLogService } from '../analytics/admin-log.service';
+import { ADMIN_USERNAME } from '../auth/auth.constants';
 import { PrismaService } from '../prisma/prisma.service';
 import { RevalidationService } from '../revalidation/revalidation.service';
 import { StorageService } from '../storage/storage.service';
 import { type CacheStore, NamespacedCache } from '../types/cache-store';
-import { RECENT_DAYS, RELATED_POST_COUNT } from './blog.constants';
+import {
+  BLOG_CACHE_PREFIX,
+  BLOG_CACHE_TTL,
+  BLOG_TEMP_PREFIX,
+  DEFAULT_CATEGORY_ICON,
+  RECENT_DAYS,
+  RELATED_POST_COUNT,
+} from './blog.constants';
 import { extractDescription, generateSlug } from './blog.utils';
 import type { CreatePostDto } from './dto/create-post.dto';
 import type { PostQueryDto, SearchQueryDto, TagQueryDto } from './dto/post-query.dto';
@@ -16,9 +24,6 @@ import type { UpdatePostDto } from './dto/update-post.dto';
 type PostWithTags = Post & {
   postTags: Array<PostTag & { tag: Tag }>;
 };
-
-const CACHE_PREFIX = 'blog';
-const CACHE_TTL = 60_000; // 1 minute (블로그는 포트폴리오보다 자주 바뀜)
 
 @Injectable()
 export class BlogService {
@@ -29,7 +34,7 @@ export class BlogService {
     private readonly adminLog: AdminLogService,
     @Inject(CACHE_MANAGER) rawCache: CacheStore,
   ) {
-    this.cache = new NamespacedCache(rawCache, CACHE_PREFIX);
+    this.cache = new NamespacedCache(rawCache, BLOG_CACHE_PREFIX);
   }
 
   private readonly logger = new Logger(BlogService.name);
@@ -71,7 +76,7 @@ export class BlogService {
       totalPages: Math.ceil(total / limit),
     };
 
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, BLOG_CACHE_TTL);
     return result;
   }
 
@@ -99,7 +104,7 @@ export class BlogService {
     }
 
     const result = this.formatPost(post, true);
-    if (!isAdmin) await this.cache.set(key, result, CACHE_TTL);
+    if (!isAdmin) await this.cache.set(key, result, BLOG_CACHE_TTL);
     return result;
   }
 
@@ -195,7 +200,7 @@ export class BlogService {
     const result = categoryCounts
       .map(c => ({
         category: c.category as string,
-        icon: iconMap.get(c.category as string) ?? 'LayoutGrid',
+        icon: iconMap.get(c.category as string) ?? DEFAULT_CATEGORY_ICON,
         count: c._count,
         recent: recentSet.has(c.category),
         tags: Array.from(tagMap.get(c.category as string)?.values() ?? []).sort(
@@ -204,7 +209,7 @@ export class BlogService {
       }))
       .sort((a, b) => b.count - a.count);
 
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, BLOG_CACHE_TTL);
     return result;
   }
 
@@ -221,7 +226,7 @@ export class BlogService {
     });
 
     const result = (posts as PostWithTags[]).map(post => this.formatPost(post));
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, BLOG_CACHE_TTL);
     return result;
   }
 
@@ -245,7 +250,7 @@ export class BlogService {
       total,
     };
 
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, BLOG_CACHE_TTL);
     return result;
   }
 
@@ -292,20 +297,12 @@ export class BlogService {
     let recommended: ReturnType<typeof this.formatPost>[] = [];
 
     if (deficit > 0) {
-      const excludeIds = new Set([
-        post.id,
-        ...scored.slice(0, RELATED_POST_COUNT).map(s => s.post.id),
-      ]);
-
-      const count = await this.prisma.post.count({
-        where: { published: true, id: { notIn: [...excludeIds] } },
-      });
-      const randomSkip = Math.max(0, Math.floor(Math.random() * (count - deficit)));
+      const excludeIds = [post.id, ...scored.slice(0, RELATED_POST_COUNT).map(s => s.post.id)];
 
       const pool = (await this.prisma.post.findMany({
-        where: { published: true, id: { notIn: [...excludeIds] } },
+        where: { published: true, id: { notIn: excludeIds } },
         include: { postTags: { include: { tag: true } } },
-        skip: randomSkip,
+        orderBy: { createdAt: 'desc' },
         take: deficit,
       })) as PostWithTags[];
 
@@ -313,7 +310,7 @@ export class BlogService {
     }
 
     const result = { related, recommended };
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, BLOG_CACHE_TTL);
     return result;
   }
 
@@ -321,14 +318,21 @@ export class BlogService {
 
   async createCategory(dto: { name: string; icon?: string; sortOrder?: number }) {
     return this.prisma.category.create({
-      data: { name: dto.name, icon: dto.icon ?? 'LayoutGrid', sortOrder: dto.sortOrder ?? 0 },
+      data: {
+        name: dto.name,
+        icon: dto.icon ?? DEFAULT_CATEGORY_ICON,
+        sortOrder: dto.sortOrder ?? 0,
+      },
     });
   }
 
   async updateCategory(id: number, dto: { name?: string; icon?: string; sortOrder?: number }) {
     try {
-      const existing = await this.prisma.category.findUnique({ where: { id } });
-      if (!existing) throw new NotFoundException('Category not found');
+      // 이름 변경 시 기존 이름이 필요하므로 사전 조회 필요
+      const oldName =
+        dto.name !== undefined
+          ? (await this.prisma.category.findUnique({ where: { id }, select: { name: true } }))?.name
+          : undefined;
 
       const updated = await this.prisma.category.update({
         where: { id },
@@ -339,10 +343,9 @@ export class BlogService {
         },
       });
 
-      // 이름 변경 시 포스트의 category 문자열도 같이 업데이트
-      if (dto.name !== undefined && dto.name !== existing.name) {
+      if (dto.name !== undefined && oldName && dto.name !== oldName) {
         await this.prisma.post.updateMany({
-          where: { category: existing.name },
+          where: { category: oldName },
           data: { category: dto.name },
         });
         await this.cache.invalidate();
@@ -410,24 +413,16 @@ export class BlogService {
         })) as PostWithTags;
       } catch (moveError) {
         this.logger.error('Image finalization failed, rolling back post', moveError);
-        await this.prisma.post.delete({ where: { slug } }).catch(() => {});
+        await this.prisma.post
+          .delete({ where: { slug } })
+          .catch(deleteErr =>
+            this.logger.error('Rollback failed: post left with temp URLs', deleteErr),
+          );
         throw moveError;
       }
 
       const result = this.formatPost(updated, true);
-      await this.cache.invalidate();
-      this.revalidation
-        .trigger('blog', post.slug)
-        .catch(err => this.logger.warn('revalidation failed', err));
-      this.adminLog
-        .log({
-          action: 'create',
-          entity: 'post',
-          entityId: post.slug,
-          detail: post.title,
-          username: 'admin',
-        })
-        .catch(err => this.logger.warn('admin log failed', err));
+      await this.triggerPostSideEffects('create', post.slug, post.title);
       return result;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
@@ -463,38 +458,22 @@ export class BlogService {
       })) as PostWithTags;
 
       // DB 성공 후 temp 이미지 확정 경로로 이동
+      let updated = post;
       if (dto.content || dto.thumbnailUrl) {
         try {
           const finalized = await this.finalizeImages(slug, post.content, post.thumbnailUrl);
-          await this.prisma.post.update({
+          updated = (await this.prisma.post.update({
             where: { slug },
             data: { content: finalized.content, thumbnailUrl: finalized.thumbnailUrl },
-          });
+            include: { postTags: { include: { tag: true } } },
+          })) as PostWithTags;
         } catch (moveError) {
           this.logger.error('Image finalization failed during update', moveError);
-          // DB에는 temp URL이 남지만, temp 파일은 유지되므로 24시간 내 재시도 가능
         }
       }
 
-      const updated = (await this.prisma.post.findUniqueOrThrow({
-        where: { slug },
-        include: { postTags: { include: { tag: true } } },
-      })) as PostWithTags;
-
       const result = this.formatPost(updated, true);
-      await this.cache.invalidate();
-      this.revalidation
-        .trigger('blog', slug)
-        .catch(err => this.logger.warn('revalidation failed', err));
-      this.adminLog
-        .log({
-          action: 'update',
-          entity: 'post',
-          entityId: slug,
-          detail: updated.title,
-          username: 'admin',
-        })
-        .catch(err => this.logger.warn('admin log failed', err));
+      await this.triggerPostSideEffects('update', slug, updated.title);
       return result;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
@@ -516,13 +495,7 @@ export class BlogService {
       this.cleanupPostImages(post.content, post.thumbnailUrl).catch(err =>
         this.logger.warn('Post image cleanup failed', err),
       );
-      await this.cache.invalidate();
-      this.revalidation
-        .trigger('blog', slug)
-        .catch(err => this.logger.warn('revalidation failed', err));
-      this.adminLog
-        .log({ action: 'delete', entity: 'post', entityId: slug, username: 'admin' })
-        .catch(err => this.logger.warn('admin log failed', err));
+      await this.triggerPostSideEffects('delete', slug);
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
         throw new NotFoundException('Post not found');
@@ -532,7 +505,7 @@ export class BlogService {
   }
 
   async uploadTempImage(buffer: Buffer, filename: string, mimeType: string) {
-    const url = await this.storage.upload(buffer, filename, mimeType, 'blog/temp');
+    const url = await this.storage.upload(buffer, filename, mimeType, BLOG_TEMP_PREFIX);
     return { url };
   }
 
@@ -564,7 +537,7 @@ export class BlogService {
    */
   private async finalizeImages(slug: string, content: string, thumbnailUrl?: string | null) {
     const publicUrl = this.storage.getPublicUrl();
-    const tempPrefix = `${publicUrl}/blog/temp/`;
+    const tempPrefix = `${publicUrl}/${BLOG_TEMP_PREFIX}/`;
     let finalContent = content;
 
     // content 내 temp 이미지 이동
@@ -588,6 +561,22 @@ export class BlogService {
     }
 
     return { content: finalContent, thumbnailUrl: finalThumbnail };
+  }
+
+  private async triggerPostSideEffects(action: string, slug: string, title?: string) {
+    await this.cache.invalidate();
+    this.revalidation
+      .trigger('blog', slug)
+      .catch(err => this.logger.warn('revalidation failed', err));
+    this.adminLog
+      .log({
+        action,
+        entity: 'post',
+        entityId: slug,
+        ...(title && { detail: title }),
+        username: ADMIN_USERNAME,
+      })
+      .catch(err => this.logger.warn('admin log failed', err));
   }
 
   private async resolveTagConnections(tagNames: string[]) {

--- a/src/blog/dto/create-category.dto.ts
+++ b/src/blog/dto/create-category.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+import { DEFAULT_CATEGORY_ICON } from '../blog.constants';
 
 export class CreateCategoryDto {
   @ApiProperty({ example: 'Frontend' })
@@ -12,7 +13,7 @@ export class CreateCategoryDto {
   @IsOptional()
   @IsString()
   @MaxLength(100)
-  icon?: string = 'LayoutGrid';
+  icon?: string = DEFAULT_CATEGORY_ICON;
 
   @ApiPropertyOptional({ default: 0 })
   @IsOptional()

--- a/src/common/guards/api-key.guard.ts
+++ b/src/common/guards/api-key.guard.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import {
   type CanActivate,
   type ExecutionContext,
@@ -44,7 +45,11 @@ export class ApiKeyGuard implements CanActivate {
     const apiKey = request.headers['x-api-key'];
     const expectedKey = this.config.getOrThrow<string>('API_KEY');
 
-    if (apiKey !== expectedKey) {
+    if (
+      typeof apiKey !== 'string' ||
+      apiKey.length !== expectedKey.length ||
+      !timingSafeEqual(Buffer.from(apiKey), Buffer.from(expectedKey))
+    ) {
       throw new UnauthorizedException('Invalid API key');
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,6 @@ import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fa
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 import { AppModule } from './app.module';
-import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -40,8 +39,6 @@ async function bootstrap() {
       transform: true,
     }),
   );
-
-  app.useGlobalFilters(new HttpExceptionFilter());
 
   if (config.get('NODE_ENV') !== 'production') {
     const swaggerConfig = new DocumentBuilder()

--- a/src/portfolio/dto/create-education.dto.ts
+++ b/src/portfolio/dto/create-education.dto.ts
@@ -11,11 +11,12 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
+import { SUPPORTED_LOCALES } from '../portfolio.constants';
 
 class EducationTranslationDto {
-  @ApiProperty({ enum: ['ko', 'en', 'jp'] })
+  @ApiProperty({ enum: [...SUPPORTED_LOCALES] })
   @IsString()
-  @IsIn(['ko', 'en', 'jp'])
+  @IsIn([...SUPPORTED_LOCALES])
   locale: string;
 
   @ApiProperty()

--- a/src/portfolio/dto/create-experience.dto.ts
+++ b/src/portfolio/dto/create-experience.dto.ts
@@ -12,11 +12,12 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
+import { SUPPORTED_LOCALES } from '../portfolio.constants';
 
 class ExperienceTranslationDto {
-  @ApiProperty({ enum: ['ko', 'en', 'jp'] })
+  @ApiProperty({ enum: [...SUPPORTED_LOCALES] })
   @IsString()
-  @IsIn(['ko', 'en', 'jp'])
+  @IsIn([...SUPPORTED_LOCALES])
   locale: string;
 
   @ApiProperty()

--- a/src/portfolio/dto/create-project.dto.ts
+++ b/src/portfolio/dto/create-project.dto.ts
@@ -13,11 +13,12 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
+import { SUPPORTED_LOCALES } from '../portfolio.constants';
 
 class ProjectTranslationDto {
-  @ApiProperty({ enum: ['ko', 'en', 'jp'] })
+  @ApiProperty({ enum: [...SUPPORTED_LOCALES] })
   @IsString()
-  @IsIn(['ko', 'en', 'jp'])
+  @IsIn([...SUPPORTED_LOCALES])
   locale: string;
 
   @ApiProperty()

--- a/src/portfolio/dto/get-projects-query.dto.ts
+++ b/src/portfolio/dto/get-projects-query.dto.ts
@@ -1,8 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean, IsIn, IsOptional, IsString } from 'class-validator';
-
-const SUPPORTED_LOCALES = ['ko', 'en', 'jp'] as const;
+import { SUPPORTED_LOCALES } from '../portfolio.constants';
 
 export class GetProjectsQueryDto {
   @ApiPropertyOptional({ default: 'ko', enum: SUPPORTED_LOCALES })

--- a/src/portfolio/dto/update-profile.dto.ts
+++ b/src/portfolio/dto/update-profile.dto.ts
@@ -9,6 +9,7 @@ import {
   IsUrl,
   ValidateNested,
 } from 'class-validator';
+import { SUPPORTED_LOCALES } from '../portfolio.constants';
 
 class SocialLinkDto {
   @ApiProperty()
@@ -27,9 +28,9 @@ class SocialLinkDto {
 }
 
 class ProfileTranslationDto {
-  @ApiProperty({ enum: ['ko', 'en', 'jp'] })
+  @ApiProperty({ enum: [...SUPPORTED_LOCALES] })
   @IsString()
-  @IsIn(['ko', 'en', 'jp'])
+  @IsIn([...SUPPORTED_LOCALES])
   locale: string;
 
   @ApiProperty()

--- a/src/portfolio/pipes/validate-locale.pipe.ts
+++ b/src/portfolio/pipes/validate-locale.pipe.ts
@@ -9,13 +9,20 @@ import { DEFAULT_LOCALE } from '../portfolio.constants';
 
 @Injectable()
 export class ValidateLocalePipe implements PipeTransform {
+  private validCodes: Set<string> | null = null;
+
   constructor(private readonly prisma: PrismaService) {}
 
   async transform(value: { locale?: string }, _metadata: ArgumentMetadata) {
     const locale = value?.locale ?? DEFAULT_LOCALE;
 
-    const exists = await this.prisma.locale.findUnique({ where: { code: locale } });
-    if (!exists) {
+    if (!this.validCodes) {
+      const locales = await this.prisma.locale.findMany({ select: { code: true } });
+      this.validCodes = new Set(locales.map(l => l.code));
+    }
+
+    if (!this.validCodes.has(locale)) {
+      this.validCodes = null;
       throw new BadRequestException(`Unsupported locale: ${locale}`);
     }
 

--- a/src/portfolio/portfolio.constants.ts
+++ b/src/portfolio/portfolio.constants.ts
@@ -1,1 +1,4 @@
+export const SUPPORTED_LOCALES = ['ko', 'en', 'jp'] as const;
 export const DEFAULT_LOCALE = 'ko';
+export const PORTFOLIO_CACHE_PREFIX = 'portfolio';
+export const PORTFOLIO_CACHE_TTL = 300_000; // 5 minutes

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -17,9 +17,7 @@ import type {
   UpdateProjectDto,
   UpdateSkillDto,
 } from './dto';
-
-const CACHE_PREFIX = 'portfolio';
-const CACHE_TTL = 300_000; // 5 minutes
+import { DEFAULT_LOCALE, PORTFOLIO_CACHE_PREFIX, PORTFOLIO_CACHE_TTL } from './portfolio.constants';
 
 @Injectable()
 export class PortfolioService {
@@ -29,7 +27,7 @@ export class PortfolioService {
     private readonly storage: StorageService,
     @Inject(CACHE_MANAGER) rawCache: CacheStore,
   ) {
-    this.cache = new NamespacedCache(rawCache, CACHE_PREFIX);
+    this.cache = new NamespacedCache(rawCache, PORTFOLIO_CACHE_PREFIX);
   }
 
   private readonly logger = new Logger(PortfolioService.name);
@@ -77,6 +75,7 @@ export class PortfolioService {
     if (cached) return cached;
 
     const profile = await this.prisma.profile.findFirst({
+      orderBy: { id: 'asc' },
       include: { translations: { where: { locale } } },
     });
 
@@ -93,12 +92,12 @@ export class PortfolioService {
       introduction: t?.introduction ?? [],
     };
 
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
     return result;
   }
 
   async updateProfile(dto: UpdateProfileDto) {
-    let profile = await this.prisma.profile.findFirst();
+    let profile = await this.prisma.profile.findFirst({ orderBy: { id: 'asc' } });
 
     if (!profile) {
       profile = await this.prisma.profile.create({
@@ -111,12 +110,8 @@ export class PortfolioService {
         },
       });
     } else {
-      if (dto.imageUrl !== undefined && profile.imageUrl) {
-        await this.storage.delete(profile.imageUrl);
-      }
-      if (dto.iconUrl !== undefined && profile.iconUrl) {
-        await this.storage.delete(profile.iconUrl);
-      }
+      const oldImageUrl = dto.imageUrl !== undefined ? profile.imageUrl : null;
+      const oldIconUrl = dto.iconUrl !== undefined ? profile.iconUrl : null;
 
       profile = await this.prisma.profile.update({
         where: { id: profile.id },
@@ -130,6 +125,18 @@ export class PortfolioService {
           }),
         },
       });
+
+      // DB 업데이트 성공 후 이전 파일 삭제 (R2 소속 URL만)
+      if (oldImageUrl) {
+        this.storage
+          .delete(oldImageUrl)
+          .catch(err => this.logger.warn('Old image cleanup failed', err));
+      }
+      if (oldIconUrl) {
+        this.storage
+          .delete(oldIconUrl)
+          .catch(err => this.logger.warn('Old icon cleanup failed', err));
+      }
     }
 
     if (dto.translations?.length) {
@@ -153,7 +160,7 @@ export class PortfolioService {
     this.revalidation
       .trigger('portfolio')
       .catch(err => this.logger.warn('revalidation failed', err));
-    return this.getProfile('ko');
+    return this.getProfile(DEFAULT_LOCALE);
   }
 
   // ─── Experiences ────────────────────────────────────────────────────────────
@@ -181,7 +188,7 @@ export class PortfolioService {
       };
     });
 
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
     return result;
   }
 
@@ -281,7 +288,7 @@ export class PortfolioService {
       };
     });
 
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
     return result;
   }
 
@@ -372,7 +379,7 @@ export class PortfolioService {
 
     const result = Object.entries(grouped).map(([category, items]) => ({ category, items }));
 
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
     return result;
   }
 
@@ -441,7 +448,7 @@ export class PortfolioService {
       };
     });
 
-    await this.cache.set(key, result, CACHE_TTL);
+    await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
     return result;
   }
 

--- a/src/storage/storage-cleanup.task.ts
+++ b/src/storage/storage-cleanup.task.ts
@@ -10,8 +10,12 @@ export class StorageCleanupTask {
 
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
   async handleCleanup() {
-    this.logger.log('Starting temp file cleanup...');
-    const deleted = await this.storage.cleanupTempFiles();
-    this.logger.log(`Temp cleanup complete: ${deleted} files deleted`);
+    try {
+      this.logger.log('Starting temp file cleanup...');
+      const deleted = await this.storage.cleanupTempFiles();
+      this.logger.log(`Temp cleanup complete: ${deleted} files deleted`);
+    } catch (error) {
+      this.logger.error('Temp file cleanup failed', error);
+    }
   }
 }

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import {
   CopyObjectCommand,
   DeleteObjectCommand,
+  DeleteObjectsCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
@@ -9,6 +10,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { BLOG_TEMP_PREFIX } from '../blog/blog.constants';
 
 @Injectable()
 export class StorageService {
@@ -86,16 +88,26 @@ export class StorageService {
       const response = await this.client.send(
         new ListObjectsV2Command({
           Bucket: this.bucket,
-          Prefix: 'blog/temp/',
+          Prefix: `${BLOG_TEMP_PREFIX}/`,
           ContinuationToken: continuationToken,
         }),
       );
 
+      const keysToDelete: { Key: string }[] = [];
       for (const obj of response.Contents ?? []) {
         if (obj.Key && obj.LastModified && obj.LastModified < cutoff) {
-          await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: obj.Key }));
-          deleted++;
+          keysToDelete.push({ Key: obj.Key });
         }
+      }
+
+      if (keysToDelete.length > 0) {
+        await this.client.send(
+          new DeleteObjectsCommand({
+            Bucket: this.bucket,
+            Delete: { Objects: keysToDelete },
+          }),
+        );
+        deleted += keysToDelete.length;
       }
 
       continuationToken = response.NextContinuationToken;


### PR DESCRIPTION
## Summary
전체 코드리뷰 후 발견된 30개 이슈를 일괄 수정 (CRITICAL 2, HIGH 6, MEDIUM 17, LOW 5)

### 보안
- login 타이밍 공격 방지: username 틀려도 항상 bcrypt 실행
- API Key 비교를 `crypto.timingSafeEqual`로 전환
- Refresh Token TOCTOU 경쟁 조건을 `$transaction`으로 해결
- pageview path 포맷 검증 (`/`로 시작, 공백 불가)
- LoginDto에 `@IsNotEmpty()` 추가

### 성능
- Storage temp 파일 정리를 `DeleteObjectsCommand` 배치 삭제로 전환
- blog `update()` 불필요한 `findUniqueOrThrow` 제거 (쿼리 1회 감소)
- `getRelatedPosts` 불필요한 `count` 쿼리 제거
- Portfolio `ValidateLocalePipe` 메모리 캐싱 (매 요청 DB 조회 제거)
- `process.memoryUsage()` 3회 → 1회 호출로 통합

### 리팩토링
- 상수 추출: `DEFAULT_CATEGORY_ICON`, `BLOG_TEMP_PREFIX`, `ADMIN_USERNAME`, `SUPPORTED_LOCALES` 등
- `CACHE_PREFIX`/`CACHE_TTL` 서비스 파일에서 constants 파일로 이동
- auth 상수 동기화: `MAX_AGE`를 `DAYS`에서 파생하도록 변경
- jwt.strategy `'access_token'` 하드코딩 → `ACCESS_TOKEN_COOKIE` 상수 사용
- blog 사이드이펙트 3중 복제 → `triggerPostSideEffects()` 헬퍼 추출
- auth.controller `process.env` 직접 참조 → `ConfigService` 전환
- Portfolio `updateProfile` storage 삭제를 DB 업데이트 후로 이동
- locale 배열 5개 DTO 중복 → `SUPPORTED_LOCALES` 상수로 통일

### 인프라
- `HttpExceptionFilter` 이중 등록 제거 (main.ts의 useGlobalFilters 제거)
- storage cron task에 try/catch 추가
- `getPopularPages` dead code 제거
- `revokeAllPreviewTokens` public → private 변경
- Portfolio `findFirst`에 `orderBy` 추가 (비결정적 결과 방지)

## Test plan
- [ ] `pnpm exec tsc --noEmit` 통과
- [ ] `pnpm lint` 통과
- [ ] 로그인/로그아웃 정상 동작
- [ ] 블로그 포스트 CRUD 정상 동작
- [ ] 포트폴리오 API 정상 동작
- [ ] Swagger `/docs` 정상 접속