### PR TITLE
fix: 코드리뷰 2차 수정

### DIFF
--- a/scripts/seed-works.ts
+++ b/scripts/seed-works.ts
@@ -55,6 +55,11 @@ async function main() {
     if (fs.existsSync(workPath)) {
       const works: WorkJson[] = JSON.parse(fs.readFileSync(workPath, 'utf8'));
 
+      if (!Array.isArray(works) || works.length === 0) {
+        console.error('Invalid work.json: expected non-empty array');
+        return;
+      }
+
       await prisma.work.deleteMany();
 
       for (const work of works) {
@@ -91,7 +96,11 @@ async function main() {
     if (fs.existsSync(skillPath)) {
       const skills: SkillJson[] = JSON.parse(fs.readFileSync(skillPath, 'utf8'));
 
-      // 기존 스킬 삭제 후 새로 시드
+      if (!Array.isArray(skills) || skills.length === 0) {
+        console.error('Invalid skills.json: expected non-empty array');
+        return;
+      }
+
       await prisma.skill.deleteMany();
 
       for (const skill of skills) {

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -17,6 +17,12 @@ import { AnalyticsService } from './analytics.service';
 import { TrackPageViewDto } from './dto/track-pageview.dto';
 import { PageViewService } from './page-view.service';
 
+function safeInt(value?: string): number | undefined {
+  if (!value) return undefined;
+  const n = Number.parseInt(value, 10);
+  return Number.isNaN(n) ? undefined : n;
+}
+
 @ApiTags('analytics')
 @Controller('api/analytics')
 export class AnalyticsController {
@@ -59,21 +65,21 @@ export class AnalyticsController {
   @ApiCookieAuth()
   @Get('popular-posts')
   getPopularPosts(@Query('limit') limit?: string) {
-    return this.analytics.getPopularPosts(limit ? Number(limit) : undefined);
+    return this.analytics.getPopularPosts(safeInt(limit));
   }
 
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('visitors')
   getVisitors(@Query('days') days?: string, @Query('app') app?: string) {
-    return this.analytics.getVisitorStats(days ? Number(days) : undefined, app);
+    return this.analytics.getVisitorStats(safeInt(days), app);
   }
 
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('referrers')
   getReferrers(@Query('days') days?: string, @Query('app') app?: string) {
-    return this.analytics.getReferrerStats(days ? Number(days) : undefined, app);
+    return this.analytics.getReferrerStats(safeInt(days), app);
   }
 
   @ApiBearerAuth()
@@ -87,6 +93,6 @@ export class AnalyticsController {
   @ApiCookieAuth()
   @Get('admin-logs')
   getAdminLogs(@Query('limit') limit?: string) {
-    return this.adminLog.getRecent(limit ? Number(limit) : undefined);
+    return this.adminLog.getRecent(safeInt(limit));
   }
 }

--- a/src/auth/auth.constants.ts
+++ b/src/auth/auth.constants.ts
@@ -10,5 +10,3 @@ export const REFRESH_TOKEN_EXPIRES_DAYS = 7;
 export const REFRESH_TOKEN_MAX_AGE = REFRESH_TOKEN_EXPIRES_DAYS * 24 * 60 * 60; // seconds
 
 export const SESSION_TIMEOUT = 60 * 60; // 60 minutes (seconds)
-
-export const ADMIN_USERNAME = 'admin';

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -1,9 +1,9 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ConflictException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import type { Post, PostTag, Tag } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import { AdminLogService } from '../analytics/admin-log.service';
-import { ADMIN_USERNAME } from '../auth/auth.constants';
 import { PrismaService } from '../prisma/prisma.service';
 import { RevalidationService } from '../revalidation/revalidation.service';
 import { StorageService } from '../storage/storage.service';
@@ -32,13 +32,16 @@ export class BlogService {
     private readonly storage: StorageService,
     private readonly revalidation: RevalidationService,
     private readonly adminLog: AdminLogService,
+    config: ConfigService,
     @Inject(CACHE_MANAGER) rawCache: CacheStore,
   ) {
     this.cache = new NamespacedCache(rawCache, BLOG_CACHE_PREFIX);
+    this.adminUsername = config.getOrThrow<string>('ADMIN_USERNAME');
   }
 
   private readonly logger = new Logger(BlogService.name);
   private readonly cache: NamespacedCache;
+  private readonly adminUsername: string;
 
   // ─── Read ─────────────────────────────────────────────────────────────────
 
@@ -328,26 +331,32 @@ export class BlogService {
 
   async updateCategory(id: number, dto: { name?: string; icon?: string; sortOrder?: number }) {
     try {
-      // 이름 변경 시 기존 이름이 필요하므로 사전 조회 필요
-      const oldName =
-        dto.name !== undefined
-          ? (await this.prisma.category.findUnique({ where: { id }, select: { name: true } }))?.name
-          : undefined;
+      const updated = await this.prisma.$transaction(async tx => {
+        const oldName =
+          dto.name !== undefined
+            ? (await tx.category.findUnique({ where: { id }, select: { name: true } }))?.name
+            : undefined;
 
-      const updated = await this.prisma.category.update({
-        where: { id },
-        data: {
-          ...(dto.name !== undefined && { name: dto.name }),
-          ...(dto.icon !== undefined && { icon: dto.icon }),
-          ...(dto.sortOrder !== undefined && { sortOrder: dto.sortOrder }),
-        },
+        const result = await tx.category.update({
+          where: { id },
+          data: {
+            ...(dto.name !== undefined && { name: dto.name }),
+            ...(dto.icon !== undefined && { icon: dto.icon }),
+            ...(dto.sortOrder !== undefined && { sortOrder: dto.sortOrder }),
+          },
+        });
+
+        if (dto.name !== undefined && oldName && dto.name !== oldName) {
+          await tx.post.updateMany({
+            where: { category: oldName },
+            data: { category: dto.name },
+          });
+        }
+
+        return result;
       });
 
-      if (dto.name !== undefined && oldName && dto.name !== oldName) {
-        await this.prisma.post.updateMany({
-          where: { category: oldName },
-          data: { category: dto.name },
-        });
+      if (dto.name !== undefined) {
         await this.cache.invalidate();
       }
 
@@ -574,7 +583,7 @@ export class BlogService {
         entity: 'post',
         entityId: slug,
         ...(title && { detail: title }),
-        username: ADMIN_USERNAME,
+        username: this.adminUsername,
       })
       .catch(err => this.logger.warn('admin log failed', err));
   }

--- a/src/portfolio/pipes/validate-locale.pipe.ts
+++ b/src/portfolio/pipes/validate-locale.pipe.ts
@@ -22,10 +22,13 @@ export class ValidateLocalePipe implements PipeTransform {
     }
 
     if (!this.validCodes.has(locale)) {
-      this.validCodes = null;
       throw new BadRequestException(`Unsupported locale: ${locale}`);
     }
 
     return { ...value, locale };
+  }
+
+  invalidateCache(): void {
+    this.validCodes = null;
   }
 }

--- a/src/portfolio/portfolio.module.ts
+++ b/src/portfolio/portfolio.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 
+import { ValidateLocalePipe } from './pipes/validate-locale.pipe';
 import { PortfolioController } from './portfolio.controller';
 import { PortfolioService } from './portfolio.service';
 
 @Module({
   controllers: [PortfolioController],
-  providers: [PortfolioService],
+  providers: [ValidateLocalePipe, PortfolioService],
 })
 export class PortfolioModule {}

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -19,6 +19,7 @@ import type {
   UpdateSkillDto,
   UpdateWorkDto,
 } from './dto';
+import { ValidateLocalePipe } from './pipes/validate-locale.pipe';
 import { DEFAULT_LOCALE, PORTFOLIO_CACHE_PREFIX, PORTFOLIO_CACHE_TTL } from './portfolio.constants';
 import { generateGradientColors } from './portfolio.utils';
 
@@ -28,6 +29,7 @@ export class PortfolioService {
     private readonly prisma: PrismaService,
     private readonly revalidation: RevalidationService,
     private readonly storage: StorageService,
+    private readonly localePipe: ValidateLocalePipe,
     @Inject(CACHE_MANAGER) rawCache: CacheStore,
   ) {
     this.cache = new NamespacedCache(rawCache, PORTFOLIO_CACHE_PREFIX);
@@ -44,9 +46,11 @@ export class PortfolioService {
 
   async createLocale(dto: CreateLocaleDto) {
     try {
-      return await this.prisma.locale.create({
+      const result = await this.prisma.locale.create({
         data: { code: dto.code, label: dto.label },
       });
+      this.localePipe.invalidateCache();
+      return result;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
         throw new ConflictException('Locale already exists');
@@ -58,6 +62,7 @@ export class PortfolioService {
   async deleteLocale(id: number): Promise<void> {
     try {
       await this.prisma.locale.delete({ where: { id } });
+      this.localePipe.invalidateCache();
     } catch (error) {
       this.handleNotFound(error, 'Locale');
     }

--- a/src/portfolio/portfolio.utils.ts
+++ b/src/portfolio/portfolio.utils.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 
 function hashToHue(title: string): number {
-  const hash = createHash('md5').update(title).digest('hex');
+  const hash = createHash('sha256').update(title).digest('hex');
   return Number.parseInt(hash.slice(0, 8), 16) % 360;
 }
 


### PR DESCRIPTION
## Summary
코드리뷰 2차에서 발견된 6개 이슈 수정

- **Critical**: `ADMIN_USERNAME` 상수 제거 → ConfigService에서 env 값 직접 사용 (감사 로그 정확성)
- **High**: `ValidateLocalePipe` locale 생성/삭제 시 캐시 무효화 (`invalidateCache()` 메서드 추가)
- **Medium**: `updateCategory` 이름 변경을 `$transaction`으로 원자적 처리
- **Medium**: seed 스크립트 JSON 배열 검증 추가 (deleteMany 전 방어)
- **Low**: analytics 쿼리 파라미터 `Number()` → `safeInt()` 헬퍼로 NaN 방지
- **Low**: gradient 해시 md5 → sha256 전환 (FIPS 호환)

## Test plan
- [ ] `pnpm exec tsc --noEmit` 통과
- [ ] `pnpm lint` 통과
- [ ] 로그인 후 블로그 포스트 CRUD 정상 동작 (admin log username 확인)
- [ ] locale 추가 후 즉시 해당 locale로 API 호출 가능한지 확인
- [ ] 카테고리 이름 변경 시 포스트 category도 함께 변경되는지 확인