### PR TITLE
fix: description DTO 주석 수정

### DIFF
--- a/src/blog/dto/create-post.dto.ts
+++ b/src/blog/dto/create-post.dto.ts
@@ -17,7 +17,7 @@ export class CreatePostDto {
   @MaxLength(500)
   title: string;
 
-  @ApiPropertyOptional({ description: '미입력 시 제목에서 자동 생성' })
+  @ApiPropertyOptional({ description: '미입력 시 content에서 자동 추출' })
   @IsOptional()
   @IsString()
   @MaxLength(200)


### PR DESCRIPTION
## Summary
- description 필드 Swagger 주석을 '미입력 시 제목에서 자동 생성' → '미입력 시 content에서 자동 추출'로 수정

## Test plan
- [ ] Swagger docs에서 description 설명 확인