### PR TITLE
fix: Contact API 코드리뷰 수정

### DIFF
--- a/src/common/http.module.ts
+++ b/src/common/http.module.ts
@@ -10,10 +10,10 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
 @Module({
   providers: [
     { provide: APP_FILTER, useClass: HttpExceptionFilter },
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
     { provide: APP_GUARD, useClass: ApiKeyGuard },
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: AdminIpGuard },
-    { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],
 })
 export class HttpModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,
-    new FastifyAdapter({ logger: process.env.NODE_ENV !== 'production' }),
+    new FastifyAdapter({ logger: process.env.NODE_ENV !== 'production', trustProxy: true }),
   );
 
   await app.register(import('@fastify/cookie'));

--- a/src/portfolio/dto/create-contact.dto.ts
+++ b/src/portfolio/dto/create-contact.dto.ts
@@ -1,14 +1,17 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsEmail, IsNotEmpty, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class CreateContactDto {
   @ApiProperty({ example: 'John Doe' })
   @IsString()
   @IsNotEmpty()
+  @MinLength(2)
   @MaxLength(100)
   name: string;
 
   @ApiProperty({ example: 'john@example.com' })
+  @Transform(({ value }) => (typeof value === 'string' ? value.toLowerCase().trim() : value))
   @IsEmail()
   @IsNotEmpty()
   @MaxLength(300)
@@ -23,6 +26,7 @@ export class CreateContactDto {
   @ApiProperty({ example: 'Hello, I would like to discuss...' })
   @IsString()
   @IsNotEmpty()
+  @MinLength(10)
   @MaxLength(2000)
   message: string;
 }

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -368,8 +368,8 @@ export class PortfolioController {
   @ApiCookieAuth()
   @Get('contacts')
   @ApiUnauthorized()
-  getContacts(@Query('limit') limit?: string) {
-    return this.portfolioService.getContacts(limit ? Number.parseInt(limit, 10) : undefined);
+  getContacts(@Query('limit', new ParseIntPipe({ optional: true })) limit?: number) {
+    return this.portfolioService.getContacts(limit);
   }
 
   @ApiBearerAuth()

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -1,5 +1,12 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { ConflictException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { RevalidationService } from '../revalidation/revalidation.service';
@@ -746,15 +753,20 @@ export class PortfolioService {
   // ─── Contact ───────────────────────────────────────────────────────────────
 
   async createContact(dto: CreateContactDto) {
-    await this.prisma.contactMessage.create({
-      data: {
-        name: dto.name,
-        email: dto.email,
-        subject: dto.subject ?? null,
-        message: dto.message,
-      },
-    });
-    return { success: true, message: 'Message sent successfully' };
+    try {
+      await this.prisma.contactMessage.create({
+        data: {
+          name: dto.name,
+          email: dto.email,
+          subject: dto.subject ?? null,
+          message: dto.message,
+        },
+      });
+      return { success: true, message: 'Message sent successfully' };
+    } catch (error) {
+      this.logger.error('Failed to save contact message', error);
+      throw new InternalServerErrorException('Failed to send message');
+    }
   }
 
   async getContacts(limit = 20) {


### PR DESCRIPTION
## Summary
Contact API 코드리뷰 이슈 6건 수정

- **HIGH**: Fastify `trustProxy: true` 활성화 — 리버스 프록시 뒤에서 실제 클라이언트 IP 추출
- **MEDIUM**: `ThrottlerGuard`를 가드 체인 맨 앞으로 이동 — rate limit이 다른 가드보다 먼저 실행
- **MEDIUM**: `getContacts` limit 파라미터에 `ParseIntPipe` 적용 — NaN이 Prisma에 전달되는 것 방지
- **MEDIUM**: `createContact` DB 에러 시 `InternalServerErrorException` + 로깅
- **LOW**: name `@MinLength(2)`, message `@MinLength(10)` 추가
- **LOW**: email `@Transform` 소문자 정규화

## Test plan
- [ ] `pnpm exec tsc --noEmit` 통과
- [ ] `pnpm lint` 통과
- [ ] POST /contact 정상 동작
- [ ] POST /contact 4번째 요청 시 429 확인
- [ ] GET /contacts?limit=abc 시 400 반환 확인