### PR TITLE
feat: Contact 메시지 API + rate limit

### DIFF
--- a/prisma/migrations/20260322140756_add_contact_messages/migration.sql
+++ b/prisma/migrations/20260322140756_add_contact_messages/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "portfolio"."contact_messages" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "email" VARCHAR(300) NOT NULL,
+    "subject" VARCHAR(200),
+    "message" TEXT NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "contact_messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "contact_messages_created_at_idx" ON "portfolio"."contact_messages"("created_at" DESC);
+
+-- CreateIndex
+CREATE INDEX "contact_messages_read_idx" ON "portfolio"."contact_messages"("read");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -244,6 +244,21 @@ model EducationTranslation {
   @@schema("portfolio")
 }
 
+model ContactMessage {
+  id        Int      @id @default(autoincrement())
+  name      String   @db.VarChar(100)
+  email     String   @db.VarChar(300)
+  subject   String?  @db.VarChar(200)
+  message   String   @db.Text
+  read      Boolean  @default(false)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@index([createdAt(sort: Desc)])
+  @@index([read])
+  @@map("contact_messages")
+  @@schema("portfolio")
+}
+
 // ─── Analytics ──────────────────────────────────────────────────────────────
 
 model PageView {

--- a/src/portfolio/dto/create-contact.dto.ts
+++ b/src/portfolio/dto/create-contact.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateContactDto {
+  @ApiProperty({ example: 'John Doe' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({ example: 'john@example.com' })
+  @IsEmail()
+  @IsNotEmpty()
+  @MaxLength(300)
+  email: string;
+
+  @ApiPropertyOptional({ example: 'Collaboration Inquiry' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  subject?: string;
+
+  @ApiProperty({ example: 'Hello, I would like to discuss...' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  message: string;
+}

--- a/src/portfolio/dto/index.ts
+++ b/src/portfolio/dto/index.ts
@@ -1,3 +1,4 @@
+export { CreateContactDto } from './create-contact.dto';
 export { CreateEducationDto } from './create-education.dto';
 export { CreateExperienceDto } from './create-experience.dto';
 export { CreateLocaleDto } from './create-locale.dto';

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -13,6 +13,7 @@ import {
   Req,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiConsumes, ApiCookieAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { Public } from '../common/decorators/public.decorator';
 import {
   ApiBadRequest,
@@ -23,6 +24,7 @@ import {
 import { safeExtension, validateAndReadFile } from '../common/utils/file-validation.util';
 import type { MultipartRequest } from '../types/fastify.d';
 import {
+  CreateContactDto,
   CreateEducationDto,
   CreateExperienceDto,
   CreateLocaleDto,
@@ -348,5 +350,44 @@ export class PortfolioController {
   @ApiNotFound('Work')
   deleteWork(@Param('id', ParseIntPipe) id: number) {
     return this.portfolioService.deleteWork(id);
+  }
+
+  // ─── Contact ───────────────────────────────────────────────────────────────
+
+  @Public()
+  @ApiSecurity('api-key')
+  @Post('contact')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { ttl: 60_000, limit: 3 } })
+  @ApiBadRequest()
+  createContact(@Body() dto: CreateContactDto) {
+    return this.portfolioService.createContact(dto);
+  }
+
+  @ApiBearerAuth()
+  @ApiCookieAuth()
+  @Get('contacts')
+  @ApiUnauthorized()
+  getContacts(@Query('limit') limit?: string) {
+    return this.portfolioService.getContacts(limit ? Number.parseInt(limit, 10) : undefined);
+  }
+
+  @ApiBearerAuth()
+  @ApiCookieAuth()
+  @Put('contacts/:id/read')
+  @ApiUnauthorized()
+  @ApiNotFound('Contact message')
+  markContactRead(@Param('id', ParseIntPipe) id: number) {
+    return this.portfolioService.markContactRead(id);
+  }
+
+  @ApiBearerAuth()
+  @ApiCookieAuth()
+  @Delete('contacts/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiUnauthorized()
+  @ApiNotFound('Contact message')
+  deleteContact(@Param('id', ParseIntPipe) id: number) {
+    return this.portfolioService.deleteContact(id);
   }
 }

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -6,6 +6,7 @@ import { RevalidationService } from '../revalidation/revalidation.service';
 import { StorageService } from '../storage/storage.service';
 import { type CacheStore, NamespacedCache } from '../types/cache-store';
 import type {
+  CreateContactDto,
   CreateEducationDto,
   CreateExperienceDto,
   CreateLocaleDto,
@@ -739,6 +740,46 @@ export class PortfolioService {
         .catch(err => this.logger.warn('revalidation failed', err));
     } catch (error) {
       this.handleNotFound(error, 'Education');
+    }
+  }
+
+  // ─── Contact ───────────────────────────────────────────────────────────────
+
+  async createContact(dto: CreateContactDto) {
+    await this.prisma.contactMessage.create({
+      data: {
+        name: dto.name,
+        email: dto.email,
+        subject: dto.subject ?? null,
+        message: dto.message,
+      },
+    });
+    return { success: true, message: 'Message sent successfully' };
+  }
+
+  async getContacts(limit = 20) {
+    return this.prisma.contactMessage.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: Math.min(Math.max(1, limit), 100),
+    });
+  }
+
+  async markContactRead(id: number) {
+    try {
+      return await this.prisma.contactMessage.update({
+        where: { id },
+        data: { read: true },
+      });
+    } catch (error) {
+      this.handleNotFound(error, 'Contact message');
+    }
+  }
+
+  async deleteContact(id: number): Promise<void> {
+    try {
+      await this.prisma.contactMessage.delete({ where: { id } });
+    } catch (error) {
+      this.handleNotFound(error, 'Contact message');
     }
   }
 }


### PR DESCRIPTION
## Summary
포트폴리오 Contact Form용 메시지 API 추가

### 공개 API
- `POST /api/portfolio/contact` — 메시지 전송 (분당 3회 rate limit)
  - name (필수, 1~100자), email (필수, 이메일 형식), subject (선택, ~200자), message (필수, 1~2000자)
  - 응답: `{ "success": true, "message": "Message sent successfully" }`

### 어드민 API
- `GET /api/portfolio/contacts?limit=20` — 메시지 목록 (최신순)
- `PUT /api/portfolio/contacts/:id/read` — 읽음 처리
- `DELETE /api/portfolio/contacts/:id` — 삭제

### DB
- `portfolio.contact_messages` 테이블 (name, email, subject, message, read, created_at)
- `read` 인덱스 + `created_at DESC` 인덱스

### Rate Limit
- `@Throttle({ default: { ttl: 60_000, limit: 3 } })` — contact 엔드포인트만 분당 3회 제한
- 글로벌 rate limit (100req/60s)와 별도 적용

## Test plan
- [ ] `pnpm exec tsc --noEmit` 통과
- [ ] `pnpm lint` 통과
- [ ] POST /contact 정상 저장 확인
- [ ] POST /contact 4번째 요청 시 429 확인
- [ ] GET /contacts 목록 조회 확인
- [ ] PUT /contacts/:id/read 읽음 처리 확인