### PR TITLE
release: 스펙 커버리지 완성 + 카테고리 수정·삭제 버그 수정

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5512,8 +5512,13 @@
           },
           "category": {
             "type": "string",
-            "example": "search",
-            "description": "direct | search | social | other"
+            "enum": [
+              "direct",
+              "search",
+              "social",
+              "other"
+            ],
+            "example": "search"
           },
           "count": {
             "type": "number",

--- a/openapi.json
+++ b/openapi.json
@@ -6025,6 +6025,11 @@
       "CategoryWithTagsDto": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "number",
+            "nullable": true,
+            "example": 1
+          },
           "category": {
             "type": "string",
             "example": "Frontend"
@@ -6053,6 +6058,7 @@
           }
         },
         "required": [
+          "id",
           "category",
           "icon",
           "count",

--- a/openapi.json
+++ b/openapi.json
@@ -902,6 +902,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostSearchResponseDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1019,6 +1029,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostDetailDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1143,7 +1163,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PostSummaryDto"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1162,7 +1192,17 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CategoryWithTagsDto"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1189,7 +1229,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1230,7 +1277,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1292,7 +1346,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagListResponseDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1319,6 +1380,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostDetailDto"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -1383,6 +1454,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostDetailDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -1572,6 +1653,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostDetailDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -1659,6 +1750,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RelatedPostsResponseDto"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -1706,6 +1807,16 @@
         "operationId": "BlogController_uploadImage",
         "parameters": [],
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadImageResponseDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4750,6 +4861,47 @@
           "tags"
         ]
       },
+      "PostSearchResponseDto": {
+        "type": "object",
+        "properties": {
+          "posts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostSummaryDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "example": 3,
+            "description": "검색 조건에 맞는 전체 건수"
+          },
+          "query": {
+            "type": "string",
+            "example": "react",
+            "description": "검색어(요청의 q를 그대로 되돌려준다)"
+          },
+          "grouped": {
+            "type": "object",
+            "description": "카테고리명을 키로 묶은 결과. 카테고리가 없는 글은 \"Uncategorized\"로 묶인다.",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/PostSummaryDto"
+              }
+            },
+            "example": {
+              "Frontend": [],
+              "Backend": []
+            }
+          }
+        },
+        "required": [
+          "posts",
+          "total",
+          "query",
+          "grouped"
+        ]
+      },
       "PostListResponseDto": {
         "type": "object",
         "properties": {
@@ -4785,6 +4937,67 @@
           "totalPages"
         ]
       },
+      "TagCountDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "React"
+          },
+          "slug": {
+            "type": "string",
+            "example": "react"
+          },
+          "count": {
+            "type": "number",
+            "example": 12,
+            "description": "이 카테고리 안에서 이 태그가 붙은 글 수"
+          }
+        },
+        "required": [
+          "name",
+          "slug",
+          "count"
+        ]
+      },
+      "CategoryWithTagsDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "example": "Frontend"
+          },
+          "icon": {
+            "type": "string",
+            "example": "Monitor",
+            "description": "lucide 아이콘 이름"
+          },
+          "count": {
+            "type": "number",
+            "example": 8,
+            "description": "이 카테고리의 발행된 글 수"
+          },
+          "recent": {
+            "type": "boolean",
+            "example": true,
+            "description": "최근 기간 내 새 글이 있는지"
+          },
+          "tags": {
+            "description": "count 내림차순",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagCountDto"
+            }
+          }
+        },
+        "required": [
+          "category",
+          "icon",
+          "count",
+          "recent",
+          "tags"
+        ]
+      },
       "CreateCategoryDto": {
         "type": "object",
         "properties": {
@@ -4804,6 +5017,163 @@
         },
         "required": [
           "name"
+        ]
+      },
+      "CategoryDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "example": "Frontend"
+          },
+          "icon": {
+            "type": "string",
+            "example": "Monitor",
+            "description": "lucide 아이콘 이름"
+          },
+          "sortOrder": {
+            "type": "number",
+            "example": 1
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "icon",
+          "sortOrder"
+        ]
+      },
+      "TagListResponseDto": {
+        "type": "object",
+        "properties": {
+          "tags": {
+            "description": "글 수 내림차순. 참조가 0인 태그는 제외된다.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagCountDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "example": 75,
+            "description": "실제로 글에 붙어 있는 태그의 총 개수"
+          }
+        },
+        "required": [
+          "tags",
+          "total"
+        ]
+      },
+      "PostDetailDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "title": {
+            "type": "string",
+            "example": "Next.js 15 App Router 완전 정복"
+          },
+          "slug": {
+            "type": "string",
+            "example": "nextjs-15-app-router"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "미입력 시 content에서 자동 추출"
+          },
+          "thumbnailUrl": {
+            "type": "string",
+            "nullable": true,
+            "example": "https://assets.chahyunwoo.dev/thumbnail/example.png"
+          },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "example": "Frontend"
+          },
+          "published": {
+            "type": "boolean",
+            "example": true
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "readingTime": {
+            "type": "number",
+            "example": 5,
+            "description": "분 단위 예상 읽기 시간"
+          },
+          "viewCount": {
+            "type": "number",
+            "example": 128
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostTagDto"
+            }
+          },
+          "content": {
+            "type": "string",
+            "description": "MDX 원문",
+            "example": "# 제목\n\n본문입니다."
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "slug",
+          "description",
+          "thumbnailUrl",
+          "category",
+          "published",
+          "publishedAt",
+          "readingTime",
+          "viewCount",
+          "createdAt",
+          "updatedAt",
+          "tags",
+          "content"
+        ]
+      },
+      "RelatedPostsResponseDto": {
+        "type": "object",
+        "properties": {
+          "related": {
+            "description": "태그가 겹치는 글 (겹친 수 내림차순)",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostSummaryDto"
+            }
+          },
+          "recommended": {
+            "description": "related가 목표 수에 못 미칠 때 최신 글로 채운 분",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostSummaryDto"
+            }
+          }
+        },
+        "required": [
+          "related",
+          "recommended"
         ]
       },
       "CreatePostDto": {
@@ -4897,6 +5267,18 @@
             }
           }
         }
+      },
+      "UploadImageResponseDto": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "example": "https://assets.chahyunwoo.dev/blog/temp/abc123.png"
+          }
+        },
+        "required": [
+          "url"
+        ]
       },
       "CreateLocaleDto": {
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -6369,16 +6369,22 @@
         "properties": {
           "name": {
             "type": "string",
-            "example": "GitHub"
+            "example": "Github"
           },
           "href": {
             "type": "string",
             "example": "https://github.com/chahyunwoo"
+          },
+          "icon": {
+            "type": "string",
+            "example": "Github",
+            "description": "lucide 아이콘 이름(대소문자 무관)"
           }
         },
         "required": [
           "name",
-          "href"
+          "href",
+          "icon"
         ]
       },
       "ProfileDto": {

--- a/openapi.json
+++ b/openapi.json
@@ -1471,6 +1471,9 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": "No Content"
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -2842,6 +2845,9 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": "No Content"
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -3084,6 +3090,9 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": "No Content"
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -3326,6 +3335,9 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": "No Content"
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -3568,6 +3580,9 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": "No Content"
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -3804,6 +3819,9 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": "No Content"
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -4154,6 +4172,9 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": "No Content"
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -4450,6 +4471,9 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": "No Content"
+          },
           "401": {
             "description": "Unauthorized",
             "content": {

--- a/openapi.json
+++ b/openapi.json
@@ -1899,7 +1899,17 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LocaleDto"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1925,6 +1935,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocaleDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2047,6 +2067,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2133,6 +2163,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileWithTranslationsDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -2183,6 +2223,16 @@
         "operationId": "PortfolioController_getProfileWithTranslations",
         "parameters": [],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileWithTranslationsDto"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -2240,6 +2290,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ExperienceDto"
+                  }
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2295,6 +2358,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExperienceRecordDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2394,6 +2467,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectDto"
+                  }
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2449,6 +2535,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectRecordDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2531,7 +2627,17 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SkillGroupDto"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -2557,6 +2663,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillRecordDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2659,6 +2775,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkDto"
+                  }
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2714,6 +2843,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkRecordDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2804,6 +2943,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkDetailDto"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -2868,6 +3017,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkRecordDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -3049,6 +3208,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExperienceRecordDto"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -3113,6 +3282,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExperienceRecordDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -3294,6 +3473,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectRecordDto"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -3358,6 +3547,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectRecordDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -3539,6 +3738,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EducationRecordDto"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -3603,6 +3812,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EducationRecordDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -3785,6 +4004,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EducationDto"
+                  }
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3840,6 +4072,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EducationRecordDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4014,6 +4256,16 @@
         "operationId": "PortfolioController_uploadProfileImage",
         "parameters": [],
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadUrlResponseDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4095,6 +4347,16 @@
         "operationId": "PortfolioController_uploadProfileIcon",
         "parameters": [],
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadUrlResponseDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4195,6 +4457,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillRecordDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -4377,6 +4649,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactResultDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4433,6 +4715,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContactMessageDto"
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -4492,6 +4787,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactMessageDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -5280,6 +5585,778 @@
           "url"
         ]
       },
+      "LocaleDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "code": {
+            "type": "string",
+            "example": "ko"
+          },
+          "label": {
+            "type": "string",
+            "example": "한국어"
+          }
+        },
+        "required": [
+          "id",
+          "code",
+          "label"
+        ]
+      },
+      "SocialLinkDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "GitHub"
+          },
+          "href": {
+            "type": "string",
+            "example": "https://github.com/chahyunwoo"
+          }
+        },
+        "required": [
+          "name",
+          "href"
+        ]
+      },
+      "ProfileDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "차현우"
+          },
+          "location": {
+            "type": "string",
+            "example": "서울, 대한민국"
+          },
+          "imageUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "socialLinks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SocialLinkDto"
+            }
+          },
+          "jobTitle": {
+            "type": "string",
+            "example": "Full-Stack Developer",
+            "description": "번역이 없으면 빈 문자열"
+          },
+          "introduction": {
+            "description": "문단 배열. 번역이 없으면 빈 배열",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "location",
+          "imageUrl",
+          "iconUrl",
+          "socialLinks",
+          "jobTitle",
+          "introduction"
+        ]
+      },
+      "ProfileTranslationDto": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string",
+            "example": "ko"
+          },
+          "jobTitle": {
+            "type": "string",
+            "example": "Full-Stack Developer"
+          },
+          "introduction": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "locale",
+          "jobTitle",
+          "introduction"
+        ]
+      },
+      "ProfileWithTranslationsDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "차현우"
+          },
+          "location": {
+            "type": "string",
+            "example": "서울, 대한민국"
+          },
+          "imageUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "socialLinks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SocialLinkDto"
+            }
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "location",
+          "imageUrl",
+          "iconUrl",
+          "socialLinks",
+          "translations"
+        ]
+      },
+      "ExperienceDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isCurrent": {
+            "type": "boolean",
+            "example": false
+          },
+          "title": {
+            "type": "string",
+            "example": "회사명",
+            "description": "번역이 없으면 빈 문자열"
+          },
+          "role": {
+            "type": "string",
+            "example": "Backend Developer",
+            "description": "번역이 없으면 빈 문자열"
+          },
+          "responsibilities": {
+            "description": "번역이 없으면 빈 배열",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "startDate",
+          "endDate",
+          "isCurrent",
+          "title",
+          "role",
+          "responsibilities"
+        ]
+      },
+      "ProjectDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "demoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "repoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "techStack": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "featured": {
+            "type": "boolean",
+            "example": false
+          },
+          "title": {
+            "type": "string",
+            "example": "프로젝트명",
+            "description": "번역이 없으면 빈 문자열"
+          },
+          "description": {
+            "type": "string",
+            "example": "설명",
+            "description": "번역이 없으면 빈 문자열"
+          }
+        },
+        "required": [
+          "id",
+          "demoUrl",
+          "repoUrl",
+          "techStack",
+          "featured",
+          "title",
+          "description"
+        ]
+      },
+      "SkillItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "example": "TypeScript"
+          },
+          "proficiency": {
+            "type": "number",
+            "example": 90,
+            "description": "0-100"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "proficiency",
+          "description"
+        ]
+      },
+      "SkillGroupDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "example": "Frontend"
+          },
+          "items": {
+            "description": "sortOrder 오름차순",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SkillItemDto"
+            }
+          }
+        },
+        "required": [
+          "category",
+          "items"
+        ]
+      },
+      "WorkDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "type": {
+            "type": "string",
+            "example": "company",
+            "description": "company | side | freelance 등"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isCurrent": {
+            "type": "boolean",
+            "example": false
+          },
+          "techStack": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "demoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "repoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "featured": {
+            "type": "boolean",
+            "example": false
+          },
+          "gradientColors": {
+            "description": "title과 featured로 서버에서 생성한 그라디언트 색. DB 값이 아니다.",
+            "example": [
+              "#4F46E5",
+              "#7C3AED"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "title": {
+            "type": "string",
+            "example": "프로젝트명",
+            "description": "번역이 없으면 빈 문자열"
+          },
+          "role": {
+            "type": "string",
+            "nullable": true,
+            "description": "번역이 없으면 null"
+          },
+          "summary": {
+            "type": "string",
+            "example": "한 줄 요약",
+            "description": "번역이 없으면 빈 문자열"
+          },
+          "content": {
+            "type": "string",
+            "description": "MDX 본문. 번역이 없으면 빈 문자열"
+          },
+          "highlights": {
+            "description": "번역이 없으면 빈 배열",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "startDate",
+          "endDate",
+          "isCurrent",
+          "techStack",
+          "demoUrl",
+          "repoUrl",
+          "featured",
+          "gradientColors",
+          "title",
+          "role",
+          "summary",
+          "content",
+          "highlights"
+        ]
+      },
+      "WorkTranslationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "workId": {
+            "type": "number",
+            "example": 1
+          },
+          "locale": {
+            "type": "string",
+            "example": "ko"
+          },
+          "title": {
+            "type": "string",
+            "example": "프로젝트명"
+          },
+          "role": {
+            "type": "string",
+            "nullable": true
+          },
+          "summary": {
+            "type": "string",
+            "example": "한 줄 요약"
+          },
+          "content": {
+            "type": "string",
+            "description": "MDX 본문"
+          },
+          "highlights": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "workId",
+          "locale",
+          "title",
+          "role",
+          "summary",
+          "content",
+          "highlights"
+        ]
+      },
+      "WorkDetailDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "type": {
+            "type": "string",
+            "example": "company"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isCurrent": {
+            "type": "boolean",
+            "example": false
+          },
+          "techStack": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "demoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "repoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "featured": {
+            "type": "boolean",
+            "example": false
+          },
+          "sortOrder": {
+            "type": "number",
+            "example": 0
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkTranslationDto"
+            }
+          },
+          "gradientColors": {
+            "description": "title과 featured로 서버에서 생성한 그라디언트 색. DB 값이 아니다.",
+            "example": [
+              "#4F46E5",
+              "#7C3AED"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "startDate",
+          "endDate",
+          "isCurrent",
+          "techStack",
+          "demoUrl",
+          "repoUrl",
+          "featured",
+          "sortOrder",
+          "translations",
+          "gradientColors"
+        ]
+      },
+      "ExperienceTranslationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "experienceId": {
+            "type": "number",
+            "example": 1
+          },
+          "locale": {
+            "type": "string",
+            "example": "ko"
+          },
+          "title": {
+            "type": "string",
+            "example": "회사명"
+          },
+          "role": {
+            "type": "string",
+            "example": "Backend Developer"
+          },
+          "responsibilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "experienceId",
+          "locale",
+          "title",
+          "role",
+          "responsibilities"
+        ]
+      },
+      "ExperienceRecordDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isCurrent": {
+            "type": "boolean",
+            "example": false
+          },
+          "sortOrder": {
+            "type": "number",
+            "example": 0
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperienceTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "startDate",
+          "endDate",
+          "isCurrent",
+          "sortOrder",
+          "translations"
+        ]
+      },
+      "ProjectTranslationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "projectId": {
+            "type": "number",
+            "example": 1
+          },
+          "locale": {
+            "type": "string",
+            "example": "ko"
+          },
+          "title": {
+            "type": "string",
+            "example": "프로젝트명"
+          },
+          "description": {
+            "type": "string",
+            "example": "설명"
+          }
+        },
+        "required": [
+          "id",
+          "projectId",
+          "locale",
+          "title",
+          "description"
+        ]
+      },
+      "ProjectRecordDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "demoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "repoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "techStack": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "featured": {
+            "type": "boolean",
+            "example": false
+          },
+          "sortOrder": {
+            "type": "number",
+            "example": 0
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "demoUrl",
+          "repoUrl",
+          "techStack",
+          "featured",
+          "sortOrder",
+          "translations"
+        ]
+      },
+      "EducationTranslationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "educationId": {
+            "type": "number",
+            "example": 1
+          },
+          "locale": {
+            "type": "string",
+            "example": "ko"
+          },
+          "institution": {
+            "type": "string",
+            "example": "○○대학교"
+          },
+          "degree": {
+            "type": "string",
+            "example": "컴퓨터공학 학사"
+          }
+        },
+        "required": [
+          "id",
+          "educationId",
+          "locale",
+          "institution",
+          "degree"
+        ]
+      },
+      "EducationRecordDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "period": {
+            "type": "string",
+            "example": "2018.03 - 2022.02"
+          },
+          "sortOrder": {
+            "type": "number",
+            "example": 0
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EducationTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "period",
+          "sortOrder",
+          "translations"
+        ]
+      },
+      "EducationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "period": {
+            "type": "string",
+            "example": "2018.03 - 2022.02"
+          },
+          "institution": {
+            "type": "string",
+            "example": "○○대학교",
+            "description": "번역이 없으면 빈 문자열"
+          },
+          "degree": {
+            "type": "string",
+            "example": "컴퓨터공학 학사",
+            "description": "번역이 없으면 빈 문자열"
+          }
+        },
+        "required": [
+          "id",
+          "period",
+          "institution",
+          "degree"
+        ]
+      },
       "CreateLocaleDto": {
         "type": "object",
         "properties": {
@@ -5295,46 +6372,6 @@
         "required": [
           "code",
           "label"
-        ]
-      },
-      "SocialLinkDto": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "href": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "href"
-        ]
-      },
-      "ProfileTranslationDto": {
-        "type": "object",
-        "properties": {
-          "locale": {
-            "type": "string"
-          },
-          "jobTitle": {
-            "type": "string"
-          },
-          "introduction": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "locale",
-          "jobTitle",
-          "introduction"
         ]
       },
       "UpdateProfileDto": {
@@ -5366,30 +6403,16 @@
           }
         }
       },
-      "ExperienceTranslationDto": {
+      "UploadUrlResponseDto": {
         "type": "object",
         "properties": {
-          "locale": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "role": {
-            "type": "string"
-          },
-          "responsibilities": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "url": {
+            "type": "string",
+            "example": "https://assets.chahyunwoo.dev/profile/image/abc.png"
           }
         },
         "required": [
-          "locale",
-          "title",
-          "role",
-          "responsibilities"
+          "url"
         ]
       },
       "CreateExperienceDto": {
@@ -5445,24 +6468,6 @@
             }
           }
         }
-      },
-      "ProjectTranslationDto": {
-        "type": "object",
-        "properties": {
-          "locale": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "locale",
-          "title"
-        ]
       },
       "CreateProjectDto": {
         "type": "object",
@@ -5558,6 +6563,43 @@
           "name"
         ]
       },
+      "SkillRecordDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "category": {
+            "type": "string",
+            "example": "Frontend"
+          },
+          "name": {
+            "type": "string",
+            "example": "TypeScript"
+          },
+          "proficiency": {
+            "type": "number",
+            "example": 90
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortOrder": {
+            "type": "number",
+            "example": 0
+          }
+        },
+        "required": [
+          "id",
+          "category",
+          "name",
+          "proficiency",
+          "description",
+          "sortOrder"
+        ]
+      },
       "UpdateSkillDto": {
         "type": "object",
         "properties": {
@@ -5581,25 +6623,6 @@
             "type": "string"
           }
         }
-      },
-      "EducationTranslationDto": {
-        "type": "object",
-        "properties": {
-          "locale": {
-            "type": "string"
-          },
-          "institution": {
-            "type": "string"
-          },
-          "degree": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "locale",
-          "institution",
-          "degree"
-        ]
       },
       "CreateEducationDto": {
         "type": "object",
@@ -5640,38 +6663,6 @@
             }
           }
         }
-      },
-      "WorkTranslationDto": {
-        "type": "object",
-        "properties": {
-          "locale": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "role": {
-            "type": "string"
-          },
-          "summary": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "highlights": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "locale",
-          "title",
-          "summary",
-          "content"
-        ]
       },
       "CreateWorkDto": {
         "type": "object",
@@ -5723,6 +6714,74 @@
         "required": [
           "type",
           "techStack",
+          "translations"
+        ]
+      },
+      "WorkRecordDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "type": {
+            "type": "string",
+            "example": "company"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isCurrent": {
+            "type": "boolean",
+            "example": false
+          },
+          "techStack": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "demoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "repoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "featured": {
+            "type": "boolean",
+            "example": false
+          },
+          "sortOrder": {
+            "type": "number",
+            "example": 0
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "startDate",
+          "endDate",
+          "isCurrent",
+          "techStack",
+          "demoUrl",
+          "repoUrl",
+          "featured",
+          "sortOrder",
           "translations"
         ]
       },
@@ -5798,6 +6857,66 @@
           "name",
           "email",
           "message"
+        ]
+      },
+      "ContactResultDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "example": "Message sent successfully"
+          }
+        },
+        "required": [
+          "success",
+          "message"
+        ]
+      },
+      "ContactMessageDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "example": "홍길동"
+          },
+          "email": {
+            "type": "string",
+            "example": "someone@example.com"
+          },
+          "subject": {
+            "type": "string",
+            "nullable": true,
+            "example": "협업 문의"
+          },
+          "message": {
+            "type": "string",
+            "example": "문의 내용입니다."
+          },
+          "read": {
+            "type": "boolean",
+            "example": false
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "email",
+          "subject",
+          "message",
+          "read",
+          "createdAt"
         ]
       }
     }

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -50,7 +57,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -89,7 +103,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PopularPostDto"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -128,7 +152,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VisitorStatsDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -167,7 +198,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VisitorTimelineDto"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -206,7 +247,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferrerStatsDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -228,7 +276,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemStatusDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -259,7 +314,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AdminLogDto"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -290,6 +355,23 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "2FA가 꺼져 있으면 쿠키를 설정하고 message만, 켜져 있으면 twoFactorToken을 돌려준다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MessageResponseDto"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TwoFactorRequiredDto"
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -373,6 +455,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponseDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -446,6 +538,16 @@
         "operationId": "AuthController_getTwoFactorStatus",
         "parameters": [],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TwoFactorStatusDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -496,6 +598,16 @@
         "operationId": "AuthController_setupTwoFactor",
         "parameters": [],
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TwoFactorSetupDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -556,6 +668,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TwoFactorToggleDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -647,6 +769,16 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TwoFactorToggleDto"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -728,6 +860,16 @@
         "operationId": "AuthController_refresh",
         "parameters": [],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponseDto"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -807,7 +949,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionExtendDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -828,8 +977,15 @@
         "operationId": "AuthController_createPreviewToken",
         "parameters": [],
         "responses": {
-          "200": {
-            "description": ""
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewTokenDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -860,7 +1016,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewValidDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4994,6 +5157,23 @@
       }
     },
     "schemas": {
+      "HealthResponseDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "ok"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "status",
+          "timestamp"
+        ]
+      },
       "TrackPageViewDto": {
         "type": "object",
         "properties": {
@@ -5017,6 +5197,489 @@
         "required": [
           "path",
           "appName"
+        ]
+      },
+      "PostStatsDto": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number",
+            "example": 40
+          },
+          "published": {
+            "type": "number",
+            "example": 38
+          },
+          "draft": {
+            "type": "number",
+            "example": 2
+          }
+        },
+        "required": [
+          "total",
+          "published",
+          "draft"
+        ]
+      },
+      "CategoryStatDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "example": "Frontend"
+          },
+          "count": {
+            "type": "number",
+            "example": 8
+          }
+        },
+        "required": [
+          "category",
+          "count"
+        ]
+      },
+      "DashboardPostDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "abc123"
+          },
+          "title": {
+            "type": "string",
+            "example": "글 제목"
+          },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "example": "Frontend"
+          },
+          "viewCount": {
+            "type": "number",
+            "example": 128
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "slug",
+          "title",
+          "category",
+          "viewCount",
+          "createdAt"
+        ]
+      },
+      "RecentlyUpdatedPostDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "abc123"
+          },
+          "title": {
+            "type": "string",
+            "example": "글 제목"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "slug",
+          "title",
+          "updatedAt"
+        ]
+      },
+      "DashboardDto": {
+        "type": "object",
+        "properties": {
+          "postStats": {
+            "$ref": "#/components/schemas/PostStatsDto"
+          },
+          "categoryStats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CategoryStatDto"
+            }
+          },
+          "recentPosts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DashboardPostDto"
+            }
+          },
+          "recentlyUpdated": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RecentlyUpdatedPostDto"
+            }
+          }
+        },
+        "required": [
+          "postStats",
+          "categoryStats",
+          "recentPosts",
+          "recentlyUpdated"
+        ]
+      },
+      "PopularPostDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "abc123"
+          },
+          "title": {
+            "type": "string",
+            "example": "글 제목"
+          },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "example": "Frontend"
+          },
+          "viewCount": {
+            "type": "number",
+            "example": 128
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "slug",
+          "title",
+          "category",
+          "viewCount",
+          "createdAt"
+        ]
+      },
+      "DailyViewDto": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "example": "2026-09-04",
+            "description": "YYYY-MM-DD"
+          },
+          "count": {
+            "type": "number",
+            "example": 42
+          }
+        },
+        "required": [
+          "date",
+          "count"
+        ]
+      },
+      "VisitorStatsDto": {
+        "type": "object",
+        "properties": {
+          "totalViews": {
+            "type": "number",
+            "example": 991
+          },
+          "uniqueVisitors": {
+            "type": "number",
+            "example": 210,
+            "description": "IP 기준 고유 방문자"
+          },
+          "daily": {
+            "description": "날짜 오름차순",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DailyViewDto"
+            }
+          }
+        },
+        "required": [
+          "totalViews",
+          "uniqueVisitors",
+          "daily"
+        ]
+      },
+      "VisitDto": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "example": "/blog/abc123",
+            "description": "URL 디코딩된 경로"
+          },
+          "referrer": {
+            "type": "string",
+            "nullable": true,
+            "example": "google.com",
+            "description": "도메인만 남긴다"
+          },
+          "visitedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "path",
+          "referrer",
+          "visitedAt"
+        ]
+      },
+      "VisitorTimelineDto": {
+        "type": "object",
+        "properties": {
+          "ipAddress": {
+            "type": "string",
+            "example": "123.45.*.*",
+            "description": "마스킹된 IP"
+          },
+          "city": {
+            "type": "string",
+            "nullable": true,
+            "example": "Seoul"
+          },
+          "country": {
+            "type": "string",
+            "nullable": true,
+            "example": "KR"
+          },
+          "isBot": {
+            "type": "boolean",
+            "example": false
+          },
+          "totalViews": {
+            "type": "number",
+            "example": 5
+          },
+          "visits": {
+            "description": "최근 방문 우선",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VisitDto"
+            }
+          }
+        },
+        "required": [
+          "ipAddress",
+          "city",
+          "country",
+          "isBot",
+          "totalViews",
+          "visits"
+        ]
+      },
+      "ReferrerSummaryDto": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number",
+            "example": 100
+          },
+          "direct": {
+            "type": "number",
+            "example": 40,
+            "description": "리퍼러 없음"
+          },
+          "search": {
+            "type": "number",
+            "example": 30
+          },
+          "social": {
+            "type": "number",
+            "example": 20
+          },
+          "other": {
+            "type": "number",
+            "example": 10
+          }
+        },
+        "required": [
+          "total",
+          "direct",
+          "search",
+          "social",
+          "other"
+        ]
+      },
+      "ReferrerItemDto": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string",
+            "example": "google.com"
+          },
+          "category": {
+            "type": "string",
+            "example": "search",
+            "description": "direct | search | social | other"
+          },
+          "count": {
+            "type": "number",
+            "example": 30
+          },
+          "percentage": {
+            "type": "number",
+            "example": 30,
+            "description": "전체 대비 백분율(정수)"
+          }
+        },
+        "required": [
+          "source",
+          "category",
+          "count",
+          "percentage"
+        ]
+      },
+      "ReferrerStatsDto": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/ReferrerSummaryDto"
+          },
+          "referrers": {
+            "description": "count 내림차순",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReferrerItemDto"
+            }
+          }
+        },
+        "required": [
+          "summary",
+          "referrers"
+        ]
+      },
+      "MemoryUsageDto": {
+        "type": "object",
+        "properties": {
+          "heapUsed": {
+            "type": "number",
+            "example": 52428800,
+            "description": "바이트"
+          },
+          "heapTotal": {
+            "type": "number",
+            "example": 83886080
+          },
+          "rss": {
+            "type": "number",
+            "example": 125829120,
+            "description": "Resident Set Size"
+          }
+        },
+        "required": [
+          "heapUsed",
+          "heapTotal",
+          "rss"
+        ]
+      },
+      "SystemStatusDto": {
+        "type": "object",
+        "properties": {
+          "uptime": {
+            "type": "number",
+            "example": 86400000,
+            "description": "프로세스 기동 후 경과 밀리초"
+          },
+          "uptimeFormatted": {
+            "type": "string",
+            "example": "1d 0h 0m"
+          },
+          "database": {
+            "type": "string",
+            "example": "connected",
+            "description": "connected | disconnected"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/MemoryUsageDto"
+          }
+        },
+        "required": [
+          "uptime",
+          "uptimeFormatted",
+          "database",
+          "memory"
+        ]
+      },
+      "AdminLogDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "action": {
+            "type": "string",
+            "example": "create",
+            "description": "create | update | delete 등"
+          },
+          "entity": {
+            "type": "string",
+            "example": "post"
+          },
+          "entityId": {
+            "type": "string",
+            "nullable": true,
+            "example": "abc123"
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true,
+            "description": "글 제목 등 부가 정보"
+          },
+          "username": {
+            "type": "string",
+            "example": "admin"
+          },
+          "ipAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "action",
+          "entity",
+          "entityId",
+          "detail",
+          "username",
+          "ipAddress",
+          "createdAt"
+        ]
+      },
+      "MessageResponseDto": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Login successful"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "TwoFactorRequiredDto": {
+        "type": "object",
+        "properties": {
+          "requiresTwoFactor": {
+            "type": "boolean",
+            "example": true
+          },
+          "twoFactorToken": {
+            "type": "string",
+            "description": "5분간 유효. 2fa/verify에 그대로 넘긴다."
+          }
+        },
+        "required": [
+          "requiresTwoFactor",
+          "twoFactorToken"
         ]
       },
       "LoginDto": {
@@ -5053,6 +5716,40 @@
           "code"
         ]
       },
+      "TwoFactorStatusDto": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "TwoFactorSetupDto": {
+        "type": "object",
+        "properties": {
+          "qrCode": {
+            "type": "string",
+            "description": "data URI 형태의 QR 이미지 (신규 설정 시)"
+          },
+          "uri": {
+            "type": "string",
+            "description": "otpauth:// URI (신규 설정 시)"
+          },
+          "configured": {
+            "type": "boolean",
+            "example": true,
+            "description": "이미 설정돼 있을 때만"
+          },
+          "message": {
+            "type": "string",
+            "example": "2FA is already configured"
+          }
+        }
+      },
       "Enable2faDto": {
         "type": "object",
         "properties": {
@@ -5063,6 +5760,66 @@
         },
         "required": [
           "code"
+        ]
+      },
+      "TwoFactorToggleDto": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "example": "2FA is not enabled",
+            "description": "이미 그 상태일 때만"
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "SessionExtendDto": {
+        "type": "object",
+        "properties": {
+          "timeout": {
+            "type": "number",
+            "example": 3600000,
+            "description": "밀리초"
+          }
+        },
+        "required": [
+          "timeout"
+        ]
+      },
+      "PreviewTokenDto": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "미리보기 URL의 쿼리로 붙인다"
+          },
+          "expiresIn": {
+            "type": "number",
+            "example": 1800,
+            "description": "초 단위"
+          }
+        },
+        "required": [
+          "token",
+          "expiresIn"
+        ]
+      },
+      "PreviewValidDto": {
+        "type": "object",
+        "properties": {
+          "valid": {
+            "type": "boolean",
+            "example": true
+          }
+        },
+        "required": [
+          "valid"
         ]
       },
       "PostTagDto": {

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -9,12 +9,21 @@ import {
   Query,
   Req,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiCookieAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiOkResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import type { FastifyRequest } from 'fastify';
 import { Public } from '../common/decorators/public.decorator';
 import { AdminLogService } from './admin-log.service';
 import { AnalyticsService } from './analytics.service';
 import { safeAppName, safeInt } from './analytics.utils';
+import {
+  AdminLogDto,
+  DashboardDto,
+  PopularPostDto,
+  ReferrerStatsDto,
+  SystemStatusDto,
+  VisitorStatsDto,
+  VisitorTimelineDto,
+} from './dto/analytics-response.dto';
 import { TrackPageViewDto } from './dto/track-pageview.dto';
 import { PageViewService } from './page-view.service';
 
@@ -52,6 +61,7 @@ export class AnalyticsController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('dashboard')
+  @ApiOkResponse({ type: DashboardDto })
   getDashboard() {
     return this.analytics.getDashboardStats();
   }
@@ -59,6 +69,7 @@ export class AnalyticsController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('popular-posts')
+  @ApiOkResponse({ type: [PopularPostDto] })
   getPopularPosts(@Query('limit') limit?: string, @Query('days') days?: string) {
     return this.analytics.getPopularPosts(safeInt(limit), safeInt(days));
   }
@@ -66,6 +77,7 @@ export class AnalyticsController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('visitors')
+  @ApiOkResponse({ type: VisitorStatsDto })
   getVisitors(@Query('days') days?: string, @Query('app') app?: string) {
     return this.analytics.getVisitorStats(safeInt(days), safeAppName(app));
   }
@@ -73,6 +85,7 @@ export class AnalyticsController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('visitors/timeline')
+  @ApiOkResponse({ type: [VisitorTimelineDto] })
   getVisitorsTimeline(@Query('days') days?: string, @Query('app') app?: string) {
     return this.analytics.getVisitorsTimeline(safeInt(days), safeAppName(app));
   }
@@ -80,6 +93,7 @@ export class AnalyticsController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('referrers')
+  @ApiOkResponse({ type: ReferrerStatsDto })
   getReferrers(@Query('days') days?: string, @Query('app') app?: string) {
     return this.analytics.getReferrerStats(safeInt(days), safeAppName(app));
   }
@@ -87,6 +101,7 @@ export class AnalyticsController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('system')
+  @ApiOkResponse({ type: SystemStatusDto })
   getSystem() {
     return this.analytics.getSystemStatus();
   }
@@ -94,6 +109,7 @@ export class AnalyticsController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('admin-logs')
+  @ApiOkResponse({ type: [AdminLogDto] })
   getAdminLogs(@Query('limit') limit?: string) {
     return this.adminLog.getRecent(safeInt(limit));
   }

--- a/src/analytics/dto/analytics-response.dto.ts
+++ b/src/analytics/dto/analytics-response.dto.ts
@@ -151,8 +151,13 @@ export class ReferrerItemDto {
   @ApiProperty({ example: 'google.com' })
   source: string;
 
-  @ApiProperty({ example: 'search', description: 'direct | search | social | other' })
-  category: string;
+  /**
+   * 자유 문자열이 아니라 `categorizeReferrer()`가 넷 중 하나로만 채운다.
+   * 프론트가 이 값을 색·라벨 매핑의 키로 쓰므로(`Record<ReferrerCategory, string>`)
+   * `string`으로 열어두면 인덱싱이 막힌다.
+   */
+  @ApiProperty({ enum: ['direct', 'search', 'social', 'other'], example: 'search' })
+  category: 'direct' | 'search' | 'social' | 'other';
 
   @ApiProperty({ example: 30 })
   count: number;

--- a/src/analytics/dto/analytics-response.dto.ts
+++ b/src/analytics/dto/analytics-response.dto.ts
@@ -1,0 +1,240 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * analytics 도메인의 응답 스키마.
+ *
+ * 필드는 실제 응답을 받아 관측한 것이다. 집계 결과라 DB 모델과 1:1이 아니고
+ * 서비스가 조립한 형태이므로, 스키마만 보고 추측하면 어긋난다.
+ */
+
+// ─── Dashboard ────────────────────────────────────────────────────────────────
+
+export class PostStatsDto {
+  @ApiProperty({ example: 40 })
+  total: number;
+
+  @ApiProperty({ example: 38 })
+  published: number;
+
+  @ApiProperty({ example: 2 })
+  draft: number;
+}
+
+export class CategoryStatDto {
+  @ApiProperty({ example: 'Frontend' })
+  category: string;
+
+  @ApiProperty({ example: 8 })
+  count: number;
+}
+
+export class DashboardPostDto {
+  @ApiProperty({ example: 'abc123' })
+  slug: string;
+
+  @ApiProperty({ example: '글 제목' })
+  title: string;
+
+  @ApiProperty({ type: String, nullable: true, example: 'Frontend' })
+  category: string | null;
+
+  @ApiProperty({ example: 128 })
+  viewCount: number;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt: string;
+}
+
+export class RecentlyUpdatedPostDto {
+  @ApiProperty({ example: 'abc123' })
+  slug: string;
+
+  @ApiProperty({ example: '글 제목' })
+  title: string;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  updatedAt: string;
+}
+
+export class DashboardDto {
+  @ApiProperty({ type: PostStatsDto })
+  postStats: PostStatsDto;
+
+  @ApiProperty({ type: [CategoryStatDto] })
+  categoryStats: CategoryStatDto[];
+
+  @ApiProperty({ type: [DashboardPostDto] })
+  recentPosts: DashboardPostDto[];
+
+  @ApiProperty({ type: [RecentlyUpdatedPostDto] })
+  recentlyUpdated: RecentlyUpdatedPostDto[];
+}
+
+// ─── Visitors ─────────────────────────────────────────────────────────────────
+
+export class DailyViewDto {
+  @ApiProperty({ example: '2026-09-04', description: 'YYYY-MM-DD' })
+  date: string;
+
+  @ApiProperty({ example: 42 })
+  count: number;
+}
+
+export class VisitorStatsDto {
+  @ApiProperty({ example: 991 })
+  totalViews: number;
+
+  @ApiProperty({ example: 210, description: 'IP 기준 고유 방문자' })
+  uniqueVisitors: number;
+
+  @ApiProperty({ type: [DailyViewDto], description: '날짜 오름차순' })
+  daily: DailyViewDto[];
+}
+
+export class VisitDto {
+  @ApiProperty({ example: '/blog/abc123', description: 'URL 디코딩된 경로' })
+  path: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    example: 'google.com',
+    description: '도메인만 남긴다',
+  })
+  referrer: string | null;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  visitedAt: string;
+}
+
+/** `GET /api/analytics/visitors/timeline` — IP별로 묶은 방문 이력. IP는 마스킹된다. */
+export class VisitorTimelineDto {
+  @ApiProperty({ example: '123.45.*.*', description: '마스킹된 IP' })
+  ipAddress: string;
+
+  @ApiProperty({ type: String, nullable: true, example: 'Seoul' })
+  city: string | null;
+
+  @ApiProperty({ type: String, nullable: true, example: 'KR' })
+  country: string | null;
+
+  @ApiProperty({ example: false })
+  isBot: boolean;
+
+  @ApiProperty({ example: 5 })
+  totalViews: number;
+
+  @ApiProperty({ type: [VisitDto], description: '최근 방문 우선' })
+  visits: VisitDto[];
+}
+
+// ─── Referrers ────────────────────────────────────────────────────────────────
+
+export class ReferrerSummaryDto {
+  @ApiProperty({ example: 100 })
+  total: number;
+
+  @ApiProperty({ example: 40, description: '리퍼러 없음' })
+  direct: number;
+
+  @ApiProperty({ example: 30 })
+  search: number;
+
+  @ApiProperty({ example: 20 })
+  social: number;
+
+  @ApiProperty({ example: 10 })
+  other: number;
+}
+
+export class ReferrerItemDto {
+  @ApiProperty({ example: 'google.com' })
+  source: string;
+
+  @ApiProperty({ example: 'search', description: 'direct | search | social | other' })
+  category: string;
+
+  @ApiProperty({ example: 30 })
+  count: number;
+
+  @ApiProperty({ example: 30, description: '전체 대비 백분율(정수)' })
+  percentage: number;
+}
+
+export class ReferrerStatsDto {
+  @ApiProperty({ type: ReferrerSummaryDto })
+  summary: ReferrerSummaryDto;
+
+  @ApiProperty({ type: [ReferrerItemDto], description: 'count 내림차순' })
+  referrers: ReferrerItemDto[];
+}
+
+// ─── Popular posts / Admin logs / System ──────────────────────────────────────
+
+export class PopularPostDto {
+  @ApiProperty({ example: 'abc123' })
+  slug: string;
+
+  @ApiProperty({ example: '글 제목' })
+  title: string;
+
+  @ApiProperty({ type: String, nullable: true, example: 'Frontend' })
+  category: string | null;
+
+  @ApiProperty({ example: 128 })
+  viewCount: number;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt: string;
+}
+
+export class AdminLogDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'create', description: 'create | update | delete 등' })
+  action: string;
+
+  @ApiProperty({ example: 'post' })
+  entity: string;
+
+  @ApiProperty({ type: String, nullable: true, example: 'abc123' })
+  entityId: string | null;
+
+  @ApiProperty({ type: String, nullable: true, description: '글 제목 등 부가 정보' })
+  detail: string | null;
+
+  @ApiProperty({ example: 'admin' })
+  username: string;
+
+  @ApiProperty({ type: String, nullable: true })
+  ipAddress: string | null;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt: string;
+}
+
+export class MemoryUsageDto {
+  @ApiProperty({ example: 52428800, description: '바이트' })
+  heapUsed: number;
+
+  @ApiProperty({ example: 83886080 })
+  heapTotal: number;
+
+  @ApiProperty({ example: 125829120, description: 'Resident Set Size' })
+  rss: number;
+}
+
+export class SystemStatusDto {
+  @ApiProperty({ example: 86400000, description: '프로세스 기동 후 경과 밀리초' })
+  uptime: number;
+
+  @ApiProperty({ example: '1d 0h 0m' })
+  uptimeFormatted: string;
+
+  @ApiProperty({ example: 'connected', description: 'connected | disconnected' })
+  database: string;
+
+  @ApiProperty({ type: MemoryUsageDto })
+  memory: MemoryUsageDto;
+}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,13 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Post, Query, Req, Res } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ApiBearerAuth, ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiCookieAuth,
+  ApiCreatedResponse,
+  ApiExtraModels,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { Public } from '../common/decorators/public.decorator';
@@ -16,6 +23,16 @@ import {
   SESSION_TIMEOUT_COOKIE,
 } from './auth.constants';
 import { AuthService } from './auth.service';
+import {
+  MessageResponseDto,
+  PreviewTokenDto,
+  PreviewValidDto,
+  SessionExtendDto,
+  TwoFactorRequiredDto,
+  TwoFactorSetupDto,
+  TwoFactorStatusDto,
+  TwoFactorToggleDto,
+} from './dto/auth-response.dto';
 import { Enable2faDto } from './dto/enable-2fa.dto';
 import { LoginDto } from './dto/login.dto';
 import { Verify2faDto } from './dto/verify-2fa.dto';
@@ -37,6 +54,17 @@ export class AuthController {
   @Public()
   @SkipApiKey()
   @Post('login')
+  @ApiOkResponse({
+    description:
+      '2FA가 꺼져 있으면 쿠키를 설정하고 message만, 켜져 있으면 twoFactorToken을 돌려준다.',
+    schema: {
+      oneOf: [
+        { $ref: '#/components/schemas/MessageResponseDto' },
+        { $ref: '#/components/schemas/TwoFactorRequiredDto' },
+      ],
+    },
+  })
+  @ApiExtraModels(MessageResponseDto, TwoFactorRequiredDto)
   @HttpCode(HttpStatus.OK)
   @Throttle({ default: { ttl: 60_000, limit: 5 } })
   @ApiUnauthorized()
@@ -55,6 +83,7 @@ export class AuthController {
   @Public()
   @SkipApiKey()
   @Post('2fa/verify')
+  @ApiOkResponse({ type: MessageResponseDto })
   @HttpCode(HttpStatus.OK)
   @Throttle({ default: { ttl: 60_000, limit: 5 } })
   @ApiUnauthorized()
@@ -76,6 +105,7 @@ export class AuthController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('2fa/status')
+  @ApiOkResponse({ type: TwoFactorStatusDto })
   @ApiUnauthorized()
   getTwoFactorStatus() {
     return this.authService.getTwoFactorStatus();
@@ -84,6 +114,7 @@ export class AuthController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('2fa/setup')
+  @ApiCreatedResponse({ type: TwoFactorSetupDto })
   @HttpCode(HttpStatus.OK)
   @ApiUnauthorized()
   setupTwoFactor() {
@@ -93,6 +124,7 @@ export class AuthController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('2fa/disable')
+  @ApiCreatedResponse({ type: TwoFactorToggleDto })
   @HttpCode(HttpStatus.OK)
   @ApiUnauthorized()
   @ApiBadRequest()
@@ -103,6 +135,7 @@ export class AuthController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('2fa/enable')
+  @ApiCreatedResponse({ type: TwoFactorToggleDto })
   @HttpCode(HttpStatus.OK)
   @ApiUnauthorized()
   @ApiBadRequest()
@@ -113,6 +146,7 @@ export class AuthController {
   @Public()
   @SkipApiKey()
   @Post('refresh')
+  @ApiOkResponse({ type: MessageResponseDto })
   @HttpCode(HttpStatus.OK)
   @ApiUnauthorized()
   async refresh(@Req() req: CookieRequest, @Res() reply: FastifyReply) {
@@ -156,6 +190,7 @@ export class AuthController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('session/extend')
+  @ApiOkResponse({ type: SessionExtendDto })
   @HttpCode(HttpStatus.OK)
   async extendSession(@Res() reply: FastifyReply) {
     reply.setCookie(SESSION_TIMEOUT_COOKIE, String(Date.now() + SESSION_TIMEOUT * 1000), {
@@ -174,6 +209,7 @@ export class AuthController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('preview-token')
+  @ApiCreatedResponse({ type: PreviewTokenDto })
   @HttpCode(HttpStatus.OK)
   createPreviewToken() {
     return this.authService.createPreviewToken();
@@ -181,6 +217,7 @@ export class AuthController {
 
   @Public()
   @Get('verify-preview')
+  @ApiOkResponse({ type: PreviewValidDto })
   verifyPreview(@Query('token') token: string, @Res() reply: FastifyReply) {
     const valid = this.authService.verifyPreviewToken(token);
     if (!valid) {

--- a/src/auth/dto/auth-response.dto.ts
+++ b/src/auth/dto/auth-response.dto.ts
@@ -1,0 +1,86 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * auth 도메인의 응답 스키마.
+ *
+ * **토큰은 응답 본문이 아니라 쿠키로 나간다.** 컨트롤러가 `setTokenCookies()`로
+ * `access_token`/`refresh_token`/`session_timeout`을 HttpOnly 쿠키에 실으므로,
+ * 본문에는 확인용 메시지만 담긴다. 프론트가 응답에서 토큰을 꺼내려 하면 안 된다.
+ */
+
+/** 쿠키를 설정한 뒤 돌려주는 확인용 응답. */
+export class MessageResponseDto {
+  @ApiProperty({ example: 'Login successful' })
+  message: string;
+}
+
+/**
+ * 2FA가 켜져 있을 때의 로그인 응답.
+ *
+ * 이때는 쿠키가 설정되지 않는다. 받은 `twoFactorToken`을 TOTP 코드와 함께
+ * `POST /api/auth/2fa/verify`로 보내야 그때 쿠키가 나간다.
+ */
+export class TwoFactorRequiredDto {
+  @ApiProperty({ example: true })
+  requiresTwoFactor: boolean;
+
+  @ApiProperty({ description: '5분간 유효. 2fa/verify에 그대로 넘긴다.' })
+  twoFactorToken: string;
+}
+
+export class TwoFactorStatusDto {
+  @ApiProperty({ example: false })
+  enabled: boolean;
+}
+
+/**
+ * `POST /api/auth/2fa/setup` — 이미 설정돼 있으면 `{ configured, message }`,
+ * 아니면 `{ qrCode, uri }`를 돌려준다. 두 경우의 키가 다르므로 전부 선택 항목이다.
+ */
+export class TwoFactorSetupDto {
+  @ApiProperty({ required: false, description: 'data URI 형태의 QR 이미지 (신규 설정 시)' })
+  qrCode?: string;
+
+  @ApiProperty({ required: false, description: 'otpauth:// URI (신규 설정 시)' })
+  uri?: string;
+
+  @ApiProperty({ required: false, example: true, description: '이미 설정돼 있을 때만' })
+  configured?: boolean;
+
+  @ApiProperty({ required: false, example: '2FA is already configured' })
+  message?: string;
+}
+
+/** `POST /api/auth/2fa/enable`, `POST /api/auth/2fa/disable`. */
+export class TwoFactorToggleDto {
+  @ApiProperty({ example: true })
+  enabled: boolean;
+
+  @ApiProperty({
+    required: false,
+    example: '2FA is not enabled',
+    description: '이미 그 상태일 때만',
+  })
+  message?: string;
+}
+
+/** `POST /api/auth/session/extend` — 연장된 세션 타임아웃(ms). */
+export class SessionExtendDto {
+  @ApiProperty({ example: 3600000, description: '밀리초' })
+  timeout: number;
+}
+
+/** `POST /api/auth/preview-token` — 미발행 글 미리보기용 임시 토큰. */
+export class PreviewTokenDto {
+  @ApiProperty({ description: '미리보기 URL의 쿼리로 붙인다' })
+  token: string;
+
+  @ApiProperty({ example: 1800, description: '초 단위' })
+  expiresIn: number;
+}
+
+/** `GET /api/auth/verify-preview` — 유효하지 않으면 401이므로 200이면 항상 true다. */
+export class PreviewValidDto {
+  @ApiProperty({ example: true })
+  valid: boolean;
+}

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -17,6 +17,7 @@ import {
   ApiBearerAuth,
   ApiConsumes,
   ApiCookieAuth,
+  ApiCreatedResponse,
   ApiOkResponse,
   ApiSecurity,
   ApiTags,
@@ -33,9 +34,18 @@ import {
 import { safeExtension, validateAndReadFile } from '../common/utils/file-validation.util';
 import type { MultipartRequest } from '../types/fastify.d';
 import { BlogService } from './blog.service';
+import {
+  CategoryDto,
+  CategoryWithTagsDto,
+  PostDetailDto,
+  PostSearchResponseDto,
+  RelatedPostsResponseDto,
+  TagListResponseDto,
+  UploadImageResponseDto,
+} from './dto/blog-response.dto';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { CreatePostDto } from './dto/create-post.dto';
-import { PostListResponseDto } from './dto/post-list-response.dto';
+import { PostListResponseDto, PostSummaryDto } from './dto/post-list-response.dto';
 import { PostQueryDto, RecentQueryDto, SearchQueryDto, TagQueryDto } from './dto/post-query.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 
@@ -50,6 +60,7 @@ export class BlogController {
   @Public()
   @ApiSecurity('api-key')
   @Get('posts/search')
+  @ApiOkResponse({ type: PostSearchResponseDto })
   @ApiBadRequest('q must be at least 2 characters')
   search(@Query() query: SearchQueryDto) {
     return this.blogService.search(query);
@@ -67,6 +78,7 @@ export class BlogController {
   @Public()
   @ApiSecurity('api-key')
   @Get('posts/recent')
+  @ApiOkResponse({ type: [PostSummaryDto] })
   getRecentPosts(@Query() query: RecentQueryDto) {
     return this.blogService.getRecentPosts(query.limit);
   }
@@ -74,6 +86,7 @@ export class BlogController {
   @Public()
   @ApiSecurity('api-key')
   @Get('categories')
+  @ApiOkResponse({ type: [CategoryWithTagsDto] })
   getCategories() {
     return this.blogService.getCategories();
   }
@@ -81,6 +94,7 @@ export class BlogController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('categories')
+  @ApiCreatedResponse({ type: CategoryDto })
   @HttpCode(HttpStatus.CREATED)
   createCategory(@Body() dto: CreateCategoryDto) {
     return this.blogService.createCategory(dto);
@@ -89,6 +103,7 @@ export class BlogController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('categories/:id')
+  @ApiOkResponse({ type: CategoryDto })
   updateCategory(@Param('id', ParseIntPipe) id: number, @Body() dto: CreateCategoryDto) {
     return this.blogService.updateCategory(id, dto);
   }
@@ -104,6 +119,7 @@ export class BlogController {
   @Public()
   @ApiSecurity('api-key')
   @Get('tags')
+  @ApiOkResponse({ type: TagListResponseDto })
   getTags(@Query() query: TagQueryDto) {
     return this.blogService.getTags(query);
   }
@@ -111,6 +127,7 @@ export class BlogController {
   @Public()
   @ApiSecurity('api-key')
   @Get('posts/:slug')
+  @ApiOkResponse({ type: PostDetailDto })
   @ApiNotFound('Post')
   findOne(@Param('slug') slug: string, @Req() req: MultipartRequest) {
     const isAdmin = this.authService.isAuthenticated(req.cookies?.access_token);
@@ -120,6 +137,7 @@ export class BlogController {
   @Public()
   @ApiSecurity('api-key')
   @Get('posts/:slug/preview')
+  @ApiOkResponse({ type: PostDetailDto })
   @ApiNotFound('Post')
   @ApiUnauthorized()
   async findOnePreview(@Param('slug') slug: string, @Query('token') token: string) {
@@ -132,6 +150,7 @@ export class BlogController {
   @Public()
   @ApiSecurity('api-key')
   @Get('posts/:slug/related')
+  @ApiOkResponse({ type: RelatedPostsResponseDto })
   @ApiNotFound('Post')
   getRelatedPosts(@Param('slug') slug: string) {
     return this.blogService.getRelatedPosts(slug);
@@ -140,6 +159,7 @@ export class BlogController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('posts')
+  @ApiCreatedResponse({ type: PostDetailDto })
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
   @ApiBadRequest()
@@ -151,6 +171,7 @@ export class BlogController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('posts/:slug')
+  @ApiOkResponse({ type: PostDetailDto })
   @ApiUnauthorized()
   @ApiNotFound('Post')
   update(@Param('slug') slug: string, @Body() dto: UpdatePostDto) {
@@ -171,6 +192,7 @@ export class BlogController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('images')
+  @ApiCreatedResponse({ type: UploadImageResponseDto })
   @ApiConsumes('multipart/form-data')
   @ApiUnauthorized()
   @ApiBadRequest('No file provided or invalid file type')

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -26,6 +26,7 @@ import { Public } from '../common/decorators/public.decorator';
 import {
   ApiBadRequest,
   ApiConflict,
+  ApiNoContent,
   ApiNotFound,
   ApiUnauthorized,
 } from '../common/swagger/error-responses';
@@ -160,6 +161,7 @@ export class BlogController {
   @ApiCookieAuth()
   @Delete('posts/:slug')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContent()
   @ApiUnauthorized()
   @ApiNotFound('Post')
   remove(@Param('slug') slug: string) {

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -199,6 +199,9 @@ export class BlogService {
 
     const recentSet = new Set(recentCategories.map(r => r.category));
     const iconMap = new Map(categoryMeta.map(c => [c.name, c.icon]));
+    // 어드민이 수정·삭제할 때 쓴다. 이 라우트가 카테고리 목록의 유일한 출처인데
+    // id가 없어서, 프론트가 이름을 경로에 넣어 호출하다 400을 맞고 있었다.
+    const idMap = new Map(categoryMeta.map(c => [c.name, c.id]));
 
     // 태그 카운트 집계
     const tagMap = new Map<string, Map<string, { name: string; slug: string; count: number }>>();
@@ -219,6 +222,7 @@ export class BlogService {
 
     const result = categoryCounts
       .map(c => ({
+        id: idMap.get(c.category as string) ?? null,
         category: c.category as string,
         icon: iconMap.get(c.category as string) ?? DEFAULT_CATEGORY_ICON,
         count: c._count,

--- a/src/blog/dto/blog-response.dto.spec.ts
+++ b/src/blog/dto/blog-response.dto.spec.ts
@@ -121,7 +121,9 @@ describe('blog 응답 스키마', () => {
       ['PostSearchResponseDto', ['posts', 'total', 'query', 'grouped']],
       ['RelatedPostsResponseDto', ['related', 'recommended']],
       ['TagListResponseDto', ['tags', 'total']],
-      ['CategoryWithTagsDto', ['category', 'icon', 'count', 'recent', 'tags']],
+      // id가 빠지면 어드민이 카테고리를 수정·삭제할 수단을 잃는다
+      // (PUT|DELETE /categories/{id}가 ParseIntPipe로 id를 받는다)
+      ['CategoryWithTagsDto', ['id', 'category', 'icon', 'count', 'recent', 'tags']],
       ['CategoryDto', ['id', 'name', 'icon', 'sortOrder']],
       ['UploadImageResponseDto', ['url']],
       ['TagCountDto', ['name', 'slug', 'count']],

--- a/src/blog/dto/blog-response.dto.spec.ts
+++ b/src/blog/dto/blog-response.dto.spec.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * 커밋된 `openapi.json`의 blog 응답 스키마가 실제 서비스 반환 shape과 맞는지 본다.
+ *
+ * **왜 이 테스트가 필요한가.** DTO는 손으로 쓴 것이라 서비스가 필드를 추가하거나
+ * 이름을 바꾸면 조용히 어긋난다. 어긋난 DTO는 타입이 없는 것보다 나쁘다 —
+ * 프론트가 그 타입을 믿고 코드를 짜기 때문이다.
+ *
+ * 여기서는 DB 없이 검사할 수 있는 것만 본다: **스키마가 존재하는지**와
+ * **`formatPost`가 만드는 필드 집합과 일치하는지**. 실제 HTTP 응답과의 대조는
+ * 통합 테스트의 몫이고, 지금은 수동으로 확인했다(커밋 메시지에 기록).
+ */
+describe('blog 응답 스키마', () => {
+  const spec = JSON.parse(readFileSync(join(__dirname, '../../../openapi.json'), 'utf8'));
+
+  /** $ref를 풀고 allOf(상속)를 합쳐 실제 프로퍼티 집합을 만든다. */
+  type Schema = {
+    $ref?: string;
+    type?: string;
+    items?: Schema;
+    properties?: Record<string, unknown>;
+    allOf?: Schema[];
+  };
+
+  function propsOf(schema: Schema): Set<string> {
+    let s = schema;
+    if (s.$ref) s = spec.components.schemas[s.$ref.split('/').pop() as string];
+    if (s.type === 'array' && s.items) return propsOf(s.items);
+    const props: Record<string, unknown> = { ...(s.properties ?? {}) };
+    for (const sub of s.allOf ?? []) {
+      const parent: Schema = sub.$ref
+        ? spec.components.schemas[sub.$ref.split('/').pop() as string]
+        : sub;
+      Object.assign(props, parent.properties ?? {}, s.properties ?? {});
+    }
+    return new Set(Object.keys(props));
+  }
+
+  function successSchema(path: string, method: string) {
+    const op = spec.paths?.[path]?.[method];
+    const res = op?.responses ?? {};
+    return (
+      res['200']?.content?.['application/json']?.schema ??
+      res['201']?.content?.['application/json']?.schema
+    );
+  }
+
+  /**
+   * `formatPost()`가 만드는 필드 — Post의 content를 뺀 전 스칼라 + tags.
+   * prisma/schema.prisma의 model Post와 1:1이다.
+   */
+  const POST_SUMMARY_FIELDS = [
+    'id',
+    'title',
+    'slug',
+    'description',
+    'thumbnailUrl',
+    'category',
+    'published',
+    'publishedAt',
+    'readingTime',
+    'viewCount',
+    'createdAt',
+    'updatedAt',
+    'tags',
+  ];
+
+  describe('스키마가 선언되어 있다', () => {
+    it.each([
+      ['/api/blog/posts', 'get'],
+      ['/api/blog/posts/{slug}', 'get'],
+      ['/api/blog/posts/{slug}/preview', 'get'],
+      ['/api/blog/posts/{slug}/related', 'get'],
+      ['/api/blog/posts/recent', 'get'],
+      ['/api/blog/posts/search', 'get'],
+      ['/api/blog/categories', 'get'],
+      ['/api/blog/tags', 'get'],
+      ['/api/blog/posts', 'post'],
+      ['/api/blog/posts/{slug}', 'put'],
+      ['/api/blog/categories', 'post'],
+      ['/api/blog/categories/{id}', 'put'],
+      ['/api/blog/images', 'post'],
+    ])('%s %s', (path, method) => {
+      expect(successSchema(path, method)).toBeDefined();
+    });
+  });
+
+  /**
+   * 본문이 없는 라우트는 204를 선언해야 한다. 에러 데코레이터(@ApiUnauthorized 등)를
+   * 붙이면 NestJS Swagger가 성공 응답 자동 추론을 멈추므로, @ApiNoContent()를
+   * 명시하지 않으면 "성공하면 무엇이 오는지 알 수 없는" 스펙이 된다.
+   */
+  describe('204 라우트는 204를 선언한다', () => {
+    it.each([
+      ['/api/blog/posts/{slug}', 'delete'],
+      ['/api/blog/categories/{id}', 'delete'],
+    ])('%s %s', (path, method) => {
+      expect(spec.paths?.[path]?.[method]?.responses?.['204']).toBeDefined();
+    });
+  });
+
+  describe('필드가 formatPost 결과와 맞는다', () => {
+    it('목록의 posts 요소는 content를 뺀 Post 전 필드를 갖는다', () => {
+      const schema = successSchema('/api/blog/posts', 'get');
+      const listProps = propsOf(schema);
+      expect(listProps).toEqual(new Set(['posts', 'total', 'page', 'limit', 'totalPages']));
+
+      const itemProps = propsOf(spec.components.schemas.PostSummaryDto);
+      expect([...itemProps].sort()).toEqual([...POST_SUMMARY_FIELDS].sort());
+      expect(itemProps.has('content')).toBe(false);
+    });
+
+    it('상세는 목록 필드에 content가 더해진 것이다', () => {
+      const detail = propsOf(spec.components.schemas.PostDetailDto);
+      expect([...detail].sort()).toEqual([...POST_SUMMARY_FIELDS, 'content'].sort());
+    });
+
+    it.each([
+      ['PostSearchResponseDto', ['posts', 'total', 'query', 'grouped']],
+      ['RelatedPostsResponseDto', ['related', 'recommended']],
+      ['TagListResponseDto', ['tags', 'total']],
+      ['CategoryWithTagsDto', ['category', 'icon', 'count', 'recent', 'tags']],
+      ['CategoryDto', ['id', 'name', 'icon', 'sortOrder']],
+      ['UploadImageResponseDto', ['url']],
+      ['TagCountDto', ['name', 'slug', 'count']],
+    ])('%s', (name, fields) => {
+      expect([...propsOf(spec.components.schemas[name])].sort()).toEqual([...fields].sort());
+    });
+  });
+});

--- a/src/blog/dto/blog-response.dto.ts
+++ b/src/blog/dto/blog-response.dto.ts
@@ -38,6 +38,16 @@ export class TagCountDto {
 
 /** `GET /api/blog/categories` — 카테고리별 글 수와 그 안의 태그 집계. */
 export class CategoryWithTagsDto {
+  /**
+   * 어드민의 수정·삭제가 이 값을 쓴다(`PUT|DELETE /categories/{id}`).
+   *
+   * nullable인 이유: 이 목록은 **발행된 글의 category 값**을 groupBy한 것이라,
+   * categories 테이블에 없는 이름이 글에 들어가 있으면 매칭되는 레코드가 없다.
+   * 그 경우 수정·삭제 대상이 아니므로 프론트가 버튼을 감춰야 한다.
+   */
+  @ApiProperty({ type: Number, nullable: true, example: 1 })
+  id: number | null;
+
   @ApiProperty({ example: 'Frontend' })
   category: string;
 

--- a/src/blog/dto/blog-response.dto.ts
+++ b/src/blog/dto/blog-response.dto.ts
@@ -1,0 +1,123 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PostSummaryDto, PostTagDto } from './post-list-response.dto';
+
+/**
+ * blog 도메인의 응답 스키마.
+ *
+ * 필드는 추측이 아니라 **실제 반환값을 관측해서** 맞췄다. 대부분은
+ * `BlogService.formatPost()`가 만드는 shape이고, 그건 `PostSummaryDto`와 같다:
+ *
+ *   formatPost(post, withContent) {
+ *     const { postTags, content, ...rest } = post;
+ *     return { ...rest, ...(withContent ? { content } : {}), tags: ... };
+ *   }
+ *
+ * 즉 `content`를 뺀 Post의 전 스칼라 필드 + `tags`다. `withContent=true`인
+ * 라우트만 `content`가 추가로 실린다(상세·미리보기·생성·수정).
+ *
+ * DTO가 실제 응답과 어긋나면 타입이 없는 것보다 나쁘다 — 프론트가 그 타입을
+ * 믿고 코드를 짜기 때문이다. 그래서 nullable까지 prisma/schema.prisma와 맞췄다.
+ */
+
+/** 상세·생성·수정 응답. 목록과 달리 `content`(MDX 원문)가 포함된다. */
+export class PostDetailDto extends PostSummaryDto {
+  @ApiProperty({ description: 'MDX 원문', example: '# 제목\n\n본문입니다.' })
+  content: string;
+}
+
+export class TagCountDto {
+  @ApiProperty({ example: 'React' })
+  name: string;
+
+  @ApiProperty({ example: 'react' })
+  slug: string;
+
+  @ApiProperty({ example: 12, description: '이 카테고리 안에서 이 태그가 붙은 글 수' })
+  count: number;
+}
+
+/** `GET /api/blog/categories` — 카테고리별 글 수와 그 안의 태그 집계. */
+export class CategoryWithTagsDto {
+  @ApiProperty({ example: 'Frontend' })
+  category: string;
+
+  @ApiProperty({ example: 'Monitor', description: 'lucide 아이콘 이름' })
+  icon: string;
+
+  @ApiProperty({ example: 8, description: '이 카테고리의 발행된 글 수' })
+  count: number;
+
+  @ApiProperty({ example: true, description: '최근 기간 내 새 글이 있는지' })
+  recent: boolean;
+
+  @ApiProperty({ type: [TagCountDto], description: 'count 내림차순' })
+  tags: TagCountDto[];
+}
+
+/**
+ * `GET /api/blog/posts/search` — 검색 결과.
+ *
+ * `grouped`는 카테고리명을 키로 하는 동적 객체라 정확한 프로퍼티를 선언할 수 없다.
+ * `additionalProperties`로 값의 형태만 기술한다.
+ */
+export class PostSearchResponseDto {
+  @ApiProperty({ type: [PostSummaryDto] })
+  posts: PostSummaryDto[];
+
+  @ApiProperty({ example: 3, description: '검색 조건에 맞는 전체 건수' })
+  total: number;
+
+  @ApiProperty({ example: 'react', description: '검색어(요청의 q를 그대로 되돌려준다)' })
+  query: string;
+
+  @ApiProperty({
+    description: '카테고리명을 키로 묶은 결과. 카테고리가 없는 글은 "Uncategorized"로 묶인다.',
+    type: 'object',
+    additionalProperties: { type: 'array', items: { $ref: '#/components/schemas/PostSummaryDto' } },
+    example: { Frontend: [], Backend: [] },
+  })
+  grouped: Record<string, PostSummaryDto[]>;
+}
+
+/** `GET /api/blog/posts/{slug}/related` — 태그가 겹치는 글과, 부족분을 채운 추천 글. */
+export class RelatedPostsResponseDto {
+  @ApiProperty({ type: [PostSummaryDto], description: '태그가 겹치는 글 (겹친 수 내림차순)' })
+  related: PostSummaryDto[];
+
+  @ApiProperty({
+    type: [PostSummaryDto],
+    description: 'related가 목표 수에 못 미칠 때 최신 글로 채운 분',
+  })
+  recommended: PostSummaryDto[];
+}
+
+export class TagListResponseDto {
+  @ApiProperty({ type: [TagCountDto], description: '글 수 내림차순. 참조가 0인 태그는 제외된다.' })
+  tags: TagCountDto[];
+
+  @ApiProperty({ example: 75, description: '실제로 글에 붙어 있는 태그의 총 개수' })
+  total: number;
+}
+
+/** `POST /api/blog/categories`, `PUT /api/blog/categories/{id}` — Category 레코드 그대로. */
+export class CategoryDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'Frontend' })
+  name: string;
+
+  @ApiProperty({ example: 'Monitor', description: 'lucide 아이콘 이름' })
+  icon: string;
+
+  @ApiProperty({ example: 1 })
+  sortOrder: number;
+}
+
+/** `POST /api/blog/images` — temp 경로에 올라간 이미지 URL. 글 저장 시 확정 경로로 옮겨진다. */
+export class UploadImageResponseDto {
+  @ApiProperty({ example: 'https://assets.chahyunwoo.dev/blog/temp/abc123.png' })
+  url: string;
+}
+
+export { PostTagDto };

--- a/src/common/swagger/error-responses.ts
+++ b/src/common/swagger/error-responses.ts
@@ -13,6 +13,20 @@ const errorSchema = (statusCode: number, error: string, message: string) => ({
   },
 });
 
+/**
+ * 본문 없이 성공하는 라우트(`@HttpCode(HttpStatus.NO_CONTENT)`)의 204를 선언한다.
+ *
+ * **에러 응답 데코레이터를 붙이면 반드시 이것도 붙여야 한다.** NestJS Swagger는
+ * 데코레이터가 하나도 없을 때만 `@HttpCode`를 보고 성공 응답을 자동 추론한다.
+ * `@ApiUnauthorized()` 같은 것이 하나라도 있으면 그 응답만 등록되고 성공 응답은
+ * 스펙에서 사라진다 — 프론트가 보기에 "성공하면 무엇이 오는지 알 수 없는" 라우트가 된다.
+ *
+ * 실측(이 문제를 발견한 경로): 컨트롤러의 NO_CONTENT 라우트 11건 중 스펙에 204가
+ * 잡힌 것은 4건뿐이었고, 나머지 7건은 전부 에러 데코레이터가 붙어 있었다.
+ */
+export const ApiNoContent = (description = 'No Content') =>
+  applyDecorators(ApiResponse({ status: 204, description }));
+
 export const ApiBadRequest = (message = 'Validation failed') =>
   applyDecorators(
     ApiResponse({

--- a/src/dto/health-response.dto.ts
+++ b/src/dto/health-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/** `GET /health` — 배포 파이프라인(deploy.yml)의 헬스체크가 이 200을 본다. */
+export class HealthResponseDto {
+  @ApiProperty({ example: 'ok' })
+  status: string;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  timestamp: string;
+}

--- a/src/dto/openapi-coverage.spec.ts
+++ b/src/dto/openapi-coverage.spec.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * 커밋된 `openapi.json`의 **응답 스키마 커버리지**를 고정한다.
+ *
+ * 프론트(`hyunwoo-dev`)는 이 파일에서 타입을 생성하고, `ApiOkJson<P, M>` 헬퍼는
+ * 스키마가 없는 라우트에 `MissingResponseSchema`를 돌려줘 컴파일을 터뜨린다.
+ * 즉 여기 구멍이 하나 생기면 프론트가 그 라우트를 타입 안전하게 쓸 수 없다.
+ *
+ * 개별 도메인의 필드 검증은 각 도메인의 `*-response.dto.spec.ts`에 있다.
+ * 이 파일은 "빠진 라우트가 없는가" 하나만 본다.
+ */
+describe('OpenAPI 응답 스키마 커버리지', () => {
+  const spec = JSON.parse(readFileSync(join(__dirname, '../../openapi.json'), 'utf8'));
+
+  type Operation = {
+    responses?: Record<string, { content?: Record<string, unknown> }>;
+  };
+
+  const operations: Array<{ path: string; method: string; op: Operation }> = [];
+  for (const [path, item] of Object.entries(
+    spec.paths as Record<string, Record<string, Operation>>,
+  )) {
+    for (const [method, op] of Object.entries(item)) {
+      operations.push({ path, method, op });
+    }
+  }
+
+  function hasSuccessBody(op: Operation) {
+    const r = op.responses ?? {};
+    return Boolean(
+      r['200']?.content?.['application/json'] ?? r['201']?.content?.['application/json'],
+    );
+  }
+  const hasNoContent = (op: Operation) => Boolean(op.responses?.['204']);
+
+  it('스펙에 오퍼레이션이 있다', () => {
+    expect(operations.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * 이 프로젝트의 핵심 불변식. 모든 오퍼레이션은 둘 중 하나여야 한다:
+   *   - 200/201에 application/json 스키마가 있다
+   *   - 204를 선언했다 (본문이 없는 라우트)
+   *
+   * 어느 쪽도 아니면 "성공하면 무엇이 오는지 알 수 없는" 라우트다.
+   * 실제로 그런 라우트가 67건 있었고(#103 착수 시점), 그중 8건은 204인데
+   * 에러 데코레이터 때문에 성공 응답이 스펙에서 사라진 경우였다.
+   */
+  it('모든 오퍼레이션이 성공 응답을 선언한다', () => {
+    const missing = operations
+      .filter(({ op }) => !hasSuccessBody(op) && !hasNoContent(op))
+      .map(({ method, path }) => `${method.toUpperCase()} ${path}`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('204 라우트는 본문 스키마를 갖지 않는다', () => {
+    const both = operations
+      .filter(({ op }) => hasNoContent(op) && hasSuccessBody(op))
+      .map(({ method, path }) => `${method.toUpperCase()} ${path}`);
+
+    expect(both).toEqual([]);
+  });
+});

--- a/src/health.controller.ts
+++ b/src/health.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from './common/decorators/public.decorator';
 import { SkipApiKey } from './common/decorators/skip-api-key.decorator';
+import { HealthResponseDto } from './dto/health-response.dto';
 
 @ApiTags('health')
 @Controller()
@@ -10,6 +10,7 @@ export class HealthController {
   @Public()
   @SkipApiKey()
   @Get('health')
+  @ApiOkResponse({ type: HealthResponseDto })
   check() {
     return { status: 'ok', timestamp: new Date().toISOString() };
   }

--- a/src/portfolio/dto/portfolio-response.dto.spec.ts
+++ b/src/portfolio/dto/portfolio-response.dto.spec.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * 커밋된 `openapi.json`의 portfolio 응답 스키마를 고정한다.
+ *
+ * 이 도메인은 i18n 구조라 **같은 리소스라도 라우트마다 shape이 다르다**:
+ *
+ *   GET /experiences?locale=  → 번역을 평탄화 (title, role, responsibilities)
+ *   GET /experiences/{id}     → Prisma 레코드 그대로 (translations 배열)
+ *   POST/PUT /experiences     → Prisma 레코드 그대로
+ *
+ * 하나로 묶으면 어느 쪽이든 거짓말이 된다. 실제 응답과 대조하며 잡은 어긋남이
+ * 세 건 있었고(아래), 그 형태를 여기에 고정한다.
+ */
+describe('portfolio 응답 스키마', () => {
+  const spec = JSON.parse(readFileSync(join(__dirname, '../../../openapi.json'), 'utf8'));
+
+  type Schema = {
+    $ref?: string;
+    type?: string;
+    items?: Schema;
+    properties?: Record<string, unknown>;
+    allOf?: Schema[];
+  };
+
+  function propsOf(schema: Schema): Set<string> {
+    let s = schema;
+    if (s.$ref) s = spec.components.schemas[s.$ref.split('/').pop() as string];
+    if (s.type === 'array' && s.items) return propsOf(s.items);
+    const props: Record<string, unknown> = { ...(s.properties ?? {}) };
+    for (const sub of s.allOf ?? []) {
+      const parent: Schema = sub.$ref
+        ? spec.components.schemas[sub.$ref.split('/').pop() as string]
+        : sub;
+      Object.assign(props, parent.properties ?? {}, s.properties ?? {});
+    }
+    return new Set(Object.keys(props));
+  }
+
+  function successSchema(path: string, method: string) {
+    const res = spec.paths?.[path]?.[method]?.responses ?? {};
+    return (
+      res['200']?.content?.['application/json']?.schema ??
+      res['201']?.content?.['application/json']?.schema
+    );
+  }
+
+  describe('스키마가 선언되어 있다', () => {
+    it.each([
+      ['/api/portfolio/locales', 'get'],
+      ['/api/portfolio/locales', 'post'],
+      ['/api/portfolio/profile', 'get'],
+      ['/api/portfolio/profile', 'put'],
+      ['/api/portfolio/profile/all', 'get'],
+      ['/api/portfolio/profile/image', 'post'],
+      ['/api/portfolio/profile/icon', 'post'],
+      ['/api/portfolio/experiences', 'get'],
+      ['/api/portfolio/experiences', 'post'],
+      ['/api/portfolio/experiences/{id}', 'get'],
+      ['/api/portfolio/experiences/{id}', 'put'],
+      ['/api/portfolio/projects', 'get'],
+      ['/api/portfolio/projects', 'post'],
+      ['/api/portfolio/projects/{id}', 'get'],
+      ['/api/portfolio/projects/{id}', 'put'],
+      ['/api/portfolio/works', 'get'],
+      ['/api/portfolio/works', 'post'],
+      ['/api/portfolio/works/{id}', 'get'],
+      ['/api/portfolio/works/{id}', 'put'],
+      ['/api/portfolio/skills', 'get'],
+      ['/api/portfolio/skills', 'post'],
+      ['/api/portfolio/skills/{id}', 'put'],
+      ['/api/portfolio/education', 'get'],
+      ['/api/portfolio/education', 'post'],
+      ['/api/portfolio/education/{id}', 'get'],
+      ['/api/portfolio/education/{id}', 'put'],
+      ['/api/portfolio/contact', 'post'],
+      ['/api/portfolio/contacts', 'get'],
+      ['/api/portfolio/contacts/{id}/read', 'put'],
+    ])('%s %s', (path, method) => {
+      expect(successSchema(path, method)).toBeDefined();
+    });
+  });
+
+  describe('204 라우트는 204를 선언한다', () => {
+    it.each([
+      ['/api/portfolio/locales/{id}', 'delete'],
+      ['/api/portfolio/experiences/{id}', 'delete'],
+      ['/api/portfolio/projects/{id}', 'delete'],
+      ['/api/portfolio/works/{id}', 'delete'],
+      ['/api/portfolio/skills/{id}', 'delete'],
+      ['/api/portfolio/education/{id}', 'delete'],
+      ['/api/portfolio/contacts/{id}', 'delete'],
+    ])('%s %s', (path, method) => {
+      expect(spec.paths?.[path]?.[method]?.responses?.['204']).toBeDefined();
+    });
+  });
+
+  describe('평탄화 조회와 레코드 조회를 구분한다', () => {
+    it('목록은 번역을 평탄화한다 (translations 배열이 없다)', () => {
+      const flat = propsOf(spec.components.schemas.ExperienceDto);
+      expect(flat).toEqual(
+        new Set(['id', 'startDate', 'endDate', 'isCurrent', 'title', 'role', 'responsibilities']),
+      );
+      expect(flat.has('translations')).toBe(false);
+    });
+
+    it('단건/CRUD는 레코드 그대로다 (translations 배열이 있다)', () => {
+      const rec = propsOf(spec.components.schemas.ExperienceRecordDto);
+      expect(rec.has('translations')).toBe(true);
+      expect(rec.has('title')).toBe(false);
+    });
+  });
+
+  /**
+   * 아래 셋은 실제 응답과 대조하다 잡은 어긋남이다. 코드가 바뀌면 다시 어긋나므로 고정한다.
+   */
+  describe('실측으로 잡은 어긋남', () => {
+    it('GET /profile/all은 id를 돌려주지 않는다', () => {
+      expect(propsOf(spec.components.schemas.ProfileWithTranslationsDto).has('id')).toBe(false);
+    });
+
+    it('GET /works/{id}만 gradientColors를 붙인다 (create/update에는 없다)', () => {
+      expect(propsOf(spec.components.schemas.WorkDetailDto).has('gradientColors')).toBe(true);
+      expect(propsOf(spec.components.schemas.WorkRecordDto).has('gradientColors')).toBe(false);
+    });
+
+    it('ContactMessageDto에 subject가 있다', () => {
+      expect(propsOf(spec.components.schemas.ContactMessageDto)).toEqual(
+        new Set(['id', 'name', 'email', 'subject', 'message', 'read', 'createdAt']),
+      );
+    });
+  });
+
+  describe('필드 집합', () => {
+    it.each([
+      ['ProfileDto', ['name', 'location', 'imageUrl', 'iconUrl', 'socialLinks', 'jobTitle', 'introduction']],
+      ['ProjectDto', ['id', 'demoUrl', 'repoUrl', 'techStack', 'featured', 'title', 'description']],
+      ['EducationDto', ['id', 'period', 'institution', 'degree']],
+      ['SkillGroupDto', ['category', 'items']],
+      ['SkillItemDto', ['id', 'name', 'proficiency', 'description']],
+      ['LocaleDto', ['id', 'code', 'label']],
+      ['ContactResultDto', ['success', 'message']],
+      ['UploadUrlResponseDto', ['url']],
+    ])('%s', (name, fields) => {
+      expect([...propsOf(spec.components.schemas[name])].sort()).toEqual([...fields].sort());
+    });
+  });
+});

--- a/src/portfolio/dto/portfolio-response.dto.spec.ts
+++ b/src/portfolio/dto/portfolio-response.dto.spec.ts
@@ -144,6 +144,8 @@ describe('portfolio 응답 스키마', () => {
       ['SkillItemDto', ['id', 'name', 'proficiency', 'description']],
       ['LocaleDto', ['id', 'code', 'label']],
       ['ContactResultDto', ['success', 'message']],
+      // icon이 빠지면 포트폴리오 연락처 섹션이 아이콘을 고르지 못한다
+      ['SocialLinkDto', ['name', 'href', 'icon']],
       ['UploadUrlResponseDto', ['url']],
     ])('%s', (name, fields) => {
       expect([...propsOf(spec.components.schemas[name])].sort()).toEqual([...fields].sort());

--- a/src/portfolio/dto/portfolio-response.dto.spec.ts
+++ b/src/portfolio/dto/portfolio-response.dto.spec.ts
@@ -134,7 +134,10 @@ describe('portfolio 응답 스키마', () => {
 
   describe('필드 집합', () => {
     it.each([
-      ['ProfileDto', ['name', 'location', 'imageUrl', 'iconUrl', 'socialLinks', 'jobTitle', 'introduction']],
+      [
+        'ProfileDto',
+        ['name', 'location', 'imageUrl', 'iconUrl', 'socialLinks', 'jobTitle', 'introduction'],
+      ],
       ['ProjectDto', ['id', 'demoUrl', 'repoUrl', 'techStack', 'featured', 'title', 'description']],
       ['EducationDto', ['id', 'period', 'institution', 'degree']],
       ['SkillGroupDto', ['category', 'items']],

--- a/src/portfolio/dto/portfolio-response.dto.ts
+++ b/src/portfolio/dto/portfolio-response.dto.ts
@@ -1,0 +1,507 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * portfolio 도메인의 응답 스키마.
+ *
+ * **목록/단건 조회와 CRUD 응답의 shape이 다르다.** 이 도메인은 i18n 구조라
+ * (`*_translations` 테이블) 조회 계열은 요청 locale의 번역을 골라 **평탄화**해서
+ * 돌려주고, `create`/`update`/`getXById`는 Prisma 레코드를 **그대로** 돌려준다
+ * (`translations` 배열이 그대로 실린다).
+ *
+ * 예: `getExperiences(locale)`는 `{ id, startDate, ..., title, role, responsibilities }`를
+ * 만들지만 `getExperienceById(id)`는 `{ id, startDate, ..., translations: [...] }`다.
+ * 둘을 같은 DTO로 묶으면 어느 쪽이든 거짓말이 된다.
+ *
+ * 필드는 추측이 아니라 서비스 코드의 반환문을 그대로 옮긴 것이고, 실제 응답과
+ * 대조해 확인했다.
+ */
+
+// ─── 공통 ─────────────────────────────────────────────────────────────────────
+
+export class SocialLinkDto {
+  @ApiProperty({ example: 'GitHub' })
+  name: string;
+
+  @ApiProperty({ example: 'https://github.com/chahyunwoo' })
+  href: string;
+}
+
+/** 업로드 응답 — `POST /profile/image`, `POST /profile/icon`. */
+export class UploadUrlResponseDto {
+  @ApiProperty({ example: 'https://assets.chahyunwoo.dev/profile/image/abc.png' })
+  url: string;
+}
+
+export class LocaleDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'ko' })
+  code: string;
+
+  @ApiProperty({ example: '한국어' })
+  label: string;
+}
+
+// ─── Profile ──────────────────────────────────────────────────────────────────
+
+/** `GET /profile?locale=` — 요청 locale의 번역을 평탄화한 결과. */
+export class ProfileDto {
+  @ApiProperty({ example: '차현우' })
+  name: string;
+
+  @ApiProperty({ example: '서울, 대한민국' })
+  location: string;
+
+  @ApiProperty({ type: String, nullable: true })
+  imageUrl: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  iconUrl: string | null;
+
+  @ApiProperty({ type: [SocialLinkDto] })
+  socialLinks: SocialLinkDto[];
+
+  @ApiProperty({ example: 'Full-Stack Developer', description: '번역이 없으면 빈 문자열' })
+  jobTitle: string;
+
+  @ApiProperty({ type: [String], description: '문단 배열. 번역이 없으면 빈 배열' })
+  introduction: string[];
+}
+
+export class ProfileTranslationDto {
+  @ApiProperty({ example: 'ko' })
+  locale: string;
+
+  @ApiProperty({ example: 'Full-Stack Developer' })
+  jobTitle: string;
+
+  @ApiProperty({ type: [String] })
+  introduction: string[];
+}
+
+/**
+ * `GET /profile/all` — 어드민용. 모든 locale의 번역을 함께 돌려준다.
+ *
+ * Prisma 레코드를 그대로 주지 않는다 — `id`를 빼고 translations도 3필드만 골라 담는다.
+ */
+export class ProfileWithTranslationsDto {
+  @ApiProperty({ example: '차현우' })
+  name: string;
+
+  @ApiProperty({ example: '서울, 대한민국' })
+  location: string;
+
+  @ApiProperty({ type: String, nullable: true })
+  imageUrl: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  iconUrl: string | null;
+
+  @ApiProperty({ type: [SocialLinkDto] })
+  socialLinks: SocialLinkDto[];
+
+  @ApiProperty({ type: [ProfileTranslationDto] })
+  translations: ProfileTranslationDto[];
+}
+
+// ─── Experience ───────────────────────────────────────────────────────────────
+
+/** `GET /experiences?locale=` — 평탄화된 목록. */
+export class ExperienceDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  startDate: string | null;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  endDate: string | null;
+
+  @ApiProperty({ example: false })
+  isCurrent: boolean;
+
+  @ApiProperty({ example: '회사명', description: '번역이 없으면 빈 문자열' })
+  title: string;
+
+  @ApiProperty({ example: 'Backend Developer', description: '번역이 없으면 빈 문자열' })
+  role: string;
+
+  @ApiProperty({ type: [String], description: '번역이 없으면 빈 배열' })
+  responsibilities: string[];
+}
+
+export class ExperienceTranslationDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 1 })
+  experienceId: number;
+
+  @ApiProperty({ example: 'ko' })
+  locale: string;
+
+  @ApiProperty({ example: '회사명' })
+  title: string;
+
+  @ApiProperty({ example: 'Backend Developer' })
+  role: string;
+
+  @ApiProperty({ type: [String] })
+  responsibilities: string[];
+}
+
+/**
+ * `GET /experiences/{id}`, `POST /experiences`, `PUT /experiences/{id}` —
+ * Prisma 레코드 그대로. 목록과 달리 평탄화하지 않고 `translations`가 그대로 실린다.
+ */
+export class ExperienceRecordDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  startDate: string | null;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  endDate: string | null;
+
+  @ApiProperty({ example: false })
+  isCurrent: boolean;
+
+  @ApiProperty({ example: 0 })
+  sortOrder: number;
+
+  @ApiProperty({ type: [ExperienceTranslationDto] })
+  translations: ExperienceTranslationDto[];
+}
+
+// ─── Project ──────────────────────────────────────────────────────────────────
+
+export class ProjectDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ type: String, nullable: true })
+  demoUrl: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  repoUrl: string | null;
+
+  @ApiProperty({ type: [String] })
+  techStack: string[];
+
+  @ApiProperty({ example: false })
+  featured: boolean;
+
+  @ApiProperty({ example: '프로젝트명', description: '번역이 없으면 빈 문자열' })
+  title: string;
+
+  @ApiProperty({ example: '설명', description: '번역이 없으면 빈 문자열' })
+  description: string;
+}
+
+export class ProjectTranslationDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 1 })
+  projectId: number;
+
+  @ApiProperty({ example: 'ko' })
+  locale: string;
+
+  @ApiProperty({ example: '프로젝트명' })
+  title: string;
+
+  @ApiProperty({ example: '설명' })
+  description: string;
+}
+
+/** `GET /projects/{id}`, `POST /projects`, `PUT /projects/{id}` — Prisma 레코드 그대로. */
+export class ProjectRecordDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ type: String, nullable: true })
+  demoUrl: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  repoUrl: string | null;
+
+  @ApiProperty({ type: [String] })
+  techStack: string[];
+
+  @ApiProperty({ example: false })
+  featured: boolean;
+
+  @ApiProperty({ example: 0 })
+  sortOrder: number;
+
+  @ApiProperty({ type: [ProjectTranslationDto] })
+  translations: ProjectTranslationDto[];
+}
+
+// ─── Work ─────────────────────────────────────────────────────────────────────
+
+export class WorkDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'company', description: 'company | side | freelance 등' })
+  type: string;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  startDate: string | null;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  endDate: string | null;
+
+  @ApiProperty({ example: false })
+  isCurrent: boolean;
+
+  @ApiProperty({ type: [String] })
+  techStack: string[];
+
+  @ApiProperty({ type: String, nullable: true })
+  demoUrl: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  repoUrl: string | null;
+
+  @ApiProperty({ example: false })
+  featured: boolean;
+
+  @ApiProperty({
+    type: [String],
+    description: 'title과 featured로 서버에서 생성한 그라디언트 색. DB 값이 아니다.',
+    example: ['#4F46E5', '#7C3AED'],
+  })
+  gradientColors: string[];
+
+  @ApiProperty({ example: '프로젝트명', description: '번역이 없으면 빈 문자열' })
+  title: string;
+
+  @ApiProperty({ type: String, nullable: true, description: '번역이 없으면 null' })
+  role: string | null;
+
+  @ApiProperty({ example: '한 줄 요약', description: '번역이 없으면 빈 문자열' })
+  summary: string;
+
+  @ApiProperty({ description: 'MDX 본문. 번역이 없으면 빈 문자열' })
+  content: string;
+
+  @ApiProperty({ type: [String], description: '번역이 없으면 빈 배열' })
+  highlights: string[];
+}
+
+export class WorkTranslationDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 1 })
+  workId: number;
+
+  @ApiProperty({ example: 'ko' })
+  locale: string;
+
+  @ApiProperty({ example: '프로젝트명' })
+  title: string;
+
+  @ApiProperty({ type: String, nullable: true })
+  role: string | null;
+
+  @ApiProperty({ example: '한 줄 요약' })
+  summary: string;
+
+  @ApiProperty({ description: 'MDX 본문' })
+  content: string;
+
+  @ApiProperty({ type: [String] })
+  highlights: string[];
+}
+
+/** `POST /works`, `PUT /works/{id}` — Prisma 레코드 그대로. */
+export class WorkRecordDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'company' })
+  type: string;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  startDate: string | null;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  endDate: string | null;
+
+  @ApiProperty({ example: false })
+  isCurrent: boolean;
+
+  @ApiProperty({ type: [String] })
+  techStack: string[];
+
+  @ApiProperty({ type: String, nullable: true })
+  demoUrl: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  repoUrl: string | null;
+
+  @ApiProperty({ example: false })
+  featured: boolean;
+
+  @ApiProperty({ example: 0 })
+  sortOrder: number;
+
+  @ApiProperty({ type: [WorkTranslationDto] })
+  translations: WorkTranslationDto[];
+}
+
+/**
+ * `GET /works/{id}` — Prisma 레코드 + `gradientColors`.
+ *
+ * `create`/`update`와 달리 상세 조회만 `gradientColors`를 덧붙인다
+ * (`getWorkById`가 기본 locale 번역의 title로 생성한다). 같은 DTO를 쓰면
+ * CRUD 응답에 없는 필드를 있다고 말하게 된다.
+ */
+export class WorkDetailDto extends WorkRecordDto {
+  @ApiProperty({
+    type: [String],
+    description: 'title과 featured로 서버에서 생성한 그라디언트 색. DB 값이 아니다.',
+    example: ['#4F46E5', '#7C3AED'],
+  })
+  gradientColors: string[];
+}
+
+// ─── Skill ────────────────────────────────────────────────────────────────────
+
+export class SkillItemDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'TypeScript' })
+  name: string;
+
+  @ApiProperty({ example: 90, description: '0-100' })
+  proficiency: number;
+
+  @ApiProperty({ type: String, nullable: true })
+  description: string | null;
+}
+
+/** `GET /skills` — category로 묶은 그룹 배열. locale 무관(번역 테이블이 없다). */
+export class SkillGroupDto {
+  @ApiProperty({ example: 'Frontend' })
+  category: string;
+
+  @ApiProperty({ type: [SkillItemDto], description: 'sortOrder 오름차순' })
+  items: SkillItemDto[];
+}
+
+/** `POST /skills`, `PUT /skills/{id}` — Prisma 레코드 그대로. */
+export class SkillRecordDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'Frontend' })
+  category: string;
+
+  @ApiProperty({ example: 'TypeScript' })
+  name: string;
+
+  @ApiProperty({ example: 90 })
+  proficiency: number;
+
+  @ApiProperty({ type: String, nullable: true })
+  description: string | null;
+
+  @ApiProperty({ example: 0 })
+  sortOrder: number;
+}
+
+// ─── Education ────────────────────────────────────────────────────────────────
+
+export class EducationDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: '2018.03 - 2022.02' })
+  period: string;
+
+  @ApiProperty({ example: '○○대학교', description: '번역이 없으면 빈 문자열' })
+  institution: string;
+
+  @ApiProperty({ example: '컴퓨터공학 학사', description: '번역이 없으면 빈 문자열' })
+  degree: string;
+}
+
+export class EducationTranslationDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 1 })
+  educationId: number;
+
+  @ApiProperty({ example: 'ko' })
+  locale: string;
+
+  @ApiProperty({ example: '○○대학교' })
+  institution: string;
+
+  @ApiProperty({ example: '컴퓨터공학 학사' })
+  degree: string;
+}
+
+/** `GET /education/{id}`, `POST /education`, `PUT /education/{id}` — Prisma 레코드 그대로. */
+export class EducationRecordDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: '2018.03 - 2022.02' })
+  period: string;
+
+  @ApiProperty({ example: 0 })
+  sortOrder: number;
+
+  @ApiProperty({ type: [EducationTranslationDto] })
+  translations: EducationTranslationDto[];
+}
+
+// ─── Contact ──────────────────────────────────────────────────────────────────
+
+/**
+ * `POST /contact` — 문의 접수 결과.
+ *
+ * 동일 이메일 10분 쿨다운에 걸려도 같은 응답을 돌려준다(스팸 대응이 드러나지 않게).
+ * 즉 `success: true`가 "새 메시지가 저장됐다"를 뜻하지는 않는다.
+ */
+export class ContactResultDto {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Message sent successfully' })
+  message: string;
+}
+
+/** `GET /contacts`, `PUT /contacts/{id}/read` — Prisma 레코드 그대로. */
+export class ContactMessageDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: '홍길동' })
+  name: string;
+
+  @ApiProperty({ example: 'someone@example.com' })
+  email: string;
+
+  @ApiProperty({ type: String, nullable: true, example: '협업 문의' })
+  subject: string | null;
+
+  @ApiProperty({ example: '문의 내용입니다.' })
+  message: string;
+
+  @ApiProperty({ example: false })
+  read: boolean;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt: string;
+}

--- a/src/portfolio/dto/portfolio-response.dto.ts
+++ b/src/portfolio/dto/portfolio-response.dto.ts
@@ -18,12 +18,23 @@ import { ApiProperty } from '@nestjs/swagger';
 
 // ─── 공통 ─────────────────────────────────────────────────────────────────────
 
+/**
+ * `profiles.social_links`(JSON 컬럼)의 요소.
+ *
+ * `icon`은 프론트가 실제로 쓴다 — 포트폴리오 연락처 섹션이 이 값으로 lucide
+ * 아이콘을 고른다(`contact-section.tsx`의 `ICON_MAP[link.icon.toLowerCase()]`).
+ * 처음 이 DTO를 쓸 때 `name`/`href`만 선언했다가, 프론트를 생성 타입으로
+ * 전환하면서 컴파일 에러로 드러났다.
+ */
 export class SocialLinkDto {
-  @ApiProperty({ example: 'GitHub' })
+  @ApiProperty({ example: 'Github' })
   name: string;
 
   @ApiProperty({ example: 'https://github.com/chahyunwoo' })
   href: string;
+
+  @ApiProperty({ example: 'Github', description: 'lucide 아이콘 이름(대소문자 무관)' })
+  icon: string;
 }
 
 /** 업로드 응답 — `POST /profile/image`, `POST /profile/icon`. */

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -12,7 +12,15 @@ import {
   Query,
   Req,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiConsumes, ApiCookieAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiConsumes,
+  ApiCookieAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { Public } from '../common/decorators/public.decorator';
 import {
@@ -42,6 +50,25 @@ import {
   UpdateSkillDto,
   UpdateWorkDto,
 } from './dto';
+import {
+  ContactMessageDto,
+  ContactResultDto,
+  EducationDto,
+  EducationRecordDto,
+  ExperienceDto,
+  ExperienceRecordDto,
+  LocaleDto,
+  ProfileDto,
+  ProfileWithTranslationsDto,
+  ProjectDto,
+  ProjectRecordDto,
+  SkillGroupDto,
+  SkillRecordDto,
+  UploadUrlResponseDto,
+  WorkDetailDto,
+  WorkDto,
+  WorkRecordDto,
+} from './dto/portfolio-response.dto';
 import { ValidateLocalePipe } from './pipes/validate-locale.pipe';
 import { PortfolioService } from './portfolio.service';
 
@@ -55,6 +82,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('locales')
+  @ApiOkResponse({ type: [LocaleDto] })
   getLocales() {
     return this.portfolioService.getLocales();
   }
@@ -62,6 +90,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('profile')
+  @ApiOkResponse({ type: ProfileDto })
   @ApiNotFound('Profile')
   @ApiBadRequest('Unsupported locale')
   getProfile(@Query(ValidateLocalePipe) query: LocaleQueryDto) {
@@ -71,6 +100,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('profile/all')
+  @ApiOkResponse({ type: ProfileWithTranslationsDto })
   @ApiNotFound('Profile')
   getProfileWithTranslations() {
     return this.portfolioService.getProfileWithTranslations();
@@ -79,6 +109,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('experiences')
+  @ApiOkResponse({ type: [ExperienceDto] })
   @ApiBadRequest('Unsupported locale')
   getExperiences(@Query(ValidateLocalePipe) query: LocaleQueryDto) {
     return this.portfolioService.getExperiences(query.locale ?? 'ko');
@@ -87,6 +118,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('projects')
+  @ApiOkResponse({ type: [ProjectDto] })
   @ApiBadRequest('Unsupported locale')
   getProjects(@Query(ValidateLocalePipe) query: GetProjectsQueryDto) {
     return this.portfolioService.getProjects(query.locale ?? 'ko', query.featured);
@@ -95,6 +127,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('skills')
+  @ApiOkResponse({ type: [SkillGroupDto] })
   getSkills() {
     return this.portfolioService.getSkills();
   }
@@ -102,6 +135,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('works')
+  @ApiOkResponse({ type: [WorkDto] })
   @ApiBadRequest('Unsupported locale')
   getWorks(@Query(ValidateLocalePipe) query: GetWorksQueryDto) {
     return this.portfolioService.getWorks(query.locale ?? 'ko', query.type);
@@ -110,6 +144,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('works/:id')
+  @ApiOkResponse({ type: WorkDetailDto })
   @ApiNotFound('Work')
   getWorkById(@Param('id', ParseIntPipe) id: number) {
     return this.portfolioService.getWorkById(id);
@@ -118,6 +153,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('experiences/:id')
+  @ApiOkResponse({ type: ExperienceRecordDto })
   @ApiNotFound('Experience')
   getExperienceById(@Param('id', ParseIntPipe) id: number) {
     return this.portfolioService.getExperienceById(id);
@@ -126,6 +162,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('projects/:id')
+  @ApiOkResponse({ type: ProjectRecordDto })
   @ApiNotFound('Project')
   getProjectById(@Param('id', ParseIntPipe) id: number) {
     return this.portfolioService.getProjectById(id);
@@ -134,6 +171,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('education/:id')
+  @ApiOkResponse({ type: EducationRecordDto })
   @ApiNotFound('Education')
   getEducationById(@Param('id', ParseIntPipe) id: number) {
     return this.portfolioService.getEducationById(id);
@@ -142,6 +180,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Get('education')
+  @ApiOkResponse({ type: [EducationDto] })
   @ApiBadRequest('Unsupported locale')
   getEducation(@Query(ValidateLocalePipe) query: LocaleQueryDto) {
     return this.portfolioService.getEducation(query.locale ?? 'ko');
@@ -152,6 +191,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('locales')
+  @ApiCreatedResponse({ type: LocaleDto })
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
   @ApiBadRequest()
@@ -174,6 +214,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('profile')
+  @ApiOkResponse({ type: ProfileWithTranslationsDto })
   @ApiUnauthorized()
   updateProfile(@Body() dto: UpdateProfileDto) {
     return this.portfolioService.updateProfile(dto);
@@ -182,6 +223,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('profile/image')
+  @ApiCreatedResponse({ type: UploadUrlResponseDto })
   @ApiConsumes('multipart/form-data')
   @ApiUnauthorized()
   @ApiBadRequest('No file provided or invalid file type')
@@ -197,6 +239,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('profile/icon')
+  @ApiCreatedResponse({ type: UploadUrlResponseDto })
   @ApiConsumes('multipart/form-data')
   @ApiUnauthorized()
   @ApiBadRequest('No file provided or invalid file type')
@@ -212,6 +255,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('experiences')
+  @ApiCreatedResponse({ type: ExperienceRecordDto })
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
   @ApiBadRequest()
@@ -222,6 +266,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('experiences/:id')
+  @ApiOkResponse({ type: ExperienceRecordDto })
   @ApiUnauthorized()
   @ApiNotFound('Experience')
   updateExperience(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateExperienceDto) {
@@ -242,6 +287,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('projects')
+  @ApiCreatedResponse({ type: ProjectRecordDto })
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
   @ApiBadRequest()
@@ -252,6 +298,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('projects/:id')
+  @ApiOkResponse({ type: ProjectRecordDto })
   @ApiUnauthorized()
   @ApiNotFound('Project')
   updateProject(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateProjectDto) {
@@ -272,6 +319,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('skills')
+  @ApiCreatedResponse({ type: SkillRecordDto })
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
   @ApiBadRequest()
@@ -282,6 +330,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('skills/:id')
+  @ApiOkResponse({ type: SkillRecordDto })
   @ApiUnauthorized()
   @ApiNotFound('Skill')
   updateSkill(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateSkillDto) {
@@ -302,6 +351,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('education')
+  @ApiCreatedResponse({ type: EducationRecordDto })
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
   @ApiBadRequest()
@@ -312,6 +362,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('education/:id')
+  @ApiOkResponse({ type: EducationRecordDto })
   @ApiUnauthorized()
   @ApiNotFound('Education')
   updateEducation(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateEducationDto) {
@@ -332,6 +383,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Post('works')
+  @ApiCreatedResponse({ type: WorkRecordDto })
   @HttpCode(HttpStatus.CREATED)
   @ApiUnauthorized()
   @ApiBadRequest()
@@ -342,6 +394,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('works/:id')
+  @ApiOkResponse({ type: WorkRecordDto })
   @ApiUnauthorized()
   @ApiNotFound('Work')
   updateWork(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateWorkDto) {
@@ -364,6 +417,7 @@ export class PortfolioController {
   @Public()
   @ApiSecurity('api-key')
   @Post('contact')
+  @ApiCreatedResponse({ type: ContactResultDto })
   @HttpCode(HttpStatus.OK)
   @Throttle({ default: { ttl: 60_000, limit: 2 } })
   @ApiBadRequest()
@@ -374,6 +428,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Get('contacts')
+  @ApiOkResponse({ type: [ContactMessageDto] })
   @ApiUnauthorized()
   getContacts(@Query('limit', new ParseIntPipe({ optional: true })) limit?: number) {
     return this.portfolioService.getContacts(limit);
@@ -382,6 +437,7 @@ export class PortfolioController {
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('contacts/:id/read')
+  @ApiOkResponse({ type: ContactMessageDto })
   @ApiUnauthorized()
   @ApiNotFound('Contact message')
   markContactRead(@Param('id', ParseIntPipe) id: number) {

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -18,6 +18,7 @@ import { Public } from '../common/decorators/public.decorator';
 import {
   ApiBadRequest,
   ApiConflict,
+  ApiNoContent,
   ApiNotFound,
   ApiUnauthorized,
 } from '../common/swagger/error-responses';
@@ -163,6 +164,7 @@ export class PortfolioController {
   @ApiCookieAuth()
   @Delete('locales/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContent()
   @ApiUnauthorized()
   @ApiNotFound('Locale')
   deleteLocale(@Param('id', ParseIntPipe) id: number) {
@@ -230,6 +232,7 @@ export class PortfolioController {
   @ApiCookieAuth()
   @Delete('experiences/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContent()
   @ApiUnauthorized()
   @ApiNotFound('Experience')
   deleteExperience(@Param('id', ParseIntPipe) id: number) {
@@ -259,6 +262,7 @@ export class PortfolioController {
   @ApiCookieAuth()
   @Delete('projects/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContent()
   @ApiUnauthorized()
   @ApiNotFound('Project')
   deleteProject(@Param('id', ParseIntPipe) id: number) {
@@ -288,6 +292,7 @@ export class PortfolioController {
   @ApiCookieAuth()
   @Delete('skills/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContent()
   @ApiUnauthorized()
   @ApiNotFound('Skill')
   deleteSkill(@Param('id', ParseIntPipe) id: number) {
@@ -317,6 +322,7 @@ export class PortfolioController {
   @ApiCookieAuth()
   @Delete('education/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContent()
   @ApiUnauthorized()
   @ApiNotFound('Education')
   deleteEducation(@Param('id', ParseIntPipe) id: number) {
@@ -346,6 +352,7 @@ export class PortfolioController {
   @ApiCookieAuth()
   @Delete('works/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContent()
   @ApiUnauthorized()
   @ApiNotFound('Work')
   deleteWork(@Param('id', ParseIntPipe) id: number) {
@@ -385,6 +392,7 @@ export class PortfolioController {
   @ApiCookieAuth()
   @Delete('contacts/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContent()
   @ApiUnauthorized()
   @ApiNotFound('Contact message')
   deleteContact(@Param('id', ParseIntPipe) id: number) {


### PR DESCRIPTION
스펙 커버리지 완성과 그 과정에서 드러난 실제 버그 수정을 프로덕션에 올린다.

**이 PR을 병합하면 배포된다** — `main` 푸시 → GitHub Actions → Tailscale SSH → 맥미니 Docker.

## 담긴 것 (13커밋)

| | 내용 |
|---|---|
| #103 | **72개 오퍼레이션 전부에 Response DTO 선언** (착수 시점 1건) |
| #134 | 카테고리 목록에 `id` 누락 — **어드민 수정·삭제가 항상 400이었다** |
| — | `SocialLinkDto.icon` 누락 — 프론트 연락처 아이콘이 못 쓰던 필드 |
| — | `ReferrerItemDto.category`를 enum으로 좁힘 |
| — | 204 라우트 8건이 스펙에서 성공 응답 없이 보이던 문제 |

## 실제 버그 하나가 섞여 있다

**어드민에서 카테고리 수정·삭제가 항상 400으로 실패하고 있었다.** 프론트는 이름을, 백엔드는 id를 쓰는데 `GET /categories`가 id를 안 줘서 프론트가 id를 보낼 방법이 없었다.

```
PUT /api/blog/categories/Frontend → 400 "numeric string is expected"
PUT /api/blog/categories/1        → 200
```

`getCategories`가 `id`를 함께 돌려주도록 고쳤다. `categoryMeta`를 이미 조회하고 있어 **추가 쿼리는 없다.**

## 나머지 둘은 "스펙이 실제보다 좁아" 프론트를 막던 것

- `SocialLinkDto`에 `icon`이 없었다 — 운영 데이터에는 있고 포트폴리오 연락처가 그 값으로 아이콘을 고른다
- `ReferrerItemDto.category`가 `string`이었다 — 실제로는 4개 값만 나오고, 프론트가 색 매핑의 키로 쓴다

둘 다 프론트를 생성 타입으로 전환하다 컴파일 에러로 드러났다.

## 배포 안전성

**마이그레이션 변경 없음:**
```
$ git diff --name-only origin/main..origin/dev -- prisma/migrations/ | wc -l
0
```

**배포 인프라 변경 없음** — `Dockerfile`, `scripts/start.sh`, `deploy.yml`, `.env.example` 전부 그대로. 새 환경변수도 없다.

**운영과 동일한 이미지로 검증했다:**
```
$ docker build -t chahyunwoo-api:predeploy2 .          DONE 18.9s
$ docker run ... predeploy2                            Up 2 seconds
$ curl /health                                         200
  GET /api/blog/posts        → 200
  GET /api/blog/categories   → 200
  GET /api/portfolio/skills  → 200
  로그 error/fatal            → 0건
```
검증 후 컨테이너와 이미지는 정리했다.

## dev에서의 검증

```
$ pnpm install --frozen-lockfile
$ pnpm lint:ci   → error 0
$ pnpm typecheck → exit 0
$ pnpm test      → Test Suites: 8 passed, Tests: 128 passed
$ pnpm build     → exit 0
```

테스트가 51건 → 128건이 됐다. DTO 필드 집합과 스펙 커버리지를 고정하는 테스트가 늘었다.

## 롤백

되돌릴 지점: `fa9eec0` (Merge pull request #118 from chahyunwoo/dev)

마이그레이션이 없으므로 코드만 되돌리면 된다. DB 상태는 이 배포로 바뀌지 않는다.

## 배포 후 확인

1. `curl https://api.chahyunwoo.dev/health` → 200
2. **어드민에서 카테고리 이름 변경·삭제** — 이번 배포의 핵심. 이전에는 항상 실패했다
3. 포트폴리오 연락처 아이콘이 정상인지
4. 어드민 대시보드 리퍼러 차트

## 관련

프론트(`hyunwoo-dev`)의 `dev → main`도 함께 올려야 한다. **백엔드를 먼저 배포하는 편이 안전하다** — 프론트가 백엔드 응답을 소비하는 방향이고, 이번엔 프론트가 새 필드(`id`, `icon`)에 의존한다.
