### PR TITLE
healthcheck IPv6 오탐 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:4000/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:4000/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- docker-compose.yml healthcheck IPv6 오탐 수정 (#100) main 반영

## Test plan
- [ ] 배포 후 맥미니에서 `docker ps`로 api-server-api-1이 `(healthy)`로 표시되는지 확인