### PR TITLE
fix: visitors timeline 정렬을 최근 방문 시간 기준으로 변경

### DIFF
--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -346,7 +346,11 @@ export class AnalyticsService {
         totalViews: data.visits.length,
         visits: data.visits,
       }))
-      .sort((a, b) => b.totalViews - a.totalViews);
+      .sort((a, b) => {
+        const aLatest = a.visits[0]?.visitedAt ?? new Date(0);
+        const bLatest = b.visits[0]?.visitedAt ?? new Date(0);
+        return new Date(bLatest).getTime() - new Date(aLatest).getTime();
+      });
   }
 
   // ─── System Status ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- 방문자 타임라인 정렬을 totalViews 내림차순 → 가장 최근 visitedAt 기준 내림차순으로 변경
- 프론트 응답 구조 변경 없음

## Test plan
- [ ] visitors/timeline API에서 최근 방문자가 상단에 오는지 확인