### PR TITLE
feat: analytics 개선 - geolocation, visitors timeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,9 @@ SMTP_USER=your@gmail.com
 SMTP_PASS=xxxx xxxx xxxx xxxx
 ADMIN_EMAIL=your@gmail.com
 
+# Analytics (comma-separated IPs to exclude from stats, e.g., your own IP)
+ANALYTICS_EXCLUDE_IPS=
+
 # Cookie domain (for cross-subdomain auth, e.g., .chahyunwoo.dev)
 COOKIE_DOMAIN=
 

--- a/prisma/migrations/20260324105724_add_geolocation_to_pageviews/migration.sql
+++ b/prisma/migrations/20260324105724_add_geolocation_to_pageviews/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "analytics"."page_views" ADD COLUMN     "city" VARCHAR(100),
+ADD COLUMN     "country" VARCHAR(10),
+ADD COLUMN     "is_bot" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "page_views_ip_address_idx" ON "analytics"."page_views"("ip_address");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -279,11 +279,15 @@ model PageView {
   referrer  String?  @db.VarChar(1000)
   userAgent String?  @map("user_agent") @db.VarChar(1000)
   ipAddress String?  @map("ip_address") @db.VarChar(45)
+  city      String?  @db.VarChar(100)
+  country   String?  @db.VarChar(10)
+  isBot     Boolean  @default(false) @map("is_bot")
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
 
   @@index([appName, createdAt(sort: Desc)])
   @@index([path])
   @@index([createdAt(sort: Desc)])
+  @@index([ipAddress])
   @@map("page_views")
   @@schema("analytics")
 }

--- a/scripts/backfill-geolocation.ts
+++ b/scripts/backfill-geolocation.ts
@@ -1,0 +1,60 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+interface IpApiResponse {
+  status: string;
+  city?: string;
+  regionName?: string;
+  countryCode?: string;
+}
+
+async function lookup(ip: string): Promise<{ city: string | null; country: string | null }> {
+  try {
+    const res = await fetch(`http://ip-api.com/json/${ip}?fields=status,city,regionName,countryCode`);
+    const data = (await res.json()) as IpApiResponse;
+    if (data.status !== 'success') return { city: null, country: null };
+    return {
+      city: data.regionName && data.city ? `${data.city}, ${data.regionName}` : (data.city ?? null),
+      country: data.countryCode ?? null,
+    };
+  } catch {
+    return { city: null, country: null };
+  }
+}
+
+async function main() {
+  const views = await prisma.pageView.findMany({
+    where: { city: null, ipAddress: { not: null } },
+    select: { id: true, ipAddress: true },
+  });
+
+  const uniqueIps = [...new Set(views.map(v => v.ipAddress).filter(Boolean))] as string[];
+  console.log(`Found ${views.length} views with ${uniqueIps.length} unique IPs to backfill`);
+
+  const geoCache = new Map<string, { city: string | null; country: string | null }>();
+
+  for (const ip of uniqueIps) {
+    const geo = await lookup(ip);
+    geoCache.set(ip, geo);
+    console.log(`  ${ip} → ${geo.city ?? 'unknown'}, ${geo.country ?? 'unknown'}`);
+    await new Promise(r => setTimeout(r, 1400)); // ip-api.com free tier: 45/min
+  }
+
+  let updated = 0;
+  for (const view of views) {
+    const geo = view.ipAddress ? geoCache.get(view.ipAddress) : null;
+    if (geo && (geo.city || geo.country)) {
+      await prisma.pageView.update({
+        where: { id: view.id },
+        data: { city: geo.city, country: geo.country },
+      });
+      updated++;
+    }
+  }
+
+  console.log(`\nBackfill complete: ${updated}/${views.length} views updated`);
+  await prisma.$disconnect();
+}
+
+main().catch(console.error);

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -59,8 +59,8 @@ export class AnalyticsController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('popular-posts')
-  getPopularPosts(@Query('limit') limit?: string) {
-    return this.analytics.getPopularPosts(safeInt(limit));
+  getPopularPosts(@Query('limit') limit?: string, @Query('days') days?: string) {
+    return this.analytics.getPopularPosts(safeInt(limit), safeInt(days));
   }
 
   @ApiBearerAuth()
@@ -68,6 +68,13 @@ export class AnalyticsController {
   @Get('visitors')
   getVisitors(@Query('days') days?: string, @Query('app') app?: string) {
     return this.analytics.getVisitorStats(safeInt(days), safeAppName(app));
+  }
+
+  @ApiBearerAuth()
+  @ApiCookieAuth()
+  @Get('visitors/timeline')
+  getVisitorsTimeline(@Query('days') days?: string, @Query('app') app?: string) {
+    return this.analytics.getVisitorsTimeline(safeInt(days), safeAppName(app));
   }
 
   @ApiBearerAuth()

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -2,12 +2,13 @@ import { Global, Module } from '@nestjs/common';
 import { AdminLogService } from './admin-log.service';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
+import { GeolocationService } from './geolocation.service';
 import { PageViewService } from './page-view.service';
 
 @Global()
 @Module({
   controllers: [AnalyticsController],
-  providers: [AnalyticsService, PageViewService, AdminLogService],
+  providers: [AnalyticsService, PageViewService, AdminLogService, GeolocationService],
   exports: [PageViewService, AdminLogService],
 })
 export class AnalyticsModule {}

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -1,20 +1,74 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 const MAX_DAYS = 365;
 const MAX_LIMIT = 100;
 
+const SEARCH_DOMAINS = new Set([
+  'google.com',
+  'bing.com',
+  'yahoo.com',
+  'duckduckgo.com',
+  'naver.com',
+  'daum.net',
+  'baidu.com',
+  'yandex.com',
+]);
+const SOCIAL_DOMAINS = new Set([
+  'twitter.com',
+  'x.com',
+  'facebook.com',
+  'instagram.com',
+  'linkedin.com',
+  'reddit.com',
+  'threads.net',
+  'github.com',
+]);
+
 function clamp(value: number | undefined, defaultVal: number, max: number): number {
   const v = value ?? defaultVal;
   return Math.min(Math.max(1, v), max);
 }
 
+function extractDomain(url: string): string {
+  try {
+    const hostname = new URL(url).hostname;
+    return hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}
+
+function categorizeReferrer(domain: string): string {
+  if (SEARCH_DOMAINS.has(domain)) return 'search';
+  if (SOCIAL_DOMAINS.has(domain)) return 'social';
+  return 'other';
+}
+
 @Injectable()
 export class AnalyticsService {
   private readonly startTime = Date.now();
+  private readonly excludeIps: Set<string>;
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {
+    const raw = this.config.get<string>('ANALYTICS_EXCLUDE_IPS', '');
+    this.excludeIps = new Set(
+      raw
+        .split(',')
+        .map(ip => ip.trim())
+        .filter(Boolean),
+    );
+  }
+
+  private get ipFilter(): Prisma.PageViewWhereInput {
+    if (this.excludeIps.size === 0) return {};
+    return { ipAddress: { notIn: [...this.excludeIps] } };
+  }
 
   // ─── Dashboard Stats ──────────────────────────────────────────────────────
 
@@ -67,13 +121,53 @@ export class AnalyticsService {
 
   // ─── Popular Posts ────────────────────────────────────────────────────────
 
-  async getPopularPosts(limit?: number) {
-    return this.prisma.post.findMany({
-      where: { published: true },
-      select: { slug: true, title: true, category: true, viewCount: true, createdAt: true },
-      orderBy: { viewCount: 'desc' },
-      take: clamp(limit, 10, MAX_LIMIT),
-    });
+  async getPopularPosts(limit?: number, days?: number) {
+    const take = clamp(limit, 10, MAX_LIMIT);
+
+    if (this.excludeIps.size === 0) {
+      return this.prisma.post.findMany({
+        where: { published: true },
+        select: { slug: true, title: true, category: true, viewCount: true, createdAt: true },
+        orderBy: { viewCount: 'desc' },
+        take,
+      });
+    }
+
+    const ips = [...this.excludeIps];
+    const dayCount = days ? clamp(days, 1, MAX_DAYS) : 0;
+    const dateFilter =
+      dayCount > 0
+        ? Prisma.sql`AND pv.created_at >= NOW() - make_interval(days => ${dayCount})`
+        : Prisma.empty;
+
+    const result = await this.prisma.$queryRaw<
+      {
+        slug: string;
+        title: string;
+        category: string | null;
+        view_count: number;
+        created_at: Date;
+      }[]
+    >`
+      SELECT p.slug, p.title, p.category, COUNT(pv.id)::int as view_count, p.created_at
+      FROM blog.posts p
+      LEFT JOIN analytics.page_views pv
+        ON pv.path = '/blog/' || p.slug
+        AND pv.ip_address NOT IN (${Prisma.join(ips)})
+        ${dateFilter}
+      WHERE p.published = true
+      GROUP BY p.id
+      ORDER BY view_count DESC
+      LIMIT ${take}
+    `;
+
+    return result.map(r => ({
+      slug: r.slug,
+      title: r.title,
+      category: r.category,
+      viewCount: r.view_count,
+      createdAt: r.created_at,
+    }));
   }
 
   // ─── Visitor Stats ────────────────────────────────────────────────────────
@@ -88,38 +182,38 @@ export class AnalyticsService {
         })()
       : undefined;
 
-    const appFilter = appName ? Prisma.sql`AND app_name = ${appName}` : Prisma.empty;
-    const dateWhere = dateFilter
-      ? Prisma.sql`WHERE created_at >= ${dateFilter} ${appFilter}`
-      : appName
-        ? Prisma.sql`WHERE app_name = ${appName}`
-        : Prisma.sql`WHERE 1=1`;
+    const where: Prisma.PageViewWhereInput = {
+      ...this.ipFilter,
+      ...(dateFilter && { createdAt: { gte: dateFilter } }),
+      ...(appName && { appName }),
+    };
 
     const [totalViews, uniqueResult, dailyResult] = await Promise.all([
-      this.prisma.pageView.count({
-        where: {
-          ...(dateFilter && { createdAt: { gte: dateFilter } }),
-          ...(appName && { appName }),
-        },
+      this.prisma.pageView.count({ where }),
+      this.prisma.pageView.groupBy({
+        by: ['ipAddress'],
+        where,
+        _count: true,
       }),
-      this.prisma.$queryRaw<[{ count: bigint }]>`
-        SELECT COUNT(DISTINCT ip_address) as count
-        FROM analytics.page_views
-        ${dateWhere}
-      `,
-      this.prisma.$queryRaw<{ date: string; count: bigint }[]>`
-        SELECT DATE(created_at) as date, COUNT(*) as count
-        FROM analytics.page_views
-        ${dateWhere}
-        GROUP BY DATE(created_at)
-        ORDER BY date ASC
-      `,
+      this.prisma.pageView.groupBy({
+        by: ['createdAt'],
+        where,
+        _count: true,
+      }),
     ]);
+
+    const dailyMap = new Map<string, number>();
+    for (const r of dailyResult) {
+      const date = r.createdAt.toISOString().split('T')[0];
+      dailyMap.set(date, (dailyMap.get(date) ?? 0) + r._count);
+    }
 
     return {
       totalViews,
-      uniqueVisitors: Number(uniqueResult[0]?.count ?? 0),
-      daily: dailyResult.map(r => ({ date: String(r.date), count: Number(r.count) })),
+      uniqueVisitors: uniqueResult.length,
+      daily: [...dailyMap.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, count]) => ({ date, count })),
     };
   }
 
@@ -130,19 +224,129 @@ export class AnalyticsService {
     const since = new Date();
     since.setDate(since.getDate() - d);
 
-    const views = await this.prisma.pageView.groupBy({
-      by: ['referrer'],
+    const views = await this.prisma.pageView.findMany({
       where: {
         createdAt: { gte: since },
-        referrer: { not: null },
+        ...this.ipFilter,
         ...(appName && { appName }),
       },
-      _count: true,
-      orderBy: { _count: { referrer: 'desc' } },
-      take: 20,
+      select: { referrer: true },
     });
 
-    return views.map(v => ({ referrer: v.referrer as string, count: v._count }));
+    const total = views.length;
+    const grouped = new Map<string, { count: number; category: string }>();
+
+    let directCount = 0;
+
+    for (const v of views) {
+      if (!v.referrer) {
+        directCount++;
+        continue;
+      }
+      const domain = extractDomain(v.referrer);
+      const category = categorizeReferrer(domain);
+      const existing = grouped.get(domain);
+      if (existing) {
+        existing.count++;
+      } else {
+        grouped.set(domain, { count: 1, category });
+      }
+    }
+
+    const referrers = [
+      {
+        source: 'direct',
+        category: 'direct',
+        count: directCount,
+        percentage: total > 0 ? Math.round((directCount / total) * 1000) / 10 : 0,
+      },
+      ...[...grouped.entries()]
+        .sort(([, a], [, b]) => b.count - a.count)
+        .map(([source, data]) => ({
+          source,
+          category: data.category,
+          count: data.count,
+          percentage: total > 0 ? Math.round((data.count / total) * 1000) / 10 : 0,
+        })),
+    ];
+
+    const summary = { total, direct: directCount, search: 0, social: 0, other: 0 };
+    for (const [, data] of grouped) {
+      if (data.category === 'search') summary.search += data.count;
+      else if (data.category === 'social') summary.social += data.count;
+      else summary.other += data.count;
+    }
+
+    return { summary, referrers };
+  }
+
+  // ─── Visitors Timeline ────────────────────────────────────────────────────
+
+  async getVisitorsTimeline(days?: number, appName?: string) {
+    const d = clamp(days, 7, MAX_DAYS);
+    const since = new Date();
+    since.setDate(since.getDate() - d);
+
+    const views = await this.prisma.pageView.findMany({
+      where: {
+        createdAt: { gte: since },
+        ...this.ipFilter,
+        ...(appName && { appName }),
+      },
+      select: {
+        ipAddress: true,
+        path: true,
+        referrer: true,
+        city: true,
+        country: true,
+        isBot: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const grouped = new Map<
+      string,
+      {
+        city: string | null;
+        country: string | null;
+        isBot: boolean;
+        visits: { path: string; referrer: string | null; visitedAt: Date }[];
+      }
+    >();
+
+    for (const v of views) {
+      const ip = v.ipAddress ?? 'unknown';
+      let visitor = grouped.get(ip);
+      if (!visitor) {
+        visitor = {
+          city: v.city,
+          country: v.country,
+          isBot: v.isBot,
+          visits: [],
+        };
+        grouped.set(ip, visitor);
+      }
+      if (!visitor.city && v.city) visitor.city = v.city;
+      if (!visitor.country && v.country) visitor.country = v.country;
+
+      visitor.visits.push({
+        path: v.path,
+        referrer: v.referrer ? extractDomain(v.referrer) : null,
+        visitedAt: v.createdAt,
+      });
+    }
+
+    return [...grouped.entries()]
+      .map(([ip, data]) => ({
+        ipAddress: this.maskIp(ip),
+        city: data.city,
+        country: data.country,
+        isBot: data.isBot,
+        totalViews: data.visits.length,
+        visits: data.visits,
+      }))
+      .sort((a, b) => b.totalViews - a.totalViews);
   }
 
   // ─── System Status ────────────────────────────────────────────────────────
@@ -170,6 +374,16 @@ export class AnalyticsService {
         };
       })(),
     };
+  }
+
+  private maskIp(ip: string): string {
+    if (ip === 'unknown') return 'unknown';
+    if (ip.includes(':')) {
+      const parts = ip.split(':');
+      return `${parts.slice(0, 4).join(':')}:****`;
+    }
+    const parts = ip.split('.');
+    return `${parts[0]}.${parts[1]}.xxx.xxx`;
   }
 
   private formatUptime(ms: number): string {

--- a/src/analytics/geolocation.service.ts
+++ b/src/analytics/geolocation.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+interface GeoResult {
+  city: string | null;
+  country: string | null;
+}
+
+interface IpApiResponse {
+  status: string;
+  city?: string;
+  regionName?: string;
+  countryCode?: string;
+}
+
+const CACHE_TTL = 24 * 60 * 60 * 1000;
+const MAX_CACHE_SIZE = 5000;
+const MIN_REQUEST_INTERVAL = 1400; // ip-api.com free: 45/min ≈ 1 req per 1.33s
+
+@Injectable()
+export class GeolocationService {
+  private readonly logger = new Logger(GeolocationService.name);
+  private readonly cache = new Map<string, { result: GeoResult; expiry: number }>();
+  private lastRequestAt = 0;
+  private pending: Promise<GeoResult> = Promise.resolve({ city: null, country: null });
+
+  async lookup(ip: string): Promise<GeoResult> {
+    if (!ip || ip === '127.0.0.1' || ip === '::1') {
+      return { city: null, country: null };
+    }
+
+    const cached = this.cache.get(ip);
+    if (cached && cached.expiry > Date.now()) {
+      return cached.result;
+    }
+
+    if (cached) this.cache.delete(ip);
+
+    return this.enqueue(ip);
+  }
+
+  private enqueue(ip: string): Promise<GeoResult> {
+    const next = this.pending.then(() => this.throttledLookup(ip));
+    this.pending = next.catch(() => ({ city: null, country: null }));
+    return next;
+  }
+
+  private async throttledLookup(ip: string): Promise<GeoResult> {
+    const recheck = this.cache.get(ip);
+    if (recheck && recheck.expiry > Date.now()) return recheck.result;
+
+    const elapsed = Date.now() - this.lastRequestAt;
+    if (elapsed < MIN_REQUEST_INTERVAL) {
+      await new Promise(r => setTimeout(r, MIN_REQUEST_INTERVAL - elapsed));
+    }
+
+    try {
+      this.lastRequestAt = Date.now();
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 3000);
+
+      const res = await fetch(
+        `http://ip-api.com/json/${ip}?fields=status,city,regionName,countryCode`,
+        { signal: controller.signal },
+      );
+      clearTimeout(timeout);
+
+      const data = (await res.json()) as IpApiResponse;
+
+      if (data.status !== 'success') {
+        return { city: null, country: null };
+      }
+
+      const result: GeoResult = {
+        city:
+          data.regionName && data.city ? `${data.city}, ${data.regionName}` : (data.city ?? null),
+        country: data.countryCode ?? null,
+      };
+
+      if (this.cache.size >= MAX_CACHE_SIZE) {
+        const firstKey = this.cache.keys().next().value;
+        if (firstKey) this.cache.delete(firstKey);
+      }
+
+      this.cache.set(ip, { result, expiry: Date.now() + CACHE_TTL });
+      return result;
+    } catch (err) {
+      this.logger.warn(`Geolocation lookup failed for ${ip}: ${err}`);
+      return { city: null, country: null };
+    }
+  }
+}

--- a/src/analytics/page-view.service.ts
+++ b/src/analytics/page-view.service.ts
@@ -1,5 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
+import { GeolocationService } from './geolocation.service';
 
 interface TrackPageViewInput {
   path: string;
@@ -35,26 +37,59 @@ const BOT_PATTERNS = [
   /puppeteer/i,
 ];
 
-function isBot(userAgent?: string): boolean {
-  if (!userAgent) return false;
+function detectBot(userAgent?: string): boolean {
+  if (!userAgent) return true;
   return BOT_PATTERNS.some(pattern => pattern.test(userAgent));
 }
 
 @Injectable()
 export class PageViewService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(PageViewService.name);
+  private readonly excludeIps: Set<string>;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly geo: GeolocationService,
+    private readonly config: ConfigService,
+  ) {
+    const raw = this.config.get<string>('ANALYTICS_EXCLUDE_IPS', '');
+    this.excludeIps = new Set(
+      raw
+        .split(',')
+        .map(ip => ip.trim())
+        .filter(Boolean),
+    );
+  }
 
   async track(dto: TrackPageViewInput): Promise<void> {
-    if (isBot(dto.userAgent)) return;
+    const isBot = detectBot(dto.userAgent);
+    if (isBot) return;
 
-    await this.prisma.pageView.create({
+    if (dto.ipAddress && this.excludeIps.has(dto.ipAddress)) return;
+
+    const record = await this.prisma.pageView.create({
       data: {
         path: dto.path,
         appName: dto.appName,
         referrer: dto.referrer ?? null,
         userAgent: dto.userAgent ?? null,
         ipAddress: dto.ipAddress ?? null,
+        isBot,
       },
     });
+
+    if (dto.ipAddress) {
+      this.geo
+        .lookup(dto.ipAddress)
+        .then(geo => {
+          if (geo.city || geo.country) {
+            return this.prisma.pageView.update({
+              where: { id: record.id },
+              data: { city: geo.city, country: geo.country },
+            });
+          }
+        })
+        .catch(err => this.logger.warn(`Geo update failed: ${err}`));
+    }
   }
 }


### PR DESCRIPTION
## Summary
- pageView 기록 시 ip-api.com으로 city/country 자동 조회 후 DB 저장
- ANALYTICS_EXCLUDE_IPS 환경변수로 본인 IP 통계 제외
- popular-posts, referrers, visitor-stats에서 제외 IP 필터링
- referrers API 도메인 정규화 + 카테고리(search/social/direct/other) + 비율 계산
- visitors/timeline API 신규 (IP별 위치 + 봇 여부 + 방문 타임라인, IP 마스킹)
- geolocation 캐시 상한(5000) + ip-api.com 레이트 리밋(1.4s 간격)
- SQL injection 수정 (Prisma.raw -> Prisma.join)
- backfill 스크립트로 기존 데이터 geolocation 채우기

## Test plan
- [ ] popular-posts에서 본인 IP 제외 확인
- [ ] visitors/timeline 응답에 city/country 포함 확인
- [ ] IP 마스킹 확인 (xxx.xxx 형태)
- [ ] referrers에 summary + category 포함 확인
- [ ] backfill 스크립트 실행