### PR TITLE
feat: GET /api/blog/posts 응답 스키마 선언 및 openapi.json 추출 (#102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,30 @@ jobs:
       - name: Type Check
         run: pnpm typecheck
 
+      # 커밋된 openapi.json이 현재 소스와 일치하는지 검사한다.
+      # 프론트(hyunwoo-dev)가 이 파일에서 타입을 생성하므로, 스펙이 낡으면
+      # 프론트 타입이 조용히 실제 API와 어긋난다.
+      # DB 접속은 하지 않지만(listen하지 않아 onModuleInit이 안 돌아감) provider
+      # 생성자의 config.getOrThrow 때문에 env 값 자체는 있어야 한다.
+      - name: OpenAPI spec drift check
+        run: |
+          pnpm openapi:generate
+          if ! git diff --exit-code openapi.json; then
+            echo "::error::openapi.json이 소스와 다릅니다. 로컬에서 'pnpm openapi:generate' 후 커밋하세요."
+            exit 1
+          fi
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/hyunwoo_test
+          JWT_SECRET: ci-test-secret-32-chars-minimum!!
+          ADMIN_USERNAME: admin
+          ADMIN_PASSWORD_HASH: $2a$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdBPj/zo.RvCNPC
+          R2_ACCOUNT_ID: placeholder
+          R2_ACCESS_KEY_ID: placeholder
+          R2_SECRET_ACCESS_KEY: placeholder
+          R2_BUCKET_NAME: placeholder
+          R2_PUBLIC_URL: https://placeholder.r2.dev
+          ALLOWED_ORIGINS: http://localhost:3000
+
       - name: Build
         run: pnpm build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,5 +111,7 @@ pnpm openapi:generate    # scripts/generate-openapi.ts → 루트 openapi.json
 - [x] 프론트 연동 후 openapi-typescript 타입 생성 설정 — 파이프라인 구축 완료 (#102)
 - [ ] **나머지 라우트의 Response DTO** — 72개 오퍼레이션 중 성공 응답 스키마가 있는 건
       `GET /api/blog/posts` 1개뿐이다. 나머지는 프론트가 타입을 생성해도 응답이 비어 쓸 수 없다.
-      확인: `jq -r '[.paths | to_entries[] | .key as $p | .value | to_entries[] | select(.value.responses["200"].content) | "\($p) \(.key)"] | .[]' openapi.json`
+      단, 본문이 원래 없는 204 라우트(`POST /api/auth/logout` 등)는 대상이 아니다.
+      확인 (프론트 헬퍼가 200 다음 201도 보므로 둘 다 센다):
+      `jq -r '[.paths|to_entries[]|.key as $p|.value|to_entries[]|select((.value.responses["200"].content["application/json"]//.value.responses["201"].content["application/json"])!=null)|"\($p) \(.key)"]|.[]' openapi.json`
 - [ ] 테스트 0건 — `pnpm test`가 `--passWithNoTests`라 CI Test 스텝이 항상 초록인데 아무것도 검사하지 않는다

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ chahyunwoo.dev 블로그 & 포트폴리오 백엔드 API.
 
 ## 기술 스택
 - **Runtime**: Node.js 22
-- **Framework**: NestJS 10 + Fastify 어댑터
+- **Framework**: NestJS 11 + Fastify 어댑터
 - **ORM**: Prisma 6 (multi-schema: blog / portfolio)
 - **DB**: PostgreSQL 16
 - **Auth**: JWT (단일 어드민, env vars로 관리)
@@ -64,12 +64,32 @@ prisma/
 - `POST /api/blog/posts/:slug/thumbnail` (multipart)
 
 ### Swagger UI
-개발 환경에서만 노출: `http://localhost:4000/docs`
+개발 환경에서만 노출: `http://localhost:4000/docs` (JSON은 `/docs-json`)
+
+### OpenAPI 스펙 (`openapi.json`)
+프론트(`hyunwoo-dev`)가 이 파일에서 API 타입을 생성한다. 저장소가 분리돼 있어 파일로 커밋해 둔다.
+
+```bash
+pnpm openapi:generate    # scripts/generate-openapi.ts → 루트 openapi.json
+```
+
+- 앱을 listen하지 않고 문서만 만든다 → `onModuleInit`이 안 돌아 **DB 접속이 없다**. 다만 provider
+  생성자의 `config.getOrThrow` 때문에 env 값 자체는 있어야 한다(로컬 `.env`, CI는 더미).
+- Swagger 설정은 `src/common/swagger/swagger.config.ts` 한 곳에서만 만든다. `/docs`와
+  `openapi.json`이 각자 `DocumentBuilder`를 들면 스펙이 조용히 갈라진다.
+- **DTO를 바꾸면 `pnpm openapi:generate` 후 같이 커밋해야 한다.** CI의 `OpenAPI spec drift check`가
+  검사한다.
+- 생성물이라 biome 검사 대상에서 제외돼 있다(`biome.json`의 `!openapi.json`).
 
 ## 브랜치 전략
 - `main` — 프로덕션
 - `dev` — 통합 브랜치
 - `feature/{ISSUE-KEY}` — 기능 브랜치 (dev에서 분기)
+
+`stg`는 의도적으로 두지 않는다(빠뜨린 게 아니다). 기여자가 1명이고 feature가 동시에 진행되지
+않아 단계를 하나 더 두면 병합만 늘고 얻는 게 없다. 대신 **`main` 푸시가 곧 프로덕션 배포**이므로
+(`.github/workflows/deploy.yml`), `dev`에서 검증을 끝내고 승인받은 뒤에만 `main`으로 올린다.
+검증 없이 `main`에 올리면 되돌릴 곳이 없다.
 
 ## 배포
 - Push to main → GitHub Actions → Tailscale SSH → 맥미니 Docker
@@ -88,4 +108,8 @@ prisma/
 ## 현재 남은 작업
 - [ ] 포트폴리오 어드민 CRUD (나중에)
 - [ ] 검색 성능 개선: pg_trgm 인덱스 마이그레이션 (필요 시)
-- [ ] 프론트 연동 후 openapi-typescript 타입 생성 설정
+- [x] 프론트 연동 후 openapi-typescript 타입 생성 설정 — 파이프라인 구축 완료 (#102)
+- [ ] **나머지 라우트의 Response DTO** — 72개 오퍼레이션 중 성공 응답 스키마가 있는 건
+      `GET /api/blog/posts` 1개뿐이다. 나머지는 프론트가 타입을 생성해도 응답이 비어 쓸 수 없다.
+      확인: `jq -r '[.paths | to_entries[] | .key as $p | .value | to_entries[] | select(.value.responses["200"].content) | "\($p) \(.key)"] | .[]' openapi.json`
+- [ ] 테스트 0건 — `pnpm test`가 `--passWithNoTests`라 CI Test 스텝이 항상 초록인데 아무것도 검사하지 않는다

--- a/biome.json
+++ b/biome.json
@@ -44,7 +44,7 @@
     }
   },
   "files": {
-    "includes": ["src/**", "*.json", "*.ts", "!openapi.json"],
+    "includes": ["src/**", "scripts/**", "*.json", "*.ts", "!openapi.json"],
     "ignoreUnknown": true
   }
 }

--- a/biome.json
+++ b/biome.json
@@ -44,7 +44,7 @@
     }
   },
   "files": {
-    "includes": ["src/**", "*.json", "*.ts"],
+    "includes": ["src/**", "*.json", "*.ts", "!openapi.json"],
     "ignoreUnknown": true
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,5399 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/health": {
+      "get": {
+        "operationId": "HealthController_check",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "health"
+        ]
+      }
+    },
+    "/api/analytics/pageview": {
+      "post": {
+        "operationId": "AnalyticsController_trackPageView",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackPageViewDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/analytics/dashboard": {
+      "get": {
+        "operationId": "AnalyticsController_getDashboard",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/analytics/popular-posts": {
+      "get": {
+        "operationId": "AnalyticsController_getPopularPosts",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/analytics/visitors": {
+      "get": {
+        "operationId": "AnalyticsController_getVisitors",
+        "parameters": [
+          {
+            "name": "days",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "app",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/analytics/visitors/timeline": {
+      "get": {
+        "operationId": "AnalyticsController_getVisitorsTimeline",
+        "parameters": [
+          {
+            "name": "days",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "app",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/analytics/referrers": {
+      "get": {
+        "operationId": "AnalyticsController_getReferrers",
+        "parameters": [
+          {
+            "name": "days",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "app",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/analytics/system": {
+      "get": {
+        "operationId": "AnalyticsController_getSystem",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/analytics/admin-logs": {
+      "get": {
+        "operationId": "AnalyticsController_getAdminLogs",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "operationId": "AuthController_login",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/2fa/verify": {
+      "post": {
+        "operationId": "AuthController_verifyTwoFactor",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Verify2faDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/2fa/status": {
+      "get": {
+        "operationId": "AuthController_getTwoFactorStatus",
+        "parameters": [],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/2fa/setup": {
+      "post": {
+        "operationId": "AuthController_setupTwoFactor",
+        "parameters": [],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/2fa/disable": {
+      "post": {
+        "operationId": "AuthController_disableTwoFactor",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Enable2faDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/2fa/enable": {
+      "post": {
+        "operationId": "AuthController_enableTwoFactor",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Enable2faDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/refresh": {
+      "post": {
+        "operationId": "AuthController_refresh",
+        "parameters": [],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "operationId": "AuthController_logout",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/logout-all": {
+      "post": {
+        "operationId": "AuthController_logoutAll",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/session/extend": {
+      "post": {
+        "operationId": "AuthController_extendSession",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/preview-token": {
+      "post": {
+        "operationId": "AuthController_createPreviewToken",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/verify-preview": {
+      "get": {
+        "operationId": "AuthController_verifyPreview",
+        "parameters": [
+          {
+            "name": "token",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/blog/posts/search": {
+      "get": {
+        "operationId": "BlogController_search",
+        "parameters": [
+          {
+            "name": "q",
+            "required": true,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "maximum": 50,
+              "default": 10,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "q must be at least 2 characters"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/blog/posts": {
+      "get": {
+        "operationId": "BlogController_findAll",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "maximum": 50,
+              "default": 10,
+              "type": "number"
+            }
+          },
+          {
+            "name": "category",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tag",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      },
+      "post": {
+        "operationId": "BlogController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePostDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 409
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Conflict"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Slug already exists"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/blog/posts/recent": {
+      "get": {
+        "operationId": "BlogController_getRecentPosts",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "maximum": 10,
+              "default": 5,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/blog/categories": {
+      "get": {
+        "operationId": "BlogController_getCategories",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      },
+      "post": {
+        "operationId": "BlogController_createCategory",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCategoryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/blog/categories/{id}": {
+      "put": {
+        "operationId": "BlogController_updateCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCategoryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      },
+      "delete": {
+        "operationId": "BlogController_deleteCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/blog/tags": {
+      "get": {
+        "operationId": "BlogController_getTags",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "maximum": 50,
+              "default": 15,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/blog/posts/{slug}": {
+      "get": {
+        "operationId": "BlogController_findOne",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Post not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      },
+      "put": {
+        "operationId": "BlogController_update",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePostDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Post not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      },
+      "delete": {
+        "operationId": "BlogController_remove",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Post not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/blog/posts/{slug}/preview": {
+      "get": {
+        "operationId": "BlogController_findOnePreview",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "token",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Post not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/blog/posts/{slug}/related": {
+      "get": {
+        "operationId": "BlogController_getRelatedPosts",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Post not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/blog/images": {
+      "post": {
+        "operationId": "BlogController_uploadImage",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "No file provided or invalid file type"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "blog"
+        ]
+      }
+    },
+    "/api/portfolio/locales": {
+      "get": {
+        "operationId": "PortfolioController_getLocales",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "post": {
+        "operationId": "PortfolioController_createLocale",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLocaleDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 409
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Conflict"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Locale already exists"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/profile": {
+      "get": {
+        "operationId": "PortfolioController_getProfile",
+        "parameters": [
+          {
+            "name": "locale",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "ko",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Unsupported locale"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Profile not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "put": {
+        "operationId": "PortfolioController_updateProfile",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProfileDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/profile/all": {
+      "get": {
+        "operationId": "PortfolioController_getProfileWithTranslations",
+        "parameters": [],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Profile not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/experiences": {
+      "get": {
+        "operationId": "PortfolioController_getExperiences",
+        "parameters": [
+          {
+            "name": "locale",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "ko",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Unsupported locale"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "post": {
+        "operationId": "PortfolioController_createExperience",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateExperienceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/projects": {
+      "get": {
+        "operationId": "PortfolioController_getProjects",
+        "parameters": [
+          {
+            "name": "locale",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "ko",
+              "type": "string"
+            }
+          },
+          {
+            "name": "featured",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Unsupported locale"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "post": {
+        "operationId": "PortfolioController_createProject",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProjectDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/skills": {
+      "get": {
+        "operationId": "PortfolioController_getSkills",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "post": {
+        "operationId": "PortfolioController_createSkill",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSkillDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/works": {
+      "get": {
+        "operationId": "PortfolioController_getWorks",
+        "parameters": [
+          {
+            "name": "locale",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "business",
+                "personal"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Unsupported locale"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "post": {
+        "operationId": "PortfolioController_createWork",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/works/{id}": {
+      "get": {
+        "operationId": "PortfolioController_getWorkById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Work not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "put": {
+        "operationId": "PortfolioController_updateWork",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Work not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "delete": {
+        "operationId": "PortfolioController_deleteWork",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Work not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/experiences/{id}": {
+      "get": {
+        "operationId": "PortfolioController_getExperienceById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Experience not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "put": {
+        "operationId": "PortfolioController_updateExperience",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateExperienceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Experience not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "delete": {
+        "operationId": "PortfolioController_deleteExperience",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Experience not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/projects/{id}": {
+      "get": {
+        "operationId": "PortfolioController_getProjectById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Project not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "put": {
+        "operationId": "PortfolioController_updateProject",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProjectDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Project not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "delete": {
+        "operationId": "PortfolioController_deleteProject",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Project not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/education/{id}": {
+      "get": {
+        "operationId": "PortfolioController_getEducationById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Education not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "put": {
+        "operationId": "PortfolioController_updateEducation",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEducationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Education not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "delete": {
+        "operationId": "PortfolioController_deleteEducation",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Education not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/education": {
+      "get": {
+        "operationId": "PortfolioController_getEducation",
+        "parameters": [
+          {
+            "name": "locale",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "ko",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Unsupported locale"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "post": {
+        "operationId": "PortfolioController_createEducation",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEducationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/locales/{id}": {
+      "delete": {
+        "operationId": "PortfolioController_deleteLocale",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Locale not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/profile/image": {
+      "post": {
+        "operationId": "PortfolioController_uploadProfileImage",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "No file provided or invalid file type"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/profile/icon": {
+      "post": {
+        "operationId": "PortfolioController_uploadProfileIcon",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "No file provided or invalid file type"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/skills/{id}": {
+      "put": {
+        "operationId": "PortfolioController_updateSkill",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSkillDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Skill not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      },
+      "delete": {
+        "operationId": "PortfolioController_deleteSkill",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Skill not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/contact": {
+      "post": {
+        "operationId": "PortfolioController_createContact",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContactDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/contacts": {
+      "get": {
+        "operationId": "PortfolioController_getContacts",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/contacts/{id}/read": {
+      "put": {
+        "operationId": "PortfolioController_markContactRead",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Contact message not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    },
+    "/api/portfolio/contacts/{id}": {
+      "delete": {
+        "operationId": "PortfolioController_deleteContact",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 401
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid credentials"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Not Found"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Contact message not found"
+                    },
+                    "path": {
+                      "type": "string",
+                      "example": "/api/..."
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2026-01-01T00:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "portfolio"
+        ]
+      }
+    }
+  },
+  "info": {
+    "title": "Hyunwoo API",
+    "description": "chahyunwoo.dev blog & portfolio API",
+    "version": "1.0",
+    "contact": {}
+  },
+  "tags": [],
+  "servers": [],
+  "components": {
+    "securitySchemes": {
+      "bearer": {
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "type": "http"
+      },
+      "cookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "access_token"
+      },
+      "api-key": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      }
+    },
+    "schemas": {
+      "TrackPageViewDto": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "example": "/blog/my-post"
+          },
+          "appName": {
+            "type": "string",
+            "enum": [
+              "blog",
+              "portfolio",
+              "admin"
+            ],
+            "example": "blog"
+          },
+          "referrer": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "appName"
+        ]
+      },
+      "LoginDto": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "example": "admin"
+          },
+          "password": {
+            "type": "string",
+            "example": "password"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ]
+      },
+      "Verify2faDto": {
+        "type": "object",
+        "properties": {
+          "twoFactorToken": {
+            "type": "string",
+            "example": "abc123..."
+          },
+          "code": {
+            "type": "string",
+            "example": "123456"
+          }
+        },
+        "required": [
+          "twoFactorToken",
+          "code"
+        ]
+      },
+      "Enable2faDto": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "123456"
+          }
+        },
+        "required": [
+          "code"
+        ]
+      },
+      "PostTagDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "example": "React"
+          },
+          "slug": {
+            "type": "string",
+            "example": "react"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "slug"
+        ]
+      },
+      "PostSummaryDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "title": {
+            "type": "string",
+            "example": "Next.js 15 App Router 완전 정복"
+          },
+          "slug": {
+            "type": "string",
+            "example": "nextjs-15-app-router"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "미입력 시 content에서 자동 추출"
+          },
+          "thumbnailUrl": {
+            "type": "string",
+            "nullable": true,
+            "example": "https://assets.chahyunwoo.dev/thumbnail/example.png"
+          },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "example": "Frontend"
+          },
+          "published": {
+            "type": "boolean",
+            "example": true
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "readingTime": {
+            "type": "number",
+            "example": 5,
+            "description": "분 단위 예상 읽기 시간"
+          },
+          "viewCount": {
+            "type": "number",
+            "example": 128
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostTagDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "slug",
+          "description",
+          "thumbnailUrl",
+          "category",
+          "published",
+          "publishedAt",
+          "readingTime",
+          "viewCount",
+          "createdAt",
+          "updatedAt",
+          "tags"
+        ]
+      },
+      "PostListResponseDto": {
+        "type": "object",
+        "properties": {
+          "posts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostSummaryDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "example": 40,
+            "description": "필터 조건에 맞는 전체 건수"
+          },
+          "page": {
+            "type": "number",
+            "example": 1
+          },
+          "limit": {
+            "type": "number",
+            "example": 10
+          },
+          "totalPages": {
+            "type": "number",
+            "example": 4
+          }
+        },
+        "required": [
+          "posts",
+          "total",
+          "page",
+          "limit",
+          "totalPages"
+        ]
+      },
+      "CreateCategoryDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "Frontend"
+          },
+          "icon": {
+            "type": "string",
+            "example": "Monitor",
+            "description": "lucide-react 아이콘 이름"
+          },
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "CreatePostDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "example": "Next.js 15 App Router 완전 정복"
+          },
+          "description": {
+            "type": "string",
+            "description": "미입력 시 content에서 자동 추출"
+          },
+          "content": {
+            "type": "string",
+            "description": "MDX content"
+          },
+          "category": {
+            "type": "string",
+            "example": "Frontend"
+          },
+          "thumbnailUrl": {
+            "type": "string",
+            "description": "이미지 업로드 API에서 받은 URL"
+          },
+          "published": {
+            "type": "boolean",
+            "default": false
+          },
+          "publishedAt": {
+            "type": "string",
+            "example": "2026-03-21",
+            "description": "발행일 (미입력 시 발행 시점 자동)"
+          },
+          "tags": {
+            "example": [
+              "React",
+              "TypeScript"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "title",
+          "content"
+        ]
+      },
+      "UpdatePostDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "example": "Next.js 15 App Router 완전 정복"
+          },
+          "description": {
+            "type": "string",
+            "description": "미입력 시 content에서 자동 추출"
+          },
+          "content": {
+            "type": "string",
+            "description": "MDX content"
+          },
+          "category": {
+            "type": "string",
+            "example": "Frontend"
+          },
+          "thumbnailUrl": {
+            "type": "string",
+            "description": "이미지 업로드 API에서 받은 URL"
+          },
+          "published": {
+            "type": "boolean",
+            "default": false
+          },
+          "publishedAt": {
+            "type": "string",
+            "example": "2026-03-21",
+            "description": "발행일 (미입력 시 발행 시점 자동)"
+          },
+          "tags": {
+            "example": [
+              "React",
+              "TypeScript"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CreateLocaleDto": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "zh"
+          },
+          "label": {
+            "type": "string",
+            "example": "中文"
+          }
+        },
+        "required": [
+          "code",
+          "label"
+        ]
+      },
+      "SocialLinkDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "href": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "href"
+        ]
+      },
+      "ProfileTranslationDto": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string"
+          },
+          "jobTitle": {
+            "type": "string"
+          },
+          "introduction": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "locale",
+          "jobTitle",
+          "introduction"
+        ]
+      },
+      "UpdateProfileDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "iconUrl": {
+            "type": "string"
+          },
+          "socialLinks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SocialLinkDto"
+            }
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileTranslationDto"
+            }
+          }
+        }
+      },
+      "ExperienceTranslationDto": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "responsibilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "locale",
+          "title",
+          "role",
+          "responsibilities"
+        ]
+      },
+      "CreateExperienceDto": {
+        "type": "object",
+        "properties": {
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "isCurrent": {
+            "type": "boolean",
+            "default": false
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperienceTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "startDate",
+          "translations"
+        ]
+      },
+      "UpdateExperienceDto": {
+        "type": "object",
+        "properties": {
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "isCurrent": {
+            "type": "boolean",
+            "default": false
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperienceTranslationDto"
+            }
+          }
+        }
+      },
+      "ProjectTranslationDto": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "locale",
+          "title"
+        ]
+      },
+      "CreateProjectDto": {
+        "type": "object",
+        "properties": {
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "demoUrl": {
+            "type": "string"
+          },
+          "repoUrl": {
+            "type": "string"
+          },
+          "techStack": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "featured": {
+            "type": "boolean",
+            "default": false
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "techStack",
+          "translations"
+        ]
+      },
+      "UpdateProjectDto": {
+        "type": "object",
+        "properties": {
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "demoUrl": {
+            "type": "string"
+          },
+          "repoUrl": {
+            "type": "string"
+          },
+          "techStack": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "featured": {
+            "type": "boolean",
+            "default": false
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectTranslationDto"
+            }
+          }
+        }
+      },
+      "CreateSkillDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "proficiency": {
+            "type": "number",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 100
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "category",
+          "name"
+        ]
+      },
+      "UpdateSkillDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "proficiency": {
+            "type": "number",
+            "default": 0,
+            "minimum": 0,
+            "maximum": 100
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "EducationTranslationDto": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string"
+          },
+          "institution": {
+            "type": "string"
+          },
+          "degree": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "locale",
+          "institution",
+          "degree"
+        ]
+      },
+      "CreateEducationDto": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EducationTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "period",
+          "translations"
+        ]
+      },
+      "UpdateEducationDto": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EducationTranslationDto"
+            }
+          }
+        }
+      },
+      "WorkTranslationDto": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "highlights": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "locale",
+          "title",
+          "summary",
+          "content"
+        ]
+      },
+      "CreateWorkDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "business",
+              "personal"
+            ]
+          },
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "isCurrent": {
+            "type": "boolean",
+            "default": false
+          },
+          "techStack": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "demoUrl": {
+            "type": "string"
+          },
+          "repoUrl": {
+            "type": "string"
+          },
+          "featured": {
+            "type": "boolean",
+            "default": false
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "techStack",
+          "translations"
+        ]
+      },
+      "UpdateWorkDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "business",
+              "personal"
+            ]
+          },
+          "sortOrder": {
+            "type": "number",
+            "default": 0
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "isCurrent": {
+            "type": "boolean",
+            "default": false
+          },
+          "techStack": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "demoUrl": {
+            "type": "string"
+          },
+          "repoUrl": {
+            "type": "string"
+          },
+          "featured": {
+            "type": "boolean",
+            "default": false
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkTranslationDto"
+            }
+          }
+        }
+      },
+      "CreateContactDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "John Doe"
+          },
+          "email": {
+            "type": "string",
+            "example": "john@example.com"
+          },
+          "subject": {
+            "type": "string",
+            "example": "Collaboration Inquiry"
+          },
+          "message": {
+            "type": "string",
+            "example": "Hello, I would like to discuss..."
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "biome check --write .",
     "lint:ci": "biome check .",
     "typecheck": "tsc --noEmit",
+    "openapi:generate": "ts-node --transpile-only -P tsconfig.json scripts/generate-openapi.ts",
     "test": "jest --passWithNoTests",
     "test:cov": "jest --coverage --passWithNoTests",
     "db:generate": "prisma generate",

--- a/scripts/backfill-geolocation.ts
+++ b/scripts/backfill-geolocation.ts
@@ -11,7 +11,9 @@ interface IpApiResponse {
 
 async function lookup(ip: string): Promise<{ city: string | null; country: string | null }> {
   try {
-    const res = await fetch(`http://ip-api.com/json/${ip}?fields=status,city,regionName,countryCode`);
+    const res = await fetch(
+      `http://ip-api.com/json/${ip}?fields=status,city,regionName,countryCode`,
+    );
     const data = (await res.json()) as IpApiResponse;
     if (data.status !== 'success') return { city: null, country: null };
     return {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,57 @@
+/**
+ * OpenAPI 스펙을 openapi.json으로 덤프한다.
+ *
+ * Usage:
+ *   pnpm openapi:generate
+ *
+ * 왜 서버를 띄우지 않는가:
+ *   main.ts의 SwaggerModule.setup은 NODE_ENV !== 'production' 게이트 안에 있어서
+ *   프로덕션 빌드에선 /docs 자체가 없다. 여기선 문서만 만들면 되므로 앱을 만들되
+ *   listen하지 않는다. NestFactory.create()는 app.init()/listen()을 부르지 않으면
+ *   onModuleInit / onApplicationBootstrap을 실행하지 않으므로 DB 접속도, 스케줄러
+ *   기동도 일어나지 않는다.
+ *
+ * 주의: provider 생성자에서 config.getOrThrow(...)를 호출하는 곳들이 있어
+ *   (auth.service, auth.module, jwt.strategy, prisma.service, storage.service, blog.service)
+ *   env 값 자체는 존재해야 한다. 로컬은 .env, CI는 더미 값을 주입한다.
+ *   API_KEY는 api-key.guard가 canActivate에서 지연 조회하므로 필요 없다(실측 확인).
+ */
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { NestFactory } from '@nestjs/core';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { SwaggerModule } from '@nestjs/swagger';
+
+import { AppModule } from '../src/app.module';
+import { buildSwaggerConfig } from '../src/common/swagger/swagger.config';
+
+const OUTPUT_PATH = join(__dirname, '..', 'openapi.json');
+
+async function main() {
+  // abortOnError: false 가 없으면 모듈 생성 실패 시 Nest가 예외를 삼키고 프로세스를
+  // 그냥 죽여서, logger가 꺼진 상태에서는 CI 로그에 아무 단서도 안 남는다.
+  const app = await NestFactory.create(AppModule, new FastifyAdapter(), {
+    logger: false,
+    abortOnError: false,
+  });
+  const document = SwaggerModule.createDocument(app, buildSwaggerConfig());
+
+  // 개행으로 끝내야 git diff --exit-code 게이트가 개행 차이로 흔들리지 않는다.
+  writeFileSync(OUTPUT_PATH, `${JSON.stringify(document, null, 2)}\n`, 'utf8');
+
+  const routeCount = Object.values(document.paths ?? {}).reduce(
+    (acc, item) => acc + Object.keys(item as object).length,
+    0,
+  );
+  const schemaCount = Object.keys(document.components?.schemas ?? {}).length;
+  process.stdout.write(`openapi.json written: ${routeCount} operations, ${schemaCount} schemas\n`);
+
+  // listen하지 않았으므로 열린 핸들은 없지만, 캐시/스케줄러 모듈이 타이머를 잡는
+  // 경우를 대비해 명시적으로 끝낸다.
+  process.exit(0);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exit(1);
+});

--- a/scripts/migrate-slugs.ts
+++ b/scripts/migrate-slugs.ts
@@ -27,7 +27,7 @@ async function main() {
       select: { id: true, slug: true, title: true },
     });
 
-    const koreanPosts = posts.filter((p) => /[가-힣ㄱ-ㅎㅏ-ㅣ]/.test(p.slug));
+    const koreanPosts = posts.filter(p => /[가-힣ㄱ-ㅎㅏ-ㅣ]/.test(p.slug));
 
     if (koreanPosts.length === 0) {
       console.log('No Korean slugs found. Nothing to migrate.');

--- a/scripts/seed-analytics.ts
+++ b/scripts/seed-analytics.ts
@@ -57,7 +57,8 @@ async function main() {
       const dailyCount = randomInt(5, 50);
       for (let i = 0; i < dailyCount; i++) {
         const app = randomItem(apps);
-        const paths = app === 'blog' ? blogPaths : app === 'portfolio' ? portfolioPaths : adminPaths;
+        const paths =
+          app === 'blog' ? blogPaths : app === 'portfolio' ? portfolioPaths : adminPaths;
         const date = new Date();
         date.setDate(date.getDate() - daysAgo);
         date.setHours(randomInt(0, 23), randomInt(0, 59), randomInt(0, 59));

--- a/scripts/seed-portfolio.ts
+++ b/scripts/seed-portfolio.ts
@@ -38,16 +38,42 @@ async function main() {
       data: {
         name: 'CHA HYUNWOO',
         location: 'Seoul, Korea',
-        socialLinks: JSON.parse(JSON.stringify([
-          { name: 'Github', href: 'https://github.com/chahyunwoo', icon: 'Github' },
-          { name: 'Instagram', href: 'https://instagram.com/chwzp', icon: 'Instagram' },
-          { name: 'Linkedin', href: 'https://www.linkedin.com/in/chahyunwoo', icon: 'Linkedin' },
-        ])),
+        socialLinks: JSON.parse(
+          JSON.stringify([
+            { name: 'Github', href: 'https://github.com/chahyunwoo', icon: 'Github' },
+            { name: 'Instagram', href: 'https://instagram.com/chwzp', icon: 'Instagram' },
+            { name: 'Linkedin', href: 'https://www.linkedin.com/in/chahyunwoo', icon: 'Linkedin' },
+          ]),
+        ),
         translations: {
           create: [
-            { locale: 'ko', jobTitle: 'Full-Stack Developer', introduction: ['어디서든 잘 녹아드는 유연한 사고와 자세가 제 장점입니다.', '생산성을 높이는 코드를 작성하는 것을 좋아합니다.', '오늘 10분 걸린 코드가, 내일은 5분 걸릴 수 있도록 노력합니다.'] },
-            { locale: 'en', jobTitle: 'Full-Stack Developer', introduction: ['I am a developer who is flexible and easy to adapt to any situation.', 'I like to write code that increases productivity.', 'I try to write code that takes 10 minutes today, but takes 5 minutes tomorrow.'] },
-            { locale: 'jp', jobTitle: 'Full-Stack Developer', introduction: ['どこでもよく溶け込む柔軟な思考と姿勢が私の長所です。', '生産性を高めるコードを作成するのが好きです。', '今日10分かかったコードが、明日は5分で済むように努力します。'] },
+            {
+              locale: 'ko',
+              jobTitle: 'Full-Stack Developer',
+              introduction: [
+                '어디서든 잘 녹아드는 유연한 사고와 자세가 제 장점입니다.',
+                '생산성을 높이는 코드를 작성하는 것을 좋아합니다.',
+                '오늘 10분 걸린 코드가, 내일은 5분 걸릴 수 있도록 노력합니다.',
+              ],
+            },
+            {
+              locale: 'en',
+              jobTitle: 'Full-Stack Developer',
+              introduction: [
+                'I am a developer who is flexible and easy to adapt to any situation.',
+                'I like to write code that increases productivity.',
+                'I try to write code that takes 10 minutes today, but takes 5 minutes tomorrow.',
+              ],
+            },
+            {
+              locale: 'jp',
+              jobTitle: 'Full-Stack Developer',
+              introduction: [
+                'どこでもよく溶け込む柔軟な思考と姿勢が私の長所です。',
+                '生産性を高めるコードを作成するのが好きです。',
+                '今日10分かかったコードが、明日は5分で済むように努力します。',
+              ],
+            },
           ],
         },
       },
@@ -57,40 +83,256 @@ async function main() {
     // ─── Experiences ──────────────────────────────────────────────────────────
     const experiences = [
       {
-        sortOrder: 1, startDate: '2025', endDate: null, isCurrent: true,
-        ko: { title: '프리랜서 풀스택 개발자', role: 'Full-Stack Developer / Freelancer', responsibilities: ['금융권 백오피스 시스템 설계 및 프론트엔드 테크 리딩 (React 19 + TanStack)', 'Feature-First Architecture 기반 도메인 중심 모듈화 구조 설계', 'TanStack Router/Query/Table/Virtual 기반 대규모 데이터 처리 시스템 구현', 'SSE 기반 실시간 데이터 스트리밍 및 JWT + 2FA 인증 시스템 개발', 'Next.js 기반 서비스 가이드 UI 개발', '대기업 디자인 시스템 및 공통 컴포넌트 설계/개발'] },
-        en: { title: 'Freelance Full-Stack Developer', role: 'Full-Stack Developer / Freelancer', responsibilities: ['Financial back-office system design and frontend tech leading (React 19 + TanStack)', 'Feature-First Architecture based domain-centric modular structure design', 'Large-scale data processing system with TanStack Router/Query/Table/Virtual', 'SSE-based real-time data streaming and JWT + 2FA authentication system', 'Next.js service guide UI development', 'Enterprise design system and shared component design/development'] },
-        jp: { title: 'フリーランスフルスタック開発者', role: 'Full-Stack Developer / Freelancer', responsibilities: ['金融バックオフィスシステム設計・フロントエンドテックリーディング (React 19 + TanStack)', 'Feature-First Architectureベースのドメイン中心モジュール化構造設計', 'TanStack Router/Query/Table/Virtualベースの大規模データ処理システム実装', 'SSEベースのリアルタイムデータストリーミング・JWT + 2FA認証システム開発', 'Next.jsサービスガイドUI開発', '大企業デザインシステム・共通コンポーネント設計/開発'] },
+        sortOrder: 1,
+        startDate: '2025',
+        endDate: null,
+        isCurrent: true,
+        ko: {
+          title: '프리랜서 풀스택 개발자',
+          role: 'Full-Stack Developer / Freelancer',
+          responsibilities: [
+            '금융권 백오피스 시스템 설계 및 프론트엔드 테크 리딩 (React 19 + TanStack)',
+            'Feature-First Architecture 기반 도메인 중심 모듈화 구조 설계',
+            'TanStack Router/Query/Table/Virtual 기반 대규모 데이터 처리 시스템 구현',
+            'SSE 기반 실시간 데이터 스트리밍 및 JWT + 2FA 인증 시스템 개발',
+            'Next.js 기반 서비스 가이드 UI 개발',
+            '대기업 디자인 시스템 및 공통 컴포넌트 설계/개발',
+          ],
+        },
+        en: {
+          title: 'Freelance Full-Stack Developer',
+          role: 'Full-Stack Developer / Freelancer',
+          responsibilities: [
+            'Financial back-office system design and frontend tech leading (React 19 + TanStack)',
+            'Feature-First Architecture based domain-centric modular structure design',
+            'Large-scale data processing system with TanStack Router/Query/Table/Virtual',
+            'SSE-based real-time data streaming and JWT + 2FA authentication system',
+            'Next.js service guide UI development',
+            'Enterprise design system and shared component design/development',
+          ],
+        },
+        jp: {
+          title: 'フリーランスフルスタック開発者',
+          role: 'Full-Stack Developer / Freelancer',
+          responsibilities: [
+            '金融バックオフィスシステム設計・フロントエンドテックリーディング (React 19 + TanStack)',
+            'Feature-First Architectureベースのドメイン中心モジュール化構造設計',
+            'TanStack Router/Query/Table/Virtualベースの大規模データ処理システム実装',
+            'SSEベースのリアルタイムデータストリーミング・JWT + 2FA認証システム開発',
+            'Next.jsサービスガイドUI開発',
+            '大企業デザインシステム・共通コンポーネント設計/開発',
+          ],
+        },
       },
       {
-        sortOrder: 2, startDate: '2024', endDate: '2025', isCurrent: false,
-        ko: { title: '대규모 사용자 IoT 서비스 webOS TV App 개발', role: 'FE Developer / PL', responsibilities: ['webOS TV 앱 아키텍처 설계부터 프로덕션 출시까지 프론트엔드 개발 리드', 'Redux 에코시스템(redux-thunk, redux-saga) 기반 상태 관리 아키텍처 설계', 'Jenkins CI/CD 파이프라인 구축 및 자동화된 빌드/배포 프로세스 최적화', '다국어 지원(미국, 독일, 러시아, 영국) 시스템 구축 및 i18n 통합 관리', 'WCAG 2.1 접근성 표준 준수 및 성능 최적화 (로딩 시간 30% 단축)', 'webOS luna API 분석 및 TV 하드웨어 리소스 최적화 연동 설계'] },
-        en: { title: 'Large-Scale IoT Service webOS TV App Development', role: 'FE Developer / PL', responsibilities: ['Led frontend development from webOS TV app architecture design to production release', 'Redux ecosystem (redux-thunk, redux-saga) based state management architecture design', 'Jenkins CI/CD pipeline and automated build/deployment process optimization', 'Multi-language support (US, Germany, Russia, UK) system and i18n integration', 'WCAG 2.1 accessibility compliance and performance optimization (30% loading time reduction)', 'webOS luna API analysis and optimized TV hardware resource integration'] },
-        jp: { title: '大規模IoTサービス webOS TV App開発', role: 'FE Developer / PL', responsibilities: ['webOS TVアプリのアーキテクチャ設計からプロダクションリリースまでフロントエンド開発をリード', 'Reduxエコシステム(redux-thunk, redux-saga)ベースの状態管理アーキテクチャ設計', 'Jenkins CI/CDパイプライン構築・自動化ビルド/デプロイプロセス最適化', '多言語対応(米国、ドイツ、ロシア、英国)システム構築・i18n統合管理', 'WCAG 2.1アクセシビリティ標準準拠・パフォーマンス最適化 (ローディング時間30%短縮)', 'webOS luna API分析・TVハードウェアリソース最適化連携設計'] },
+        sortOrder: 2,
+        startDate: '2024',
+        endDate: '2025',
+        isCurrent: false,
+        ko: {
+          title: '대규모 사용자 IoT 서비스 webOS TV App 개발',
+          role: 'FE Developer / PL',
+          responsibilities: [
+            'webOS TV 앱 아키텍처 설계부터 프로덕션 출시까지 프론트엔드 개발 리드',
+            'Redux 에코시스템(redux-thunk, redux-saga) 기반 상태 관리 아키텍처 설계',
+            'Jenkins CI/CD 파이프라인 구축 및 자동화된 빌드/배포 프로세스 최적화',
+            '다국어 지원(미국, 독일, 러시아, 영국) 시스템 구축 및 i18n 통합 관리',
+            'WCAG 2.1 접근성 표준 준수 및 성능 최적화 (로딩 시간 30% 단축)',
+            'webOS luna API 분석 및 TV 하드웨어 리소스 최적화 연동 설계',
+          ],
+        },
+        en: {
+          title: 'Large-Scale IoT Service webOS TV App Development',
+          role: 'FE Developer / PL',
+          responsibilities: [
+            'Led frontend development from webOS TV app architecture design to production release',
+            'Redux ecosystem (redux-thunk, redux-saga) based state management architecture design',
+            'Jenkins CI/CD pipeline and automated build/deployment process optimization',
+            'Multi-language support (US, Germany, Russia, UK) system and i18n integration',
+            'WCAG 2.1 accessibility compliance and performance optimization (30% loading time reduction)',
+            'webOS luna API analysis and optimized TV hardware resource integration',
+          ],
+        },
+        jp: {
+          title: '大規模IoTサービス webOS TV App開発',
+          role: 'FE Developer / PL',
+          responsibilities: [
+            'webOS TVアプリのアーキテクチャ設計からプロダクションリリースまでフロントエンド開発をリード',
+            'Reduxエコシステム(redux-thunk, redux-saga)ベースの状態管理アーキテクチャ設計',
+            'Jenkins CI/CDパイプライン構築・自動化ビルド/デプロイプロセス最適化',
+            '多言語対応(米国、ドイツ、ロシア、英国)システム構築・i18n統合管理',
+            'WCAG 2.1アクセシビリティ標準準拠・パフォーマンス最適化 (ローディング時間30%短縮)',
+            'webOS luna API分析・TVハードウェアリソース最適化連携設計',
+          ],
+        },
       },
       {
-        sortOrder: 3, startDate: '2023', endDate: '2023', isCurrent: false,
-        ko: { title: '대규모 사용자 IoT 서비스 공통 컴포넌트 개발', role: 'FE Developer', responsibilities: ['React 기반 크로스플랫폼 웹뷰 아키텍처 설계 및 성능 최적화 (로딩 속도 40% 개선)', '엔터프라이즈급 컴포넌트 라이브러리 구축 및 Storybook 인터랙티브 문서화', 'D3.js 기반 실시간 데이터 시각화 대시보드 개발', 'iOS/Android 플랫폼별 브라우저 엔진 차이 분석 및 적응형 렌더링 로직 구현', 'PropTypes + TypeScript 타입 안정성 강화로 런타임 오류 85% 감소', 'FUT(Functional Under Test) 환경 구축으로 컴포넌트 테스트 자동화'] },
-        en: { title: 'Large-Scale IoT Service Shared Component Development', role: 'FE Developer', responsibilities: ['React cross-platform webview architecture design and performance optimization (40% loading speed improvement)', 'Enterprise component library development with Storybook interactive documentation', 'D3.js real-time data visualization dashboard development', 'iOS/Android platform browser engine analysis and adaptive rendering implementation', 'PropTypes + TypeScript type safety improvements reducing runtime errors by 85%', 'FUT (Functional Under Test) environment for component test automation'] },
-        jp: { title: '大規模IoTサービス共通コンポーネント開発', role: 'FE Developer', responsibilities: ['Reactクロスプラットフォームウェブビューアーキテクチャ設計・パフォーマンス最適化 (ローディング速度40%改善)', 'エンタープライズコンポーネントライブラリ構築・Storybookインタラクティブドキュメンテーション', 'D3.jsリアルタイムデータ可視化ダッシュボード開発', 'iOS/Androidプラットフォーム別ブラウザエンジン分析・適応型レンダリング実装', 'PropTypes + TypeScript型安全性強化によりランタイムエラー85%削減', 'FUT(Functional Under Test)環境構築によるコンポーネントテスト自動化'] },
+        sortOrder: 3,
+        startDate: '2023',
+        endDate: '2023',
+        isCurrent: false,
+        ko: {
+          title: '대규모 사용자 IoT 서비스 공통 컴포넌트 개발',
+          role: 'FE Developer',
+          responsibilities: [
+            'React 기반 크로스플랫폼 웹뷰 아키텍처 설계 및 성능 최적화 (로딩 속도 40% 개선)',
+            '엔터프라이즈급 컴포넌트 라이브러리 구축 및 Storybook 인터랙티브 문서화',
+            'D3.js 기반 실시간 데이터 시각화 대시보드 개발',
+            'iOS/Android 플랫폼별 브라우저 엔진 차이 분석 및 적응형 렌더링 로직 구현',
+            'PropTypes + TypeScript 타입 안정성 강화로 런타임 오류 85% 감소',
+            'FUT(Functional Under Test) 환경 구축으로 컴포넌트 테스트 자동화',
+          ],
+        },
+        en: {
+          title: 'Large-Scale IoT Service Shared Component Development',
+          role: 'FE Developer',
+          responsibilities: [
+            'React cross-platform webview architecture design and performance optimization (40% loading speed improvement)',
+            'Enterprise component library development with Storybook interactive documentation',
+            'D3.js real-time data visualization dashboard development',
+            'iOS/Android platform browser engine analysis and adaptive rendering implementation',
+            'PropTypes + TypeScript type safety improvements reducing runtime errors by 85%',
+            'FUT (Functional Under Test) environment for component test automation',
+          ],
+        },
+        jp: {
+          title: '大規模IoTサービス共通コンポーネント開発',
+          role: 'FE Developer',
+          responsibilities: [
+            'Reactクロスプラットフォームウェブビューアーキテクチャ設計・パフォーマンス最適化 (ローディング速度40%改善)',
+            'エンタープライズコンポーネントライブラリ構築・Storybookインタラクティブドキュメンテーション',
+            'D3.jsリアルタイムデータ可視化ダッシュボード開発',
+            'iOS/Androidプラットフォーム別ブラウザエンジン分析・適応型レンダリング実装',
+            'PropTypes + TypeScript型安全性強化によりランタイムエラー85%削減',
+            'FUT(Functional Under Test)環境構築によるコンポーネントテスト自動化',
+          ],
+        },
       },
       {
-        sortOrder: 4, startDate: '2021', endDate: '2022', isCurrent: false,
-        ko: { title: '채용 플랫폼 서비스 프론트엔드 개발', role: 'FE Developer', responsibilities: ['Vue.js, React 기반 채용 플랫폼 프론트엔드 핵심 기능 설계 및 개발', '초기 스타트업 핵심 멤버로 서비스 고속 성장기 확장 및 안정화 기여', '반응형 웹 UI/UX 설계 및 사용자 경험 최적화', 'REST API 연동 및 클라이언트 상태 관리 아키텍처 설계', '재사용 가능한 컴포넌트 라이브러리 설계 및 개발', '사용자 트래픽 증가에 따른 성능 병목 분석 및 렌더링 최적화'] },
-        en: { title: 'Recruitment Platform Frontend Development', role: 'FE Developer', responsibilities: ['Core frontend feature design and development for recruitment platform with Vue.js and React', 'Contributed to service scaling and stabilization during rapid growth as an early startup member', 'Responsive web UI/UX design and user experience optimization', 'REST API integration and client state management architecture design', 'Reusable component library design and development', 'Performance bottleneck analysis and rendering optimization for growing user traffic'] },
-        jp: { title: '採用プラットフォームフロントエンド開発', role: 'FE Developer', responsibilities: ['Vue.js、Reactベースの採用プラットフォームのフロントエンドコア機能設計・開発', 'スタートアップ初期メンバーとしてサービス急成長期の拡張・安定化に貢献', 'レスポンシブウェブUI/UX設計・ユーザー体験最適化', 'REST API連携・クライアント状態管理アーキテクチャ設計', '再利用可能なコンポーネントライブラリ設計・開発', 'ユーザートラフィック増加に伴うパフォーマンスボトルネック分析・レンダリング最適化'] },
+        sortOrder: 4,
+        startDate: '2021',
+        endDate: '2022',
+        isCurrent: false,
+        ko: {
+          title: '채용 플랫폼 서비스 프론트엔드 개발',
+          role: 'FE Developer',
+          responsibilities: [
+            'Vue.js, React 기반 채용 플랫폼 프론트엔드 핵심 기능 설계 및 개발',
+            '초기 스타트업 핵심 멤버로 서비스 고속 성장기 확장 및 안정화 기여',
+            '반응형 웹 UI/UX 설계 및 사용자 경험 최적화',
+            'REST API 연동 및 클라이언트 상태 관리 아키텍처 설계',
+            '재사용 가능한 컴포넌트 라이브러리 설계 및 개발',
+            '사용자 트래픽 증가에 따른 성능 병목 분석 및 렌더링 최적화',
+          ],
+        },
+        en: {
+          title: 'Recruitment Platform Frontend Development',
+          role: 'FE Developer',
+          responsibilities: [
+            'Core frontend feature design and development for recruitment platform with Vue.js and React',
+            'Contributed to service scaling and stabilization during rapid growth as an early startup member',
+            'Responsive web UI/UX design and user experience optimization',
+            'REST API integration and client state management architecture design',
+            'Reusable component library design and development',
+            'Performance bottleneck analysis and rendering optimization for growing user traffic',
+          ],
+        },
+        jp: {
+          title: '採用プラットフォームフロントエンド開発',
+          role: 'FE Developer',
+          responsibilities: [
+            'Vue.js、Reactベースの採用プラットフォームのフロントエンドコア機能設計・開発',
+            'スタートアップ初期メンバーとしてサービス急成長期の拡張・安定化に貢献',
+            'レスポンシブウェブUI/UX設計・ユーザー体験最適化',
+            'REST API連携・クライアント状態管理アーキテクチャ設計',
+            '再利用可能なコンポーネントライブラリ設計・開発',
+            'ユーザートラフィック増加に伴うパフォーマンスボトルネック分析・レンダリング最適化',
+          ],
+        },
       },
       {
-        sortOrder: 5, startDate: '2021', endDate: '2021', isCurrent: false,
-        ko: { title: 'Web3 & 블록체인 기반 금융 서비스 개발', role: 'Full-Stack Developer', responsibilities: ['은행권 모바일 앱 UI 개발 및 사용자 인터페이스 담당', 'NFT 기반 인증 시스템 개발 (OpenSea 연동, 전자지갑 통합)', 'Web3 기술을 활용한 탈중앙화 웹 서비스 개발', '메타마스크 등 전자지갑 연동 로그인 시스템 구축', 'NFT 민팅/거래 인터페이스 설계 및 스마트 컨트랙트 연동', '블록체인 기반 사용자 인증 플로우 설계 및 구현'] },
-        en: { title: 'Web3 & Blockchain-Based Financial Service Development', role: 'Full-Stack Developer', responsibilities: ['Banking mobile app UI development and user interface management', 'NFT-based authentication system development (OpenSea integration, digital wallet)', 'Decentralized web service development utilizing Web3 technology', 'MetaMask and digital wallet login system development', 'NFT minting/trading interface design and smart contract integration', 'Blockchain-based user authentication flow design and implementation'] },
-        jp: { title: 'Web3・ブロックチェーンベース金融サービス開発', role: 'Full-Stack Developer', responsibilities: ['銀行モバイルアプリUI開発・ユーザーインターフェース担当', 'NFTベース認証システム開発 (OpenSea連携、電子ウォレット統合)', 'Web3技術を活用した分散型ウェブサービス開発', 'メタマスク等電子ウォレット連携ログインシステム構築', 'NFTミンティング/取引インターフェース設計・スマートコントラクト連携', 'ブロックチェーンベースのユーザー認証フロー設計・実装'] },
+        sortOrder: 5,
+        startDate: '2021',
+        endDate: '2021',
+        isCurrent: false,
+        ko: {
+          title: 'Web3 & 블록체인 기반 금융 서비스 개발',
+          role: 'Full-Stack Developer',
+          responsibilities: [
+            '은행권 모바일 앱 UI 개발 및 사용자 인터페이스 담당',
+            'NFT 기반 인증 시스템 개발 (OpenSea 연동, 전자지갑 통합)',
+            'Web3 기술을 활용한 탈중앙화 웹 서비스 개발',
+            '메타마스크 등 전자지갑 연동 로그인 시스템 구축',
+            'NFT 민팅/거래 인터페이스 설계 및 스마트 컨트랙트 연동',
+            '블록체인 기반 사용자 인증 플로우 설계 및 구현',
+          ],
+        },
+        en: {
+          title: 'Web3 & Blockchain-Based Financial Service Development',
+          role: 'Full-Stack Developer',
+          responsibilities: [
+            'Banking mobile app UI development and user interface management',
+            'NFT-based authentication system development (OpenSea integration, digital wallet)',
+            'Decentralized web service development utilizing Web3 technology',
+            'MetaMask and digital wallet login system development',
+            'NFT minting/trading interface design and smart contract integration',
+            'Blockchain-based user authentication flow design and implementation',
+          ],
+        },
+        jp: {
+          title: 'Web3・ブロックチェーンベース金融サービス開発',
+          role: 'Full-Stack Developer',
+          responsibilities: [
+            '銀行モバイルアプリUI開発・ユーザーインターフェース担当',
+            'NFTベース認証システム開発 (OpenSea連携、電子ウォレット統合)',
+            'Web3技術を活用した分散型ウェブサービス開発',
+            'メタマスク等電子ウォレット連携ログインシステム構築',
+            'NFTミンティング/取引インターフェース設計・スマートコントラクト連携',
+            'ブロックチェーンベースのユーザー認証フロー設計・実装',
+          ],
+        },
       },
       {
-        sortOrder: 6, startDate: '2017', endDate: '2020', isCurrent: false,
-        ko: { title: '금융 서비스 풀스택 개발', role: 'Full-Stack Developer', responsibilities: ['Java Spring 기반 금융 서비스 백엔드 시스템 설계 및 개발', '금융 데이터 처리를 위한 DB 스키마 설계 및 쿼리 최적화', '대용량 금융 트랜잭션 처리 시스템 안정성 확보', '프론트엔드 + 백엔드 풀스택 웹 서비스 구축', 'REST API 설계 및 외부 금융 API 연동 개발', '금융 보안 규정 준수를 위한 인증/인가 시스템 구현'] },
-        en: { title: 'Financial Service Full-Stack Development', role: 'Full-Stack Developer', responsibilities: ['Financial service backend system design and development with Java Spring', 'DB schema design and query optimization for financial data processing', 'High-volume financial transaction processing system stability assurance', 'Full-stack web service development (frontend + backend)', 'REST API design and external financial API integration', 'Authentication/authorization system for financial security regulation compliance'] },
-        jp: { title: '金融サービスフルスタック開発', role: 'Full-Stack Developer', responsibilities: ['Java Springベースの金融サービスバックエンドシステム設計・開発', '金融データ処理のためのDBスキーマ設計・クエリ最適化', '大容量金融トランザクション処理システムの安定性確保', 'フロントエンド + バックエンドフルスタックウェブサービス構築', 'REST API設計・外部金融API連携開発', '金融セキュリティ規定準拠のための認証/認可システム実装'] },
+        sortOrder: 6,
+        startDate: '2017',
+        endDate: '2020',
+        isCurrent: false,
+        ko: {
+          title: '금융 서비스 풀스택 개발',
+          role: 'Full-Stack Developer',
+          responsibilities: [
+            'Java Spring 기반 금융 서비스 백엔드 시스템 설계 및 개발',
+            '금융 데이터 처리를 위한 DB 스키마 설계 및 쿼리 최적화',
+            '대용량 금융 트랜잭션 처리 시스템 안정성 확보',
+            '프론트엔드 + 백엔드 풀스택 웹 서비스 구축',
+            'REST API 설계 및 외부 금융 API 연동 개발',
+            '금융 보안 규정 준수를 위한 인증/인가 시스템 구현',
+          ],
+        },
+        en: {
+          title: 'Financial Service Full-Stack Development',
+          role: 'Full-Stack Developer',
+          responsibilities: [
+            'Financial service backend system design and development with Java Spring',
+            'DB schema design and query optimization for financial data processing',
+            'High-volume financial transaction processing system stability assurance',
+            'Full-stack web service development (frontend + backend)',
+            'REST API design and external financial API integration',
+            'Authentication/authorization system for financial security regulation compliance',
+          ],
+        },
+        jp: {
+          title: '金融サービスフルスタック開発',
+          role: 'Full-Stack Developer',
+          responsibilities: [
+            'Java Springベースの金融サービスバックエンドシステム設計・開発',
+            '金融データ処理のためのDBスキーマ設計・クエリ最適化',
+            '大容量金融トランザクション処理システムの安定性確保',
+            'フロントエンド + バックエンドフルスタックウェブサービス構築',
+            'REST API設計・外部金融API連携開発',
+            '金融セキュリティ規定準拠のための認証/認可システム実装',
+          ],
+        },
       },
     ];
 
@@ -116,22 +358,65 @@ async function main() {
     // ─── Projects ─────────────────────────────────────────────────────────────
     const projects = [
       {
-        sortOrder: 1, demoUrl: 'https://chahyunwoo.dev', repoUrl: null, techStack: ['Next.js', 'TypeScript', 'Tailwind CSS', 'MDX', 'Vercel'], featured: true,
-        ko: { title: 'hyunwoo.dev', description: 'Next.js 16 기반 개인 기술 블로그. MDX 콘텐츠, Cmd+K 검색, SEO 최적화.' },
-        en: { title: 'hyunwoo.dev', description: 'Personal tech blog built with Next.js 16. MDX content, Cmd+K search, SEO optimized.' },
-        jp: { title: 'hyunwoo.dev', description: 'Next.js 16ベースの個人技術ブログ。MDXコンテンツ、Cmd+K検索、SEO最適化。' },
+        sortOrder: 1,
+        demoUrl: 'https://chahyunwoo.dev',
+        repoUrl: null,
+        techStack: ['Next.js', 'TypeScript', 'Tailwind CSS', 'MDX', 'Vercel'],
+        featured: true,
+        ko: {
+          title: 'hyunwoo.dev',
+          description: 'Next.js 16 기반 개인 기술 블로그. MDX 콘텐츠, Cmd+K 검색, SEO 최적화.',
+        },
+        en: {
+          title: 'hyunwoo.dev',
+          description:
+            'Personal tech blog built with Next.js 16. MDX content, Cmd+K search, SEO optimized.',
+        },
+        jp: {
+          title: 'hyunwoo.dev',
+          description: 'Next.js 16ベースの個人技術ブログ。MDXコンテンツ、Cmd+K検索、SEO最適化。',
+        },
       },
       {
-        sortOrder: 2, demoUrl: null, repoUrl: 'https://github.com/chahyunwoo/github-tier', techStack: ['Hono', 'TypeScript', 'Vercel Edge Functions', 'GitHub API'], featured: true,
-        ko: { title: 'GitHub Tier', description: 'GitHub 활동을 분석해 롤 티어 스타일 랭크 카드를 생성하는 오픈소스 위젯.' },
-        en: { title: 'GitHub Tier', description: 'Open-source widget that generates LoL-style tier rank cards based on GitHub activity.' },
-        jp: { title: 'GitHub Tier', description: 'GitHub活動を分析してLoLスタイルのティアランクカードを生成するオープンソースウィジェット。' },
+        sortOrder: 2,
+        demoUrl: null,
+        repoUrl: 'https://github.com/chahyunwoo/github-tier',
+        techStack: ['Hono', 'TypeScript', 'Vercel Edge Functions', 'GitHub API'],
+        featured: true,
+        ko: {
+          title: 'GitHub Tier',
+          description: 'GitHub 활동을 분석해 롤 티어 스타일 랭크 카드를 생성하는 오픈소스 위젯.',
+        },
+        en: {
+          title: 'GitHub Tier',
+          description:
+            'Open-source widget that generates LoL-style tier rank cards based on GitHub activity.',
+        },
+        jp: {
+          title: 'GitHub Tier',
+          description:
+            'GitHub活動を分析してLoLスタイルのティアランクカードを生成するオープンソースウィジェット。',
+        },
       },
       {
-        sortOrder: 3, demoUrl: 'https://discord.gg/fgwtkprgyg', repoUrl: null, techStack: ['Python', 'discord.py', 'Docker', 'AWS', 'GitHub Actions'], featured: true,
-        ko: { title: 'Discord Multi-Bot', description: '열차 예매 보조, 실시간 주유 최저가 알림 등 다기능 디스코드 봇.' },
-        en: { title: 'Discord Multi-Bot', description: 'Multi-feature Discord bot with train booking assistance and real-time gas price alerts.' },
-        jp: { title: 'Discord Multi-Bot', description: '列車予約補助、リアルタイム給油最安値アラートなど多機能Discordボット。' },
+        sortOrder: 3,
+        demoUrl: 'https://discord.gg/fgwtkprgyg',
+        repoUrl: null,
+        techStack: ['Python', 'discord.py', 'Docker', 'AWS', 'GitHub Actions'],
+        featured: true,
+        ko: {
+          title: 'Discord Multi-Bot',
+          description: '열차 예매 보조, 실시간 주유 최저가 알림 등 다기능 디스코드 봇.',
+        },
+        en: {
+          title: 'Discord Multi-Bot',
+          description:
+            'Multi-feature Discord bot with train booking assistance and real-time gas price alerts.',
+        },
+        jp: {
+          title: 'Discord Multi-Bot',
+          description: '列車予約補助、リアルタイム給油最安値アラートなど多機能Discordボット。',
+        },
       },
     ];
 
@@ -157,10 +442,28 @@ async function main() {
 
     // ─── Skills ───────────────────────────────────────────────────────────────
     const skillData = [
-      { category: 'Frontend', items: ['TypeScript', 'React', 'Next.js', 'Vue.js', 'Tailwind CSS', 'Redux', 'Zustand', 'TanStack Query'] },
-      { category: 'Backend', items: ['Node.js', 'Python', 'Java Spring', 'FastAPI', 'PostgreSQL', 'Docker'] },
+      {
+        category: 'Frontend',
+        items: [
+          'TypeScript',
+          'React',
+          'Next.js',
+          'Vue.js',
+          'Tailwind CSS',
+          'Redux',
+          'Zustand',
+          'TanStack Query',
+        ],
+      },
+      {
+        category: 'Backend',
+        items: ['Node.js', 'Python', 'Java Spring', 'FastAPI', 'PostgreSQL', 'Docker'],
+      },
       { category: 'Mobile', items: ['React Native', 'Flutter'] },
-      { category: 'DevOps & Tools', items: ['GitHub Actions', 'Jenkins', 'AWS', 'Vercel', 'Docker', 'Figma'] },
+      {
+        category: 'DevOps & Tools',
+        items: ['GitHub Actions', 'Jenkins', 'AWS', 'Vercel', 'Docker', 'Figma'],
+      },
     ];
 
     let skillOrder = 0;
@@ -176,13 +479,21 @@ async function main() {
     // ─── Education ────────────────────────────────────────────────────────────
     const educationData = [
       {
-        period: '2011 - 2017', sortOrder: 1,
+        period: '2011 - 2017',
+        sortOrder: 1,
         ko: { institution: '숭실대학교', degree: '회계학 학사, 컴퓨터공학 부전공' },
-        en: { institution: 'Soongsil University', degree: 'Bachelor of Accounting, Computer Science Minor' },
-        jp: { institution: 'SOONGSIL UNIVERSITY', degree: '会計学 学士, コンピュータサイエンス 副専攻' },
+        en: {
+          institution: 'Soongsil University',
+          degree: 'Bachelor of Accounting, Computer Science Minor',
+        },
+        jp: {
+          institution: 'SOONGSIL UNIVERSITY',
+          degree: '会計学 学士, コンピュータサイエンス 副専攻',
+        },
       },
       {
-        period: '2024 - 2025', sortOrder: 2,
+        period: '2024 - 2025',
+        sortOrder: 2,
         ko: { institution: '학점은행제', degree: '컴퓨터공학 학사' },
         en: { institution: 'ACBS', degree: 'Bachelor of Computer Science' },
         jp: { institution: 'ACBS', degree: 'コンピュータサイエンス 学士' },

--- a/scripts/seed-posts.ts
+++ b/scripts/seed-posts.ts
@@ -267,7 +267,9 @@ async function main() {
       created++;
     }
 
-    console.log(`\nDone: ${created} created, ${skipped} skipped, ${totalImages} post images uploaded`);
+    console.log(
+      `\nDone: ${created} created, ${skipped} skipped, ${totalImages} post images uploaded`,
+    );
   } finally {
     await prisma.$disconnect();
   }

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -13,7 +13,14 @@ import {
   Req,
   UnauthorizedException,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiConsumes, ApiCookieAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiConsumes,
+  ApiCookieAuth,
+  ApiOkResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
 import { AuthService } from '../auth/auth.service';
 import { Public } from '../common/decorators/public.decorator';
 import {
@@ -27,6 +34,7 @@ import type { MultipartRequest } from '../types/fastify.d';
 import { BlogService } from './blog.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { CreatePostDto } from './dto/create-post.dto';
+import { PostListResponseDto } from './dto/post-list-response.dto';
 import { PostQueryDto, RecentQueryDto, SearchQueryDto, TagQueryDto } from './dto/post-query.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 
@@ -49,6 +57,7 @@ export class BlogController {
   @Public()
   @ApiSecurity('api-key')
   @Get('posts')
+  @ApiOkResponse({ type: PostListResponseDto })
   findAll(@Query() query: PostQueryDto, @Req() req: MultipartRequest) {
     const isAdmin = this.authService.isAuthenticated(req.cookies?.access_token);
     return this.blogService.findAll(query, isAdmin);

--- a/src/blog/dto/post-list-response.dto.ts
+++ b/src/blog/dto/post-list-response.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * GET /api/blog/posts 응답 스키마.
+ *
+ * 실제 반환 shape는 BlogService.findAll() → formatPost()가 만든다.
+ * formatPost는 `const { postTags, content, ...rest } = post`로 Post의 content를 뺀
+ * 전 스칼라 필드를 그대로 싣고, postTags를 Tag 배열로 펼친다.
+ * 따라서 여기 필드는 prisma/schema.prisma의 model Post / model Tag와 1:1로 맞춰야 하며,
+ * nullable도 스키마와 동일해야 한다.
+ */
+export class PostTagDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'React' })
+  name: string;
+
+  @ApiProperty({ example: 'react' })
+  slug: string;
+}
+
+export class PostSummaryDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'Next.js 15 App Router 완전 정복' })
+  title: string;
+
+  @ApiProperty({ example: 'nextjs-15-app-router' })
+  slug: string;
+
+  @ApiProperty({ type: String, nullable: true, description: '미입력 시 content에서 자동 추출' })
+  description: string | null;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    example: 'https://assets.chahyunwoo.dev/thumbnail/example.png',
+  })
+  thumbnailUrl: string | null;
+
+  @ApiProperty({ type: String, nullable: true, example: 'Frontend' })
+  category: string | null;
+
+  @ApiProperty({ example: true })
+  published: boolean;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  publishedAt: string | null;
+
+  @ApiProperty({ example: 5, description: '분 단위 예상 읽기 시간' })
+  readingTime: number;
+
+  @ApiProperty({ example: 128 })
+  viewCount: number;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt: string;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  updatedAt: string;
+
+  @ApiProperty({ type: [PostTagDto] })
+  tags: PostTagDto[];
+}
+
+export class PostListResponseDto {
+  @ApiProperty({ type: [PostSummaryDto] })
+  posts: PostSummaryDto[];
+
+  @ApiProperty({ example: 40, description: '필터 조건에 맞는 전체 건수' })
+  total: number;
+
+  @ApiProperty({ example: 1 })
+  page: number;
+
+  @ApiProperty({ example: 10 })
+  limit: number;
+
+  @ApiProperty({ example: 4 })
+  totalPages: number;
+}

--- a/src/common/swagger/swagger.config.ts
+++ b/src/common/swagger/swagger.config.ts
@@ -1,0 +1,18 @@
+import { DocumentBuilder } from '@nestjs/swagger';
+
+/**
+ * Swagger 문서 설정 단일 출처.
+ *
+ * main.ts의 /docs와 scripts/generate-openapi.ts의 openapi.json이 같은 설정을 쓰도록
+ * 여기 한 곳에서만 만든다. 양쪽에 DocumentBuilder를 각각 두면 스펙이 조용히 갈라진다.
+ */
+export function buildSwaggerConfig() {
+  return new DocumentBuilder()
+    .setTitle('Hyunwoo API')
+    .setDescription('chahyunwoo.dev blog & portfolio API')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .addCookieAuth('access_token')
+    .addApiKey({ type: 'apiKey', name: 'x-api-key', in: 'header' }, 'api-key')
+    .build();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,10 @@ import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { SwaggerModule } from '@nestjs/swagger';
 
 import { AppModule } from './app.module';
+import { buildSwaggerConfig } from './common/swagger/swagger.config';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -41,15 +42,7 @@ async function bootstrap() {
   );
 
   if (config.get('NODE_ENV') !== 'production') {
-    const swaggerConfig = new DocumentBuilder()
-      .setTitle('Hyunwoo API')
-      .setDescription('chahyunwoo.dev blog & portfolio API')
-      .setVersion('1.0')
-      .addBearerAuth()
-      .addCookieAuth('access_token')
-      .addApiKey({ type: 'apiKey', name: 'x-api-key', in: 'header' }, 'api-key')
-      .build();
-    const document = SwaggerModule.createDocument(app, swaggerConfig);
+    const document = SwaggerModule.createDocument(app, buildSwaggerConfig());
     SwaggerModule.setup('docs', app, document);
   }
 


### PR DESCRIPTION
로컬에만 있던 #102 작업을 원격에 올린다. 커밋 3개는 이 세션 이전에 작성된 것으로, 내용을 바꾸지 않고 그대로 푸시했다.

- `GET /api/blog/posts`에 응답 스키마 선언 (`PostListResponseDto`)
- `pnpm openapi:generate` — `scripts/generate-openapi.ts`가 앱을 listen하지 않고 문서만 만들어 루트 `openapi.json`으로 덤프
- CI의 OpenAPI spec drift check
- 코드리뷰 반영: 린트 범위에 `scripts` 포함, CLAUDE.md 정정

## 짝이 되는 프론트 작업

**이 PR은 hyunwoo-dev의 #126(`feature/118`)과 짝이다.** 그쪽이 이 저장소의 `openapi.json`을 받아(`pnpm api:sync`) `openapi-typescript`로 타입을 생성한다. 두 저장소 어느 쪽도 병합되지 않으면 파이프라인이 연결되지 않는다.

## 현황

72개 오퍼레이션 중 성공 응답 스키마가 있는 건 이 PR로 1개가 된다:

```
$ jq '[.paths|to_entries[]|.value|to_entries[]]|length' openapi.json
72

$ jq -r '[.paths|to_entries[]|.key as $p|.value|to_entries[]|select((.value.responses["200"].content["application/json"]//.value.responses["201"].content["application/json"])!=null)|"\($p) \(.key)"]|.[]' openapi.json
/api/blog/posts get

$ jq -r '[.paths|to_entries[]|.key as $p|.value|to_entries[]|select(.value.responses["204"]!=null)|"\($p) \(.key|ascii_upcase)"]|.[]' openapi.json
/api/analytics/pageview POST
/api/auth/logout POST
/api/auth/logout-all POST
/api/blog/categories/{id} DELETE
```

나머지 67개(204 제외)는 #103에서 다룬다. 그때까지 프론트는 `ApiOkJson`을 이 라우트 하나에만 쓸 수 있다 — 스키마가 없는 라우트에 쓰면 `MissingResponseSchema` 브랜딩 때문에 컴파일이 터진다(의도된 동작).

## 관련 PR

- #113 — 운영 버그 3건 수정 + 테스트 기반 (#107 #108 #110 #104)
- #114 — 타입 게이트 공백 두 건 (#105 #106)

셋 다 서로 독립이고 파일이 겹치지 않는다.
