### PR TITLE
fix: 코드리뷰 지적사항 수정 + 어드민 미발행 조회

### DIFF
--- a/src/analytics/analytics.constants.ts
+++ b/src/analytics/analytics.constants.ts
@@ -1,0 +1,1 @@
+export const VALID_APP_NAMES = new Set(['blog', 'portfolio', 'admin']);

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -14,21 +14,9 @@ import type { FastifyRequest } from 'fastify';
 import { Public } from '../common/decorators/public.decorator';
 import { AdminLogService } from './admin-log.service';
 import { AnalyticsService } from './analytics.service';
+import { safeAppName, safeInt } from './analytics.utils';
 import { TrackPageViewDto } from './dto/track-pageview.dto';
 import { PageViewService } from './page-view.service';
-
-const VALID_APP_NAMES = new Set(['blog', 'portfolio', 'admin']);
-
-function safeInt(value?: string): number | undefined {
-  if (!value) return undefined;
-  const n = Number.parseInt(value, 10);
-  return Number.isNaN(n) ? undefined : n;
-}
-
-function safeAppName(value?: string): string | undefined {
-  if (!value) return undefined;
-  return VALID_APP_NAMES.has(value) ? value : undefined;
-}
 
 @ApiTags('analytics')
 @Controller('api/analytics')

--- a/src/analytics/analytics.utils.ts
+++ b/src/analytics/analytics.utils.ts
@@ -1,0 +1,12 @@
+import { VALID_APP_NAMES } from './analytics.constants';
+
+export function safeInt(value?: string): number | undefined {
+  if (!value) return undefined;
+  const n = Number.parseInt(value, 10);
+  return Number.isNaN(n) ? undefined : n;
+}
+
+export function safeAppName(value?: string): string | undefined {
+  if (!value) return undefined;
+  return VALID_APP_NAMES.has(value) ? value : undefined;
+}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -36,8 +36,11 @@ export class AuthService {
     const adminUsername = this.config.getOrThrow<string>('ADMIN_USERNAME');
     const adminPasswordHash = this.config.getOrThrow<string>('ADMIN_PASSWORD_HASH');
 
+    if (username !== adminUsername) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
     const isValid = await bcrypt.compare(password, adminPasswordHash);
-    if (!isValid || username !== adminUsername) {
+    if (!isValid) {
       throw new UnauthorizedException('Invalid credentials');
     }
 
@@ -270,6 +273,16 @@ export class AuthService {
     this.previewTokens.set(token, Date.now() + AuthService.PREVIEW_TOKEN_TTL);
 
     return { token, expiresIn: 1800 };
+  }
+
+  isAuthenticated(token?: string): boolean {
+    if (!token) return false;
+    try {
+      this.jwtService.verify(token);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   verifyPreviewToken(token: string): boolean {

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -49,8 +49,9 @@ export class BlogController {
   @Public()
   @ApiSecurity('api-key')
   @Get('posts')
-  findAll(@Query() query: PostQueryDto) {
-    return this.blogService.findAll(query);
+  findAll(@Query() query: PostQueryDto, @Req() req: MultipartRequest) {
+    const isAdmin = this.authService.isAuthenticated(req.cookies?.access_token);
+    return this.blogService.findAll(query, isAdmin);
   }
 
   @Public()
@@ -101,8 +102,9 @@ export class BlogController {
   @ApiSecurity('api-key')
   @Get('posts/:slug')
   @ApiNotFound('Post')
-  findOne(@Param('slug') slug: string) {
-    return this.blogService.findBySlug(slug);
+  findOne(@Param('slug') slug: string, @Req() req: MultipartRequest) {
+    const isAdmin = this.authService.isAuthenticated(req.cookies?.access_token);
+    return this.blogService.findBySlug(slug, isAdmin);
   }
 
   @Public()

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -45,15 +45,15 @@ export class BlogService {
 
   // ─── Read ─────────────────────────────────────────────────────────────────
 
-  async findAll(query: PostQueryDto) {
+  async findAll(query: PostQueryDto, isAdmin = false) {
     const { page = 1, limit = 10, category, tag } = query;
-    const key = `posts:${page}:${limit}:${category ?? ''}:${tag ?? ''}`;
+    const key = `posts:${page}:${limit}:${category ?? ''}:${tag ?? ''}:${isAdmin}`;
     const cached = await this.cache.get(key);
     if (cached) return cached;
 
     const skip = (page - 1) * limit;
     const where = {
-      published: true,
+      ...(isAdmin ? {} : { published: true }),
       ...(category && { category }),
       ...(tag && { postTags: { some: { tag: { slug: tag } } } }),
     };

--- a/src/blog/blog.utils.ts
+++ b/src/blog/blog.utils.ts
@@ -18,7 +18,6 @@ export function generateSlug(title: string): string {
   return base ? `${base}-${suffix}` : suffix;
 }
 
-
 const KOREAN_CHARS_PER_MINUTE = 500;
 
 function stripMarkdown(content: string): string {

--- a/src/blog/blog.utils.ts
+++ b/src/blog/blog.utils.ts
@@ -8,7 +8,7 @@ export function generateSlug(title: string): string {
   const base = title
     .toLowerCase()
     .trim()
-    .replace(/[^\w\s가-힣-]/g, '')
+    .replace(/[^\w\s가-힣ㄱ-ㅎㅏ-ㅣ-]/g, '')
     .replace(/[\s_]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '')
@@ -18,7 +18,6 @@ export function generateSlug(title: string): string {
   return base ? `${base}-${suffix}` : suffix;
 }
 
-export { safeExtension } from '../common/utils/file-validation.util';
 
 const KOREAN_CHARS_PER_MINUTE = 500;
 

--- a/src/blog/dto/create-post.dto.ts
+++ b/src/blog/dto/create-post.dto.ts
@@ -38,7 +38,7 @@ export class CreatePostDto {
   @ApiPropertyOptional({ description: '이미지 업로드 API에서 받은 URL' })
   @IsOptional()
   @IsString()
-  @Matches(/^https?:\/\//, { message: 'thumbnailUrl must be a valid HTTP URL' })
+  @Matches(/^https:\/\/assets\.chahyunwoo\.dev\//, { message: 'thumbnailUrl must be from assets.chahyunwoo.dev' })
   thumbnailUrl?: string;
 
   @ApiPropertyOptional({ default: false })

--- a/src/blog/dto/create-post.dto.ts
+++ b/src/blog/dto/create-post.dto.ts
@@ -38,7 +38,9 @@ export class CreatePostDto {
   @ApiPropertyOptional({ description: '이미지 업로드 API에서 받은 URL' })
   @IsOptional()
   @IsString()
-  @Matches(/^https:\/\/assets\.chahyunwoo\.dev\//, { message: 'thumbnailUrl must be from assets.chahyunwoo.dev' })
+  @Matches(/^https:\/\/assets\.chahyunwoo\.dev\//, {
+    message: 'thumbnailUrl must be from assets.chahyunwoo.dev',
+  })
   thumbnailUrl?: string;
 
   @ApiPropertyOptional({ default: false })

--- a/src/blog/dto/post-query.dto.ts
+++ b/src/blog/dto/post-query.dto.ts
@@ -1,4 +1,4 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, IsNotEmpty, IsOptional, IsString, Max, Min, MinLength } from 'class-validator';
 
@@ -50,7 +50,7 @@ export class TagQueryDto {
 }
 
 export class SearchQueryDto {
-  @ApiPropertyOptional({ description: 'Search keyword' })
+  @ApiProperty({ description: 'Search keyword' })
   @IsString()
   @IsNotEmpty()
   @MinLength(2)

--- a/src/portfolio/dto/create-work.dto.ts
+++ b/src/portfolio/dto/create-work.dto.ts
@@ -6,7 +6,6 @@ import {
   IsBoolean,
   IsIn,
   IsInt,
-  IsNotEmpty,
   IsOptional,
   IsString,
   IsUrl,
@@ -14,38 +13,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 
-class WorkTranslationDto {
-  @ApiProperty()
-  @IsString()
-  locale: string;
-
-  @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
-  title: string;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
-  @IsNotEmpty()
-  role?: string;
-
-  @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
-  summary: string;
-
-  @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
-  content: string;
-
-  @ApiPropertyOptional({ type: [String] })
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  highlights?: string[] = [];
-}
+import { WorkTranslationDto } from './work-translation.dto';
 
 export class CreateWorkDto {
   @ApiProperty({ enum: ['business', 'personal'] })

--- a/src/portfolio/dto/work-translation.dto.ts
+++ b/src/portfolio/dto/work-translation.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class WorkTranslationDto {
+  @ApiProperty()
+  @IsString()
+  locale: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  role?: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  summary: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  highlights?: string[] = [];
+}


### PR DESCRIPTION
## Summary
- login username 비교를 bcrypt 전으로 이동 (불필요한 해시 연산 방지)
- thumbnailUrl 도메인을 assets.chahyunwoo.dev로 제한 (SSRF 방지)
- blog.utils.ts의 cross-domain re-export 제거
- SearchQueryDto q 필드 @ApiPropertyOptional → @ApiProperty 수정
- WorkTranslationDto 별도 파일 분리
- analytics 유틸/상수를 컨트롤러에서 분리
- 어드민 JWT 인증 시 미발행 포스트 리스트/상세 조회 허용
- 한글 자모(ㄱ-ㅎ, ㅏ-ㅣ) slug 허용

## Test plan
- [ ] 로그인 정상 동작 확인
- [ ] 어드민 로그인 상태에서 미발행 포스트 리스트/상세 조회
- [ ] 비로그인 상태에서 미발행 포스트 미노출
- [ ] 한글 자모 제목 포스트 생성 확인
- [ ] thumbnailUrl에 외부 URL 입력 시 400 반환