### PR TITLE
fix: 스펙 오류 2건 — referrer category enum, 카테고리 목록 id 누락 (#134)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5512,8 +5512,13 @@
           },
           "category": {
             "type": "string",
-            "example": "search",
-            "description": "direct | search | social | other"
+            "enum": [
+              "direct",
+              "search",
+              "social",
+              "other"
+            ],
+            "example": "search"
           },
           "count": {
             "type": "number",

--- a/openapi.json
+++ b/openapi.json
@@ -6025,6 +6025,11 @@
       "CategoryWithTagsDto": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "number",
+            "nullable": true,
+            "example": 1
+          },
           "category": {
             "type": "string",
             "example": "Frontend"
@@ -6053,6 +6058,7 @@
           }
         },
         "required": [
+          "id",
           "category",
           "icon",
           "count",

--- a/src/analytics/dto/analytics-response.dto.ts
+++ b/src/analytics/dto/analytics-response.dto.ts
@@ -151,8 +151,13 @@ export class ReferrerItemDto {
   @ApiProperty({ example: 'google.com' })
   source: string;
 
-  @ApiProperty({ example: 'search', description: 'direct | search | social | other' })
-  category: string;
+  /**
+   * 자유 문자열이 아니라 `categorizeReferrer()`가 넷 중 하나로만 채운다.
+   * 프론트가 이 값을 색·라벨 매핑의 키로 쓰므로(`Record<ReferrerCategory, string>`)
+   * `string`으로 열어두면 인덱싱이 막힌다.
+   */
+  @ApiProperty({ enum: ['direct', 'search', 'social', 'other'], example: 'search' })
+  category: 'direct' | 'search' | 'social' | 'other';
 
   @ApiProperty({ example: 30 })
   count: number;

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -199,6 +199,9 @@ export class BlogService {
 
     const recentSet = new Set(recentCategories.map(r => r.category));
     const iconMap = new Map(categoryMeta.map(c => [c.name, c.icon]));
+    // 어드민이 수정·삭제할 때 쓴다. 이 라우트가 카테고리 목록의 유일한 출처인데
+    // id가 없어서, 프론트가 이름을 경로에 넣어 호출하다 400을 맞고 있었다.
+    const idMap = new Map(categoryMeta.map(c => [c.name, c.id]));
 
     // 태그 카운트 집계
     const tagMap = new Map<string, Map<string, { name: string; slug: string; count: number }>>();
@@ -219,6 +222,7 @@ export class BlogService {
 
     const result = categoryCounts
       .map(c => ({
+        id: idMap.get(c.category as string) ?? null,
         category: c.category as string,
         icon: iconMap.get(c.category as string) ?? DEFAULT_CATEGORY_ICON,
         count: c._count,

--- a/src/blog/dto/blog-response.dto.spec.ts
+++ b/src/blog/dto/blog-response.dto.spec.ts
@@ -121,7 +121,9 @@ describe('blog 응답 스키마', () => {
       ['PostSearchResponseDto', ['posts', 'total', 'query', 'grouped']],
       ['RelatedPostsResponseDto', ['related', 'recommended']],
       ['TagListResponseDto', ['tags', 'total']],
-      ['CategoryWithTagsDto', ['category', 'icon', 'count', 'recent', 'tags']],
+      // id가 빠지면 어드민이 카테고리를 수정·삭제할 수단을 잃는다
+      // (PUT|DELETE /categories/{id}가 ParseIntPipe로 id를 받는다)
+      ['CategoryWithTagsDto', ['id', 'category', 'icon', 'count', 'recent', 'tags']],
       ['CategoryDto', ['id', 'name', 'icon', 'sortOrder']],
       ['UploadImageResponseDto', ['url']],
       ['TagCountDto', ['name', 'slug', 'count']],

--- a/src/blog/dto/blog-response.dto.ts
+++ b/src/blog/dto/blog-response.dto.ts
@@ -38,6 +38,16 @@ export class TagCountDto {
 
 /** `GET /api/blog/categories` — 카테고리별 글 수와 그 안의 태그 집계. */
 export class CategoryWithTagsDto {
+  /**
+   * 어드민의 수정·삭제가 이 값을 쓴다(`PUT|DELETE /categories/{id}`).
+   *
+   * nullable인 이유: 이 목록은 **발행된 글의 category 값**을 groupBy한 것이라,
+   * categories 테이블에 없는 이름이 글에 들어가 있으면 매칭되는 레코드가 없다.
+   * 그 경우 수정·삭제 대상이 아니므로 프론트가 버튼을 감춰야 한다.
+   */
+  @ApiProperty({ type: Number, nullable: true, example: 1 })
+  id: number | null;
+
   @ApiProperty({ example: 'Frontend' })
   category: string;
 


### PR DESCRIPTION
프론트를 생성 타입으로 전환하는 과정에서(hyunwoo-dev #120) 드러난 스펙 오류 둘을 고친다. **둘 다 스펙이 실제와 달라 프론트가 제대로 된 코드를 못 쓰게 만드는** 형태다.

## 1. `ReferrerItemDto.category`를 enum으로 좁힌다

`category`를 `string`으로 선언했지만 자유 문자열이 아니다. `categorizeReferrer()`가 넷 중 하나로만 채운다:

```ts
// src/analytics/analytics.service.ts:44-47
if (SEARCH_DOMAINS.has(domain)) return 'search';
if (SOCIAL_DOMAINS.has(domain)) return 'social';
return 'other';
// :259  category: 'direct',
```

프론트는 이 값을 색·라벨 매핑의 **키**로 쓴다:

```
src/pages/dashboard/dashboard-page.tsx(189,57): error TS7053:
  Element implicitly has an 'any' type because expression of type 'string'
  can't be used to index type 'Record<ReferrerCategory, string>'.
```

프론트에서 단언으로 좁힐 수도 있지만 그건 스펙이 실제보다 넓다는 사실을 가릴 뿐이다. **값의 범위를 아는 쪽이 선언하는 것이 맞다.**

```
$ jq '.components.schemas.ReferrerItemDto.properties.category' openapi.json
{ "type": "string", "enum": ["direct","search","social","other"], "example": "search" }
```

## 2. 카테고리 목록에 `id`를 실어 어드민 수정·삭제를 가능하게 (#134)

**이건 실제 버그다. 어드민에서 카테고리 수정·삭제가 항상 400으로 실패하고 있었다.**

프론트는 카테고리 **이름**을 경로에 넣는데:
```ts
adminApi.put(`api/blog/categories/${encodeURIComponent(category)}`, ...)
```
백엔드는 **id**를 받는다:
```ts
@Put('categories/:id')
updateCategory(@Param('id', ParseIntPipe) id: number, ...)
```

재현 (테스트 DB):
```
$ curl -X PUT .../api/blog/categories/Frontend -d '{"name":"x"}'
400 "Validation failed (numeric string is expected)"

$ curl -X PUT .../api/blog/categories/1 -d '{"name":"x"}'
200
```

프론트가 id를 보내려 해도 방법이 없었다 — `GET /api/blog/categories`가 이름만 주고 id를 안 줬다. 그래서 백엔드를 고친다.

`getCategories`가 `id`를 함께 돌려준다. `categoryMeta`(= `category.findMany()`)를 이미 조회하고 있어 **추가 쿼리는 없다** — `iconMap`과 같은 자리에서 `idMap`을 만든다.

`id`는 nullable이다. 이 목록은 발행된 글의 `category` 값을 groupBy한 것이라, categories 테이블에 없는 이름이 글에 들어가 있으면 매칭되는 레코드가 없다. 그 경우 수정·삭제 대상이 아니므로 프론트가 버튼을 감춰야 한다.

검증:
```
GET /api/blog/categories → [{ id: 1, category: "Frontend", count: 1, ... }]
PUT /api/blog/categories/1 → 200
```

## 왜 지금까지 안 드러났나

카테고리 CRUD에 테스트가 없고, 경로를 템플릿 문자열로 조립하므로 타입도 잡지 못한다. `ENDPOINTS`를 스펙에 묶으면서 `categoryById(id: number)`와 호출부 인자가 어긋나며 드러났다.

## 검증

```
$ pnpm lint:ci   → error 0
$ pnpm typecheck → exit 0
$ pnpm test      → Tests: 128 passed
$ pnpm openapi:generate → drift 없음
```

두 DTO의 필드 집합을 테스트에 고정했다 — `id`나 enum이 빠지면 실패한다.

## 후속

프론트에서 호출부를 id 기반으로 바꾸는 작업은 [hyunwoo-dev #134](https://github.com/chahyunwoo/hyunwoo-dev/issues/134)에서 이어간다. 이 PR이 그 선행 조건이다.
