### PR TITLE
feat: 개별 조회 API + 프로필 이미지 업로드 + 파일 검증 공통화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Thumbs.db
 
 # Logs
 *.log
+temp/

--- a/src/blog/blog.constants.ts
+++ b/src/blog/blog.constants.ts
@@ -1,7 +1,7 @@
+export { ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from '../common/utils/file-validation.util';
+
 export const RECENT_DAYS = 5;
 export const RELATED_POST_COUNT = 3;
-export const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
-export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 export const DEFAULT_CATEGORY_ICON = 'LayoutGrid';
 export const BLOG_CACHE_PREFIX = 'blog';
 export const BLOG_CACHE_TTL = 60_000; // 1 minute

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -23,10 +22,9 @@ import {
   ApiNotFound,
   ApiUnauthorized,
 } from '../common/swagger/error-responses';
+import { safeExtension, validateAndReadFile } from '../common/utils/file-validation.util';
 import type { MultipartRequest } from '../types/fastify.d';
-import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from './blog.constants';
 import { BlogService } from './blog.service';
-import { safeExtension } from './blog.utils';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { CreatePostDto } from './dto/create-post.dto';
 import { PostQueryDto, RecentQueryDto, SearchQueryDto, TagQueryDto } from './dto/post-query.dto';
@@ -164,26 +162,7 @@ export class BlogController {
   @ApiUnauthorized()
   @ApiBadRequest('No file provided or invalid file type')
   async uploadImage(@Req() request: MultipartRequest) {
-    const { buffer, mimeType } = await this.validateAndReadFile(request);
+    const { buffer, mimeType } = await validateAndReadFile(request);
     return this.blogService.uploadTempImage(buffer, `image${safeExtension(mimeType)}`, mimeType);
-  }
-
-  private async validateAndReadFile(request: MultipartRequest) {
-    const data = await request.file();
-    if (!data) throw new BadRequestException('No file provided');
-
-    const buffer = await data.toBuffer();
-
-    if (buffer.length > MAX_FILE_SIZE) {
-      throw new BadRequestException(`File too large (max ${MAX_FILE_SIZE / 1024 / 1024} MB)`);
-    }
-
-    const { fileTypeFromBuffer } = await import('file-type');
-    const detected = await fileTypeFromBuffer(buffer);
-    if (!detected || !ALLOWED_MIME_TYPES.has(detected.mime)) {
-      throw new BadRequestException('Only JPEG, PNG, WebP, GIF are allowed');
-    }
-
-    return { buffer, mimeType: detected.mime };
   }
 }

--- a/src/blog/blog.utils.ts
+++ b/src/blog/blog.utils.ts
@@ -23,19 +23,7 @@ export function generateSlug(title: string): string {
   return `${base}-${suffix}`;
 }
 
-const MIME_TO_EXT: Record<string, string> = {
-  'image/jpeg': '.jpg',
-  'image/png': '.png',
-  'image/webp': '.webp',
-  'image/gif': '.gif',
-};
-
-/**
- * MIME 타입에서 안전한 확장자 추출
- */
-export function safeExtension(mimeType: string): string {
-  return MIME_TO_EXT[mimeType] ?? '.bin';
-}
+export { safeExtension } from '../common/utils/file-validation.util';
 
 /**
  * content 앞부분에서 description 자동 추출

--- a/src/common/utils/file-validation.util.ts
+++ b/src/common/utils/file-validation.util.ts
@@ -1,0 +1,36 @@
+import { BadRequestException } from '@nestjs/common';
+import type { MultipartRequest } from '../../types/fastify.d';
+
+export const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
+
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+};
+
+export function safeExtension(mimeType: string): string {
+  return MIME_TO_EXT[mimeType] ?? '.bin';
+}
+
+export async function validateAndReadFile(request: MultipartRequest) {
+  const data = await request.file();
+  if (!data) throw new BadRequestException('No file provided');
+
+  const buffer = await data.toBuffer();
+
+  if (buffer.length > MAX_FILE_SIZE) {
+    throw new BadRequestException(`File too large (max ${MAX_FILE_SIZE / 1024 / 1024} MB)`);
+  }
+
+  const { fileTypeFromBuffer } = await import('file-type');
+  const detected = await fileTypeFromBuffer(buffer);
+  if (!detected || !ALLOWED_MIME_TYPES.has(detected.mime)) {
+    throw new BadRequestException('Only JPEG, PNG, WebP, GIF are allowed');
+  }
+
+  return { buffer, mimeType: detected.mime };
+}

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -10,8 +10,9 @@ import {
   Post,
   Put,
   Query,
+  Req,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiCookieAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiConsumes, ApiCookieAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { Public } from '../common/decorators/public.decorator';
 import {
   ApiBadRequest,
@@ -19,6 +20,8 @@ import {
   ApiNotFound,
   ApiUnauthorized,
 } from '../common/swagger/error-responses';
+import { safeExtension, validateAndReadFile } from '../common/utils/file-validation.util';
+import type { MultipartRequest } from '../types/fastify.d';
 import {
   CreateEducationDto,
   CreateExperienceDto,
@@ -64,6 +67,14 @@ export class PortfolioController {
 
   @Public()
   @ApiSecurity('api-key')
+  @Get('profile/all')
+  @ApiNotFound('Profile')
+  getProfileWithTranslations() {
+    return this.portfolioService.getProfileWithTranslations();
+  }
+
+  @Public()
+  @ApiSecurity('api-key')
   @Get('experiences')
   @ApiBadRequest('Unsupported locale')
   getExperiences(@Query(ValidateLocalePipe) query: LocaleQueryDto) {
@@ -91,6 +102,38 @@ export class PortfolioController {
   @ApiBadRequest('Unsupported locale')
   getWorks(@Query(ValidateLocalePipe) query: GetWorksQueryDto) {
     return this.portfolioService.getWorks(query.locale ?? 'ko', query.type);
+  }
+
+  @Public()
+  @ApiSecurity('api-key')
+  @Get('works/:id')
+  @ApiNotFound('Work')
+  getWorkById(@Param('id', ParseIntPipe) id: number) {
+    return this.portfolioService.getWorkById(id);
+  }
+
+  @Public()
+  @ApiSecurity('api-key')
+  @Get('experiences/:id')
+  @ApiNotFound('Experience')
+  getExperienceById(@Param('id', ParseIntPipe) id: number) {
+    return this.portfolioService.getExperienceById(id);
+  }
+
+  @Public()
+  @ApiSecurity('api-key')
+  @Get('projects/:id')
+  @ApiNotFound('Project')
+  getProjectById(@Param('id', ParseIntPipe) id: number) {
+    return this.portfolioService.getProjectById(id);
+  }
+
+  @Public()
+  @ApiSecurity('api-key')
+  @Get('education/:id')
+  @ApiNotFound('Education')
+  getEducationById(@Param('id', ParseIntPipe) id: number) {
+    return this.portfolioService.getEducationById(id);
   }
 
   @Public()
@@ -130,6 +173,36 @@ export class PortfolioController {
   @ApiUnauthorized()
   updateProfile(@Body() dto: UpdateProfileDto) {
     return this.portfolioService.updateProfile(dto);
+  }
+
+  @ApiBearerAuth()
+  @ApiCookieAuth()
+  @Post('profile/image')
+  @ApiConsumes('multipart/form-data')
+  @ApiUnauthorized()
+  @ApiBadRequest('No file provided or invalid file type')
+  async uploadProfileImage(@Req() request: MultipartRequest) {
+    const { buffer, mimeType } = await validateAndReadFile(request);
+    return this.portfolioService.uploadProfileImage(
+      buffer,
+      `image${safeExtension(mimeType)}`,
+      mimeType,
+    );
+  }
+
+  @ApiBearerAuth()
+  @ApiCookieAuth()
+  @Post('profile/icon')
+  @ApiConsumes('multipart/form-data')
+  @ApiUnauthorized()
+  @ApiBadRequest('No file provided or invalid file type')
+  async uploadProfileIcon(@Req() request: MultipartRequest) {
+    const { buffer, mimeType } = await validateAndReadFile(request);
+    return this.portfolioService.uploadProfileIcon(
+      buffer,
+      `icon${safeExtension(mimeType)}`,
+      mimeType,
+    );
   }
 
   @ApiBearerAuth()

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -171,6 +171,43 @@ export class PortfolioService {
     return this.getProfile(DEFAULT_LOCALE);
   }
 
+  async getProfileWithTranslations() {
+    const key = 'profile:all';
+    const cached = await this.cache.get(key);
+    if (cached) return cached;
+
+    const profile = await this.prisma.profile.findFirst({
+      orderBy: { id: 'asc' },
+      include: { translations: true },
+    });
+
+    if (!profile) throw new NotFoundException('Profile not found');
+
+    const result = {
+      name: profile.name,
+      location: profile.location,
+      imageUrl: profile.imageUrl,
+      iconUrl: profile.iconUrl,
+      socialLinks: profile.socialLinks,
+      translations: profile.translations.map(t => ({
+        locale: t.locale,
+        jobTitle: t.jobTitle,
+        introduction: t.introduction,
+      })),
+    };
+
+    await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
+    return result;
+  }
+
+  async uploadProfileImage(buffer: Buffer, filename: string, mimeType: string) {
+    return { url: await this.storage.upload(buffer, filename, mimeType, 'profile/image') };
+  }
+
+  async uploadProfileIcon(buffer: Buffer, filename: string, mimeType: string) {
+    return { url: await this.storage.upload(buffer, filename, mimeType, 'profile/icon') };
+  }
+
   // ─── Experiences ────────────────────────────────────────────────────────────
 
   async getExperiences(locale: string) {
@@ -198,6 +235,15 @@ export class PortfolioService {
 
     await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
     return result;
+  }
+
+  async getExperienceById(id: number) {
+    const experience = await this.prisma.experience.findUnique({
+      where: { id },
+      include: { translations: true },
+    });
+    if (!experience) throw new NotFoundException('Experience not found');
+    return experience;
   }
 
   async createExperience(dto: CreateExperienceDto) {
@@ -298,6 +344,15 @@ export class PortfolioService {
 
     await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
     return result;
+  }
+
+  async getProjectById(id: number) {
+    const project = await this.prisma.project.findUnique({
+      where: { id },
+      include: { translations: true },
+    });
+    if (!project) throw new NotFoundException('Project not found');
+    return project;
   }
 
   async createProject(dto: CreateProjectDto) {
@@ -406,6 +461,20 @@ export class PortfolioService {
 
     await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
     return result;
+  }
+
+  async getWorkById(id: number) {
+    const work = await this.prisma.work.findUnique({
+      where: { id },
+      include: { translations: true },
+    });
+    if (!work) throw new NotFoundException('Work not found');
+
+    const t = work.translations.find(tr => tr.locale === DEFAULT_LOCALE) ?? work.translations[0];
+    return {
+      ...work,
+      gradientColors: generateGradientColors(t?.title ?? '', work.featured),
+    };
   }
 
   async createWork(dto: CreateWorkDto) {
@@ -597,6 +666,15 @@ export class PortfolioService {
 
     await this.cache.set(key, result, PORTFOLIO_CACHE_TTL);
     return result;
+  }
+
+  async getEducationById(id: number) {
+    const education = await this.prisma.education.findUnique({
+      where: { id },
+      include: { translations: true },
+    });
+    if (!education) throw new NotFoundException('Education not found');
+    return education;
   }
 
   async createEducation(dto: CreateEducationDto) {

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -574,11 +574,12 @@ export class PortfolioService {
 
     const grouped: Record<
       string,
-      { name: string; proficiency: number; description: string | null }[]
+      { id: number; name: string; proficiency: number; description: string | null }[]
     > = {};
     for (const skill of skills) {
       if (!grouped[skill.category]) grouped[skill.category] = [];
       grouped[skill.category].push({
+        id: skill.id,
         name: skill.name,
         proficiency: skill.proficiency,
         description: skill.description,


### PR DESCRIPTION
## Summary

### 새 공개 API
- `GET /api/portfolio/works/:id` — Work 상세 (translations 전체 + gradientColors)
- `GET /api/portfolio/experiences/:id` — Experience 상세 (translations 전체)
- `GET /api/portfolio/projects/:id` — Project 상세 (translations 전체)
- `GET /api/portfolio/education/:id` — Education 상세 (translations 전체)
- `GET /api/portfolio/profile/all` — Profile + translations 전체 (locale 파라미터 불필요)

### 어드민 API
- `POST /api/portfolio/profile/image` — 프로필 이미지 업로드 (R2 `profile/image/`)
- `POST /api/portfolio/profile/icon` — 프로필 아이콘 업로드 (R2 `profile/icon/`)

### 리팩토링
- `validateAndReadFile`을 `src/common/utils/file-validation.util.ts`로 추출
- blog/portfolio 양쪽 컨트롤러에서 공유 함수 사용
- `ALLOWED_MIME_TYPES`, `MAX_FILE_SIZE`, `safeExtension`도 common으로 이동
- `getWorkById` gradient 색상을 `DEFAULT_LOCALE` 기준으로 결정 (비결정적 → 결정적)
- profile locale 검증을 ValidateLocalePipe로 유지, translations 전체는 별도 엔드포인트(`/profile/all`)로 분리

## Test plan
- [ ] `pnpm exec tsc --noEmit` 통과
- [ ] `pnpm lint` 통과
- [ ] GET /works/:id translations 배열 포함 확인
- [ ] GET /profile/all translations 전체 반환 확인
- [ ] POST /profile/image 파일 업로드 후 URL 반환 확인
- [ ] 기존 blog 이미지 업로드 정상 동작 확인