### PR TITLE
fix(portfolio): SocialLinkDto에 icon 필드 누락 (#103)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6369,16 +6369,22 @@
         "properties": {
           "name": {
             "type": "string",
-            "example": "GitHub"
+            "example": "Github"
           },
           "href": {
             "type": "string",
             "example": "https://github.com/chahyunwoo"
+          },
+          "icon": {
+            "type": "string",
+            "example": "Github",
+            "description": "lucide 아이콘 이름(대소문자 무관)"
           }
         },
         "required": [
           "name",
-          "href"
+          "href",
+          "icon"
         ]
       },
       "ProfileDto": {

--- a/src/portfolio/dto/portfolio-response.dto.spec.ts
+++ b/src/portfolio/dto/portfolio-response.dto.spec.ts
@@ -144,6 +144,8 @@ describe('portfolio 응답 스키마', () => {
       ['SkillItemDto', ['id', 'name', 'proficiency', 'description']],
       ['LocaleDto', ['id', 'code', 'label']],
       ['ContactResultDto', ['success', 'message']],
+      // icon이 빠지면 포트폴리오 연락처 섹션이 아이콘을 고르지 못한다
+      ['SocialLinkDto', ['name', 'href', 'icon']],
       ['UploadUrlResponseDto', ['url']],
     ])('%s', (name, fields) => {
       expect([...propsOf(spec.components.schemas[name])].sort()).toEqual([...fields].sort());

--- a/src/portfolio/dto/portfolio-response.dto.ts
+++ b/src/portfolio/dto/portfolio-response.dto.ts
@@ -18,12 +18,23 @@ import { ApiProperty } from '@nestjs/swagger';
 
 // ─── 공통 ─────────────────────────────────────────────────────────────────────
 
+/**
+ * `profiles.social_links`(JSON 컬럼)의 요소.
+ *
+ * `icon`은 프론트가 실제로 쓴다 — 포트폴리오 연락처 섹션이 이 값으로 lucide
+ * 아이콘을 고른다(`contact-section.tsx`의 `ICON_MAP[link.icon.toLowerCase()]`).
+ * 처음 이 DTO를 쓸 때 `name`/`href`만 선언했다가, 프론트를 생성 타입으로
+ * 전환하면서 컴파일 에러로 드러났다.
+ */
 export class SocialLinkDto {
-  @ApiProperty({ example: 'GitHub' })
+  @ApiProperty({ example: 'Github' })
   name: string;
 
   @ApiProperty({ example: 'https://github.com/chahyunwoo' })
   href: string;
+
+  @ApiProperty({ example: 'Github', description: 'lucide 아이콘 이름(대소문자 무관)' })
+  icon: string;
 }
 
 /** 업로드 응답 — `POST /profile/image`, `POST /profile/icon`. */


### PR DESCRIPTION
`SocialLinkDto`에 `icon`이 빠져 있었다. **스펙이 실제보다 좁아서 프론트가 멀쩡한 코드를 못 쓰게 되는** 형태다.

## 실제 데이터에는 icon이 있다

```
$ select social_links from portfolio.profiles limit 1;
[{"href": "https://github.com/chahyunwoo", "icon": "Github", "name": "Github"},
 {"href": "https://www.instagram.com/chwzp", "icon": "Instagram", "name": "Instagram"},
 {"href": "https://www.linkedin.com/in/chahyunwoo", "icon": "Linkedin", "name": "Linkedin"}]
```

**프론트가 이 값을 실제로 쓴다.** 포트폴리오 연락처 섹션이 이걸로 lucide 아이콘을 고른다:

```tsx
// apps/portfolio/src/widgets/contact/contact-section.tsx
const Icon = ICON_MAP[link.icon.toLowerCase()] ?? Globe
```

## 어떻게 드러났나

프론트를 생성 타입으로 전환하다(hyunwoo-dev #119) 컴파일 에러로 잡혔다:

```
src/widgets/contact/contact-section.tsx(37,38): error TS2339:
  Property 'icon' does not exist on type '{ name: string; href: string; }'
```

#103에서 DTO를 쓸 때 서비스 코드의 `socialLinks: profile.socialLinks`만 보고 JSON 컬럼의 내부 구조를 확인하지 않은 것이 원인이다. 그 컬럼은 Prisma가 `Json` 타입으로만 알고 있어 서비스 코드에는 구조가 드러나지 않는다.

## 검증

실제 응답과 대조 (테스트 DB):

```
실제 socialLinks[0] 키: ['href', 'icon', 'name']
DTO  키:               ['href', 'icon', 'name']
```

```
$ pnpm test → Tests: 127 passed
```

테스트에 `SocialLinkDto`의 필드 집합을 고정했다 — 다시 빠지면 실패한다.

## 관련

이 PR이 병합되어야 hyunwoo-dev #119의 portfolio 전환이 완료된다. 프론트는 스펙을 동기화(`pnpm api:sync`)해서 쓴다.
