### PR TITLE
feat: 슬러그 nanoid 방식 + 썸네일 경로 랜덤화

### DIFF
--- a/scripts/migrate-slugs.ts
+++ b/scripts/migrate-slugs.ts
@@ -1,0 +1,55 @@
+/**
+ * 한국어 슬러그를 nanoid 스타일 랜덤 슬러그로 마이그레이션
+ *
+ * Usage: npx tsx scripts/migrate-slugs.ts
+ */
+import 'dotenv/config';
+import { randomBytes } from 'node:crypto';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@prisma/client';
+
+function getEnvOrThrow(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`${key} is not defined`);
+  return value;
+}
+
+function generateSlug(): string {
+  return randomBytes(8).toString('base64url').slice(0, 10);
+}
+
+async function main() {
+  const adapter = new PrismaPg({ connectionString: getEnvOrThrow('DATABASE_URL') });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    const posts = await prisma.post.findMany({
+      select: { id: true, slug: true, title: true },
+    });
+
+    const koreanPosts = posts.filter((p) => /[가-힣ㄱ-ㅎㅏ-ㅣ]/.test(p.slug));
+
+    if (koreanPosts.length === 0) {
+      console.log('No Korean slugs found. Nothing to migrate.');
+      return;
+    }
+
+    console.log(`Found ${koreanPosts.length} posts with Korean slugs:\n`);
+
+    for (const post of koreanPosts) {
+      const newSlug = generateSlug();
+      await prisma.post.update({
+        where: { id: post.id },
+        data: { slug: newSlug },
+      });
+      console.log(`  [${post.id}] "${post.title}"`);
+      console.log(`    ${post.slug} → ${newSlug}\n`);
+    }
+
+    console.log(`Migrated ${koreanPosts.length} slugs.`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch(console.error);

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -386,7 +386,7 @@ export class BlogService {
   // ─── Write ────────────────────────────────────────────────────────────────
 
   async create(dto: CreatePostDto) {
-    const slug = generateSlug(dto.title);
+    const slug = generateSlug();
     const description = dto.description || extractDescription(dto.content);
 
     try {
@@ -547,7 +547,7 @@ export class BlogService {
   /**
    * content + thumbnailUrl에서 temp URL을 찾아서 확정 경로로 이동
    * blog/temp/xxx.png → blog/posts/{slug}/xxx.png
-   * blog/temp/xxx.jpg (thumbnail) → blog/thumbnails/{slug}.ext
+   * blog/temp/xxx.jpg (thumbnail) → blog/thumbnails/{nanoid}.ext
    */
   private async finalizeImages(slug: string, content: string, thumbnailUrl?: string | null) {
     const publicUrl = this.storage.getPublicUrl();
@@ -566,11 +566,11 @@ export class BlogService {
       finalContent = finalContent.replace(tempUrl, newUrl);
     }
 
-    // 썸네일 temp → 확정 경로
+    // 썸네일 temp → 확정 경로 (랜덤 ID로 저장)
     let finalThumbnail = thumbnailUrl;
     if (thumbnailUrl?.startsWith(tempPrefix)) {
       const ext = thumbnailUrl.slice(thumbnailUrl.lastIndexOf('.'));
-      const destKey = `blog/thumbnails/${slug}${ext}`;
+      const destKey = `blog/thumbnails/${generateSlug()}${ext}`;
       finalThumbnail = await this.storage.move(thumbnailUrl, destKey);
     }
 

--- a/src/blog/blog.utils.ts
+++ b/src/blog/blog.utils.ts
@@ -1,21 +1,10 @@
 import { randomBytes } from 'node:crypto';
 
 /**
- * 제목에서 URL-safe slug 생성
- * 한글/영문/숫자 허용, 중복 방지 suffix 추가
+ * nanoid 스타일 URL-safe slug 생성 (10자)
  */
-export function generateSlug(title: string): string {
-  const base = title
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s가-힣ㄱ-ㅎㅏ-ㅣ-]/g, '')
-    .replace(/[\s_]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 80);
-
-  const suffix = randomBytes(2).toString('hex');
-  return base ? `${base}-${suffix}` : suffix;
+export function generateSlug(): string {
+  return randomBytes(8).toString('base64url').slice(0, 10);
 }
 
 const KOREAN_CHARS_PER_MINUTE = 500;


### PR DESCRIPTION
## Summary
- 포스트 슬러그를 한국어 title 기반에서 randomBytes 10자 랜덤 ID로 변경
- R2 썸네일 경로를 slug 기반에서 랜덤 ID로 변경
- 기존 한국어 슬러그 마이그레이션 스크립트 추가

## Test plan
- [ ] 새 포스트 생성 시 랜덤 슬러그 생성 확인
- [ ] 썸네일 업로드 시 랜덤 파일명 확인
- [ ] 프로덕션 마이그레이션 스크립트 실행