### PR TITLE
healthcheck IPv6 오탐 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:4000/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:4000/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- docker-compose.yml healthcheck에서 `http://localhost:4000/health` → `http://127.0.0.1:4000/health`로 변경
- Alpine 계열 컨테이너에서 wget이 localhost를 IPv6(::1)로 먼저 시도하다 연결 거부로 실패, 앱은 정상 동작 중인데도 컨테이너가 unhealthy로 오탐되던 문제 해결
- 컨테이너 내부에서 `wget -qO- http://127.0.0.1:4000/health`는 정상 응답(`{"status":"ok"}`) 확인됨. docker inspect Health.Log에는 `wget: can't connect to remote host: Connection refused`만 반복 기록되고 있었음
- docker-compose.prod.yml, docker-compose.local.yml은 healthcheck를 별도 정의하지 않고 base 파일을 상속받는 구조라 이 파일 하나만 수정하면 됨

## Test plan
- [ ] main 병합 후 GitHub Actions 자동 배포 확인
- [ ] 맥미니에서 `docker ps`로 api-server-api-1이 `(healthy)`로 표시되는지 확인
- [ ] `docker inspect api-server-api-1`의 Health.Log가 정상 응답으로 갱신되는지 확인