### PR TITLE
chore: husky + lint-staged 도입 — 커밋 시점에 포맷을 강제한다

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint-staged

--- a/docs/portfolio.json
+++ b/docs/portfolio.json
@@ -1,0 +1,136 @@
+{
+  "project": "개인 기술 블로그·포트폴리오 백엔드 API 서버 (NestJS + Fastify + Prisma)",
+  "period": "2026-03 ~ 2026-09 (진행 중, 첫 커밋 2026-03-21 / 마지막 커밋 2026-09-04)",
+  "role": "백엔드 단독 개발. 구체적으로 (1) REST API 설계 — 5개 도메인(blog/portfolio/auth/analytics/health) 72개 오퍼레이션의 라우트·쿼리·DTO 계약 설계, (2) DB 모델링 — PostgreSQL 멀티스키마(auth/blog/portfolio/analytics) 21개 모델과 마이그레이션 14회 운영, (3) 인증·인가 — JWT 액세스 토큰 + Refresh Token Rotation, TOTP 2FA, 공개 API용 API Key, 어드민 IP 화이트리스트, 전역 Guard 체인 구성, (4) 파일 스토리지 — Cloudflare R2(S3 호환) 업로드·이동·삭제와 임시 파일 크론 정리, (5) 배포 — Dockerfile 멀티스테이지, Compose 환경 분리(base/local/prod), GitHub Actions CI(lint·typecheck·OpenAPI drift·build·test) 및 Tailscale SSH를 통한 홈서버 자동 배포, (6) 프론트와의 타입 계약 — openapi.json 생성 파이프라인과 CI 게이트, (7) 테스트 기반 구축 — 운영 DB 접속 차단 가드와 순수 로직 단위 테스트 도입. 프론트엔드 코드는 이 저장소에 없다(별도 저장소).",
+  "stack": {
+    "frontend": [],
+    "backend": [
+      "TypeScript 5",
+      "NestJS 11",
+      "Fastify 5 (@nestjs/platform-fastify)",
+      "Prisma 7 (@prisma/adapter-pg)",
+      "PostgreSQL 16 (multi-schema)",
+      "Passport-JWT",
+      "bcryptjs",
+      "otplib (TOTP 2FA)",
+      "class-validator / class-transformer",
+      "@nestjs/swagger (OpenAPI)",
+      "@nestjs/throttler (rate limit)",
+      "@nestjs/cache-manager (in-memory)",
+      "@nestjs/schedule (cron)",
+      "nodemailer",
+      "Jest / ts-jest"
+    ],
+    "infra": [
+      "Docker (멀티스테이지 빌드)",
+      "Docker Compose (base + local/prod override)",
+      "GitHub Actions (CI / Deploy)",
+      "Tailscale SSH",
+      "Mac mini 홈서버 자가호스팅",
+      "Cloudflare R2 (@aws-sdk/client-s3)",
+      "Biome 2 (lint/format)",
+      "pnpm + Dependabot"
+    ]
+  },
+  "contribution": {
+    "frontend": null,
+    "backend": "NestJS 11 + Fastify 위에 blog·portfolio·auth·analytics 4개 도메인 API 72개 오퍼레이션을 설계·구현하고, Prisma 멀티스키마 21개 모델과 다국어 translation 테이블 구조를 잡았으며, JWT + Refresh Token Rotation·TOTP 2FA·API Key·IP 화이트리스트로 이어지는 전역 Guard 체인과 Prisma 에러 코드 매핑까지 포함한 예외 표준화를 구현했다.",
+    "infra": "멀티스테이지 Dockerfile과 base/local/prod로 나눈 Compose 구성을 만들고, GitHub Actions에서 lint·typecheck·OpenAPI 스펙 drift·build·test를 게이트로 걸었으며, main 푸시 시 Tailscale SSH로 Mac mini에 접속해 재빌드·기동 후 /health를 최대 60초 폴링해 실패하면 배포를 실패로 떨어뜨리는 파이프라인을 구성했다."
+  },
+  "problem": "블로그와 포트폴리오라는 성격이 다른 두 프론트(별도 저장소)가 하나의 백엔드를 소비해야 했고, 글·이미지·다국어 이력·방문 통계·어드민 인증이 각각 따로 관리되면 운영이 불가능했다. 한 서버에서 콘텐츠 CRUD와 자산 저장, 다국어 조회, 접속 통계, 어드민 보안을 모두 처리하면서, 정적 생성 기반 프론트가 변경을 즉시 반영할 수 있도록 갱신 신호까지 밀어 주는 것이 목표였다.",
+  "decisions": [
+    {
+      "선택": "다국어를 `title_ko`/`title_en` 같은 컬럼 접미사나 JSONB 한 컬럼이 아니라, 엔티티마다 별도 translation 테이블(`profile_translations`, `experience_translations`, `project_translations`, `work_translations`, `education_translations`)로 분리하고 `(entityId, locale)` 유니크 제약을 걸었다. 지원 언어 자체도 `portfolio.locales` 테이블로 관리해 파이프에서 검증한다.",
+      "대안": "번역 대상 컬럼마다 언어 접미사를 붙이는 방식, 또는 번역 전체를 JSONB 한 컬럼에 넣는 방식.",
+      "이유": "언어를 추가할 때 스키마 변경이 필요 없고(행만 추가), 번역 누락을 DB 제약과 조회로 확인할 수 있다. 지원 언어를 코드 상수가 아니라 테이블로 두면 `?locale=` 검증이 하드코딩 목록에 묶이지 않는다.",
+      "트레이드오프": "모든 조회에 `include: { translations: { where: { locale } } }`가 붙어 쿼리와 매핑 코드가 늘었고(portfolio.service.ts 815줄 중 상당량이 이 매핑), 번역이 없으면 빈 문자열/빈 배열로 떨어질 뿐 기본 언어로의 폴백이 없다. 또 locale 테이블이 검증 경로에 들어오면서 캐시가 빈 결과로 굳으면 포트폴리오 조회 전체가 400이 되는 실패 모드를 새로 만들었다(실제로 발생, 커밋 51a899b에서 수정)."
+    },
+    {
+      "선택": "OpenAPI 스펙을 런타임에만 노출하지 않고 `openapi.json`으로 추출해 저장소에 커밋하고, CI에서 재생성 후 `git diff --exit-code`로 drift를 막았다. 여기에 더해 '모든 오퍼레이션은 200/201 JSON 스키마를 갖거나 204를 선언한다'는 불변식을 Jest 테스트(`src/dto/openapi-coverage.spec.ts`)로 고정했다.",
+      "대안": "프론트가 빌드 시점에 실행 중인 서버의 `/docs-json`을 fetch해 타입을 생성하는 방식, 또는 DTO 타입을 공유 npm 패키지로 배포하는 방식.",
+      "이유": "프론트가 별도 저장소라 빌드 타임에 API 서버가 떠 있다고 보장할 수 없다. 파일로 커밋해 두면 서버 없이도 타입 생성이 되고, 스펙 변경이 diff로 리뷰에 드러난다. Swagger 설정을 `swagger.config.ts` 한 곳에서만 만들어 `/docs`와 추출본이 갈라지지 않게 했다.",
+      "트레이드오프": "DTO를 건드릴 때마다 `pnpm openapi:generate` 후 함께 커밋해야 하고, 잊으면 CI가 빨개진다(의도한 마찰이지만 마찰은 마찰이다). 생성물이 커밋에 섞여 diff 노이즈가 생기고, 스펙 파일을 lint 대상에서 제외(`biome.json`의 `!openapi.json`)해야 했다. 또 커버리지 테스트는 '스키마가 선언돼 있는가'만 보장할 뿐 '그 스키마가 실제 응답과 같은가'는 보장하지 않아, 도메인별 DTO 테스트를 따로 둬야 했다."
+    },
+    {
+      "선택": "본문 이미지를 `blog/temp/`에 먼저 올려 두고 글 저장 시 확정 경로로 옮기는 2단계 플로우에서, 순서를 'DB 저장 → R2 이동 → 이동 결과 DB 반영'으로 두고, 이동이 중간에 실패하면 **그때까지 옮겨진 만큼을 DB에 반영한 뒤 500을 던진다**. 실패를 삼키고 200을 반환하지 않는다.",
+      "대안": "R2 이동을 먼저 끝내고 확정 URL로 DB를 한 번만 쓰는 방식, 또는 이동 실패를 로그만 남기고 삼켜 200을 반환하는 방식.",
+      "이유": "R2 이동은 Copy→Head→Delete라 성공한 파일의 원본 temp가 이미 사라진다. 이동을 먼저 하고 DB 쓰기가 실패하면 파일은 옮겨졌는데 DB는 없어진 temp URL을 가리켜 이미지가 즉시 깨진다. 반대로 실패를 삼키면 temp URL이 남은 채 200이 나가고, 매일 3시 크론이 24시간 지난 temp를 지우므로 저장 당시엔 멀쩡하다가 다음 날 깨진다 — 원인 추적이 가장 어려운 형태다.",
+      "트레이드오프": "부분 성공 상태를 정상 응답이 아니라 500으로 알리므로 사용자는 '저장은 됐는데 이미지를 다시 저장하라'는 애매한 상태를 마주한다. 트랜잭션으로 묶을 수 없는 외부 스토리지라 완전한 원자성은 포기했고, 태그 정리·revalidation 같은 부수 효과의 실행 순서를 손으로 관리해야 해서 실제로 병합 과정에서 순서가 뒤집혀 회귀가 한 번 났다(커밋 70b00e4)."
+    }
+  ],
+  "metrics": [
+    {
+      "지표": "커밋 수 / 개발 기간",
+      "값": "118건, 2026-03-21 ~ 2026-09-04 (dev 브랜치 기준, 2026-09-04 측정)",
+      "근거": "git log --oneline | wc -l → 118 / git log --format='%ad' --date=short | sort | sed -n '1p;$p' → 2026-03-21 / 2026-09-04"
+    },
+    {
+      "지표": "API 오퍼레이션 수",
+      "값": "72개 (portfolio 36 / blog 15 / auth 12 / analytics 8 / health 1)",
+      "근거": "jq '[.paths|to_entries[]|.value|to_entries[]]|length' openapi.json → 72"
+    },
+    {
+      "지표": "OpenAPI 성공 응답 스키마 커버리지",
+      "값": "72개 중 60개가 200/201 JSON 스키마 선언, 12개가 204 → 미선언 0건 (#103 착수 시점에는 미선언 67건)",
+      "근거": "jq '[.paths|to_entries[]|.value|to_entries[]|select((.value.responses[\"200\"].content[\"application/json\"]//.value.responses[\"201\"].content[\"application/json\"])!=null)]|length' openapi.json → 60 / select(.value.responses[\"204\"]!=null) → 12. 착수 시점 67건은 src/dto/openapi-coverage.spec.ts 주석과 CLAUDE.md '남은 작업' 항목에 기록"
+    },
+    {
+      "지표": "DB 규모",
+      "값": "Prisma 모델 21개, 스키마 4개(auth/blog/portfolio/analytics), 마이그레이션 14회",
+      "근거": "grep -c '^model ' prisma/schema.prisma → 21 / ls prisma/migrations | grep -c '^2026' → 14"
+    },
+    {
+      "지표": "소스 규모",
+      "값": "src/ TypeScript 7,634줄 (portfolio 2,698 / blog 2,051 / analytics 1,032 / auth 800 / common 570)",
+      "근거": "wc -l $(git ls-files 'src/**' | grep -E '\\.ts$') | tail -1 → 7634 total"
+    },
+    {
+      "지표": "테스트",
+      "값": "spec 파일 8개, 1,049줄, it/test 블록 50건 (그중 8건은 it.each 테이블)",
+      "근거": "git ls-files | grep -c 'spec.ts$' → 8 / wc -l $(git ls-files | grep 'spec.ts$') | tail -1 → 1049 / grep -rhoE '\\b(it|test)\\(' $(git ls-files | grep 'spec.ts$') | wc -l → 50"
+    },
+    {
+      "지표": "병합된 PR",
+      "값": "13건 (전체 커밋 중 dependabot 자동 커밋 10건 포함)",
+      "근거": "git log --oneline | grep -c 'Merge pull request' → 13 / git log --format='%an' | sort | uniq -c → Cha Hyun Woo 57, chahyunwoo 51(같은 사람의 다른 git 설정), dependabot[bot] 10"
+    }
+  ],
+  "shots": [],
+  "blogSeeds": [
+    {
+      "제목후보": "빈 캐시가 굳어서 API 5개가 영구히 400을 뱉은 이야기",
+      "왜 쓸 만한지": "`if (!cache)`로 캐시 유무를 판정하면 빈 Set·빈 배열은 falsy가 아니라 그대로 굳는다는, 언어 레벨 함정이 실제 장애로 이어진 사례다. 명시적 무효화 호출부만 믿으면 DB 직접 삽입·시드·다중 인스턴스 경로가 전부 빠진다는 것과, TTL을 안전망으로 함께 두는 이유까지 한 파일로 설명할 수 있다.",
+      "근거": "src/portfolio/pipes/validate-locale.pipe.ts (파일 상단 JSDoc에 실패 경로가 서술돼 있음), 커밋 51a899b 'fix(portfolio): locale 목록 캐시가 빈 결과로 굳어 포트폴리오 전체가 400 고착 (#108)', 테스트 src/portfolio/pipes/validate-locale.pipe.spec.ts"
+    },
+    {
+      "제목후보": "외부 스토리지에는 트랜잭션이 없다 — 이미지 temp→확정 플로우의 순서 설계",
+      "왜 쓸 만한지": "Copy→Head→Delete로 파일을 옮기는 순간 되돌릴 수 없는 지점이 생긴다. DB를 먼저 쓰느냐 파일을 먼저 옮기느냐, 부분 실패를 200으로 삼키느냐 500으로 알리느냐에 따라 깨지는 방식이 어떻게 달라지는지를 코드 주석과 회귀 커밋으로 추적할 수 있다. '저장할 땐 멀쩡했는데 다음 날 깨진다'는 지연 실패의 원인 분석이 특히 쓸 만하다.",
+      "근거": "src/blog/blog.service.ts finalizeImages() 및 update() (624~690행 주석), 커밋 f8a6d66 'fix(blog): 글 수정 시 이미지 확정 실패를 삼켜 200을 반환하던 문제 (#110)', 커밋 70b00e4 'fix(blog): 병합으로 생긴 회귀 — 이미지 확정 실패가 태그 정리를 건너뛰게 했다', 테스트 src/blog/blog.service.images.spec.ts"
+    },
+    {
+      "제목후보": "저장소가 분리된 프론트와 타입을 맞추는 법 — openapi.json을 커밋하고 CI로 고정하기",
+      "왜 쓸 만한지": "'스펙이 낡아도 아무도 안 죽는다'가 프론트 타입이 조용히 실제 API와 어긋나는 가장 흔한 원인이다. 스펙을 파일로 커밋 → CI에서 재생성 후 diff → 커버리지 불변식을 테스트로 고정, 이렇게 세 겹으로 막는 구성과 각 겹이 무엇을 못 막는지를 정직하게 쓸 수 있다.",
+      "근거": ".github/workflows/ci.yml의 'OpenAPI spec drift check' 스텝, scripts/generate-openapi.ts, src/dto/openapi-coverage.spec.ts, 커밋 202dc58 'feat: GET /api/blog/posts 응답 스키마 선언 및 openapi.json 추출 추가 (#102)', 커밋 c9e5813 'fix(openapi): 204 라우트 8건이 스펙에서 성공 응답 없이 보이던 문제 (#103)'"
+    },
+    {
+      "제목후보": "'테스트는 운영 DB를 안 쓴다'는 약속을 코드로 바꾸기",
+      "왜 쓸 만한지": "운영 컨테이너도 localhost:5432를 열고 있어 호스트로는 구별이 안 된다는 실측 근거가 있고, 판정 기준을 'DB 이름이 _test로 끝나는가' 하나로 좁힌 이유가 명확하다. 텍스트 규칙 대신 부팅 경로에 물리적 게이트를 박는다는 원칙의 짧고 완결된 예시로 쓰기 좋다.",
+      "근거": "src/common/testing/test-db-guard.ts (파일 상단 JSDoc에 판정 근거 서술), src/common/testing/test-db-guard.spec.ts, 커밋 4693503 'test: 테스트 기반 구축 — 운영 DB 가드와 순수 로직 테스트 (#111)'"
+    },
+    {
+      "제목후보": "다국어 포트폴리오 스키마 — 컬럼 접미사 대신 translation 테이블을 고른 이유와 그 대가",
+      "왜 쓸 만한지": "`title_ko`/`title_en` → JSONB → 별도 테이블로 이어지는 3가지 선택지의 비용을 실제 스키마와 조회 코드로 비교할 수 있다. 특히 '언어 추가가 싸진 대신 모든 조회에 include가 붙고 폴백을 직접 짜야 한다'는 대가가 코드에 그대로 남아 있어서, 장점만 늘어놓지 않는 글이 된다.",
+      "근거": "prisma/schema.prisma의 ProfileTranslation·ExperienceTranslation·ProjectTranslation·WorkTranslation·EducationTranslation 모델과 각 모델의 @@unique([entityId, locale]), 마이그레이션 prisma/migrations/20260321073608_portfolio_i18n_schema, src/portfolio/portfolio.service.ts getProfile()·getExperiences()의 `t?.title ?? ''` 매핑"
+    }
+  ],
+  "imagePrompt": "포트폴리오 카드용 16:9 가로 이미지. 다크 네이비(#0F172A)에서 짙은 슬레이트로 떨어지는 그라디언트 배경, 오른쪽 절반에 매우 낮은 대비(불투명도 8% 내외)로 API 엔드포인트 목록과 계층형 DB 스키마 다이어그램이 겹친 추상 라인아트를 배치. 사진·인물·로고·목업 없음, 플랫한 기하학적 일러스트만. 왼쪽 정렬 텍스트 레이아웃으로 다음 한글 문구를 정확히 그대로 표기할 것 — 상단 작은 라벨(연회색, 12pt 상당): '백엔드 API 서버 · 2026'. 그 아래 큰 제목(흰색, 굵게, 2줄 허용): '블로그·포트폴리오 통합 API 서버'. 그 아래 한 줄 요약(밝은 회색, 얇게): 'REST API 72개 · 다국어 스키마 · 무중단 자가호스팅 배포'. 카드 하단에는 둥근 모서리 pill 형태의 스택 뱃지를 가로로 나열하고 각각의 텍스트는 'NestJS', 'Fastify', 'Prisma', 'PostgreSQL', 'Docker'. 뱃지는 반투명 흰색 테두리에 배경은 투명, 텍스트는 흰색. 포인트 컬러는 앰버(#F59E0B)로 제목 왼쪽에 얇은 세로 액센트 바 하나만 사용. 여백을 넉넉히 두고 전체적으로 차분하고 기술적인 인상. 한글이 깨지지 않는 산세리프 서체로 렌더링할 것.",
+  "clientSafe": true,
+  "needsInput": [
+    "이 프로젝트는 외부 클라이언트 납품물이 아니라 본인 소유 서비스가 맞나요? 포트폴리오 카드에 서비스 도메인(chahyunwoo.dev)과 저장소 링크를 그대로 노출해도 될까요?",
+    "프론트엔드(hyunwoo-dev)도 같은 사람이 만든 것이라면, 이 API 서버를 별도 항목으로 낼지 프론트와 묶어 하나의 풀스택 프로젝트로 낼지 어느 쪽을 원하시나요?",
+    "실운영 지표(월간 순방문자, 일평균 요청 수, p95 응답시간, 가동률 등)를 포트폴리오에 넣고 싶으신가요? 코드에는 analytics 수집 로직만 있고 집계된 실제 수치는 저장소에 없어서 지금은 metrics에 넣지 않았습니다. 필요하면 운영 DB나 배포 로그에서 뽑을 값을 알려주세요.",
+    "Mac mini 자가호스팅 + Tailscale이라는 배포 방식을 카드에 드러내도 될까요? 비용 절감·홈서버 운영 경험으로는 강점이지만, 채용/수주 상대에 따라 '가용성이 낮다'로 읽힐 여지도 있습니다.",
+    "CLAUDE.md에 남아 있는 미완료 항목(포트폴리오 어드민 CRUD 일부, pg_trgm 검색 인덱스)은 포트폴리오에 '진행 중'으로 표기할까요, 아니면 완료된 범위만 서술할까요?",
+    "GitHub Actions CI(.github/workflows/ci.yml)에 더미 JWT_SECRET과 bcrypt 해시 리터럴이 커밋돼 있습니다. 테스트 전용 플레이스홀더라 실제 위험은 없지만, 저장소를 공개할 계획이라면 GitHub Secrets로 옮길까요?"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,16 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate deploy",
     "db:migrate:dev": "prisma migrate dev",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.ts": [
+      "biome check --write --no-errors-on-unmatched"
+    ],
+    "*.json": [
+      "biome format --write --no-errors-on-unmatched"
+    ]
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1024.0",
@@ -66,7 +75,9 @@
     "fast-glob": "^3.3.3",
     "fastify": "5.8.2",
     "gray-matter": "^4.0.3",
+    "husky": "^9.1.7",
     "jest": "^30.3.0",
+    "lint-staged": "^16.4.0",
     "prisma": "^7.6.0",
     "ts-jest": "^29.2.0",
     "ts-node": "^10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,15 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       jest:
         specifier: ^30.3.0
         version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
       prisma:
         specifier: ^7.6.0
         version: 7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -1934,6 +1940,10 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2149,6 +2159,10 @@ packages:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
@@ -2156,6 +2170,10 @@ packages:
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -2185,6 +2203,13 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2340,6 +2365,9 @@ packages:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2357,6 +2385,10 @@ packages:
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -2400,6 +2432,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -2538,6 +2573,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
@@ -2631,6 +2670,11 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -2680,6 +2724,10 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-generator-fn@2.1.0:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
@@ -2943,6 +2991,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
+    engines: {node: '>=20.0.0'}
+
   load-esm@1.0.3:
     resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
     engines: {node: '>=13.2.0'}
@@ -2985,6 +3042,10 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -3051,6 +3112,10 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -3145,6 +3210,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -3445,6 +3514,10 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
@@ -3546,6 +3619,14 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -3585,6 +3666,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -3596,6 +3681,14 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3890,6 +3983,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3910,6 +4007,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
@@ -6058,6 +6160,10 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -6284,6 +6390,10 @@ snapshots:
     dependencies:
       restore-cursor: 3.1.0
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   cli-spinners@2.9.2: {}
 
   cli-table3@0.6.5:
@@ -6291,6 +6401,11 @@ snapshots:
       string-width: 4.2.3
     optionalDependencies:
       '@colors/colors': 1.5.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.2
 
   cli-width@4.1.0: {}
 
@@ -6317,6 +6432,10 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorette@2.0.20: {}
+
+  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -6427,6 +6546,8 @@ snapshots:
 
   emittery@0.13.1: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -6439,6 +6560,8 @@ snapshots:
       tapable: 2.3.0
 
   env-paths@3.0.0: {}
+
+  environment@1.1.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -6496,6 +6619,8 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -6690,6 +6815,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-package-type@0.1.0: {}
 
   get-port-please@3.2.0: {}
@@ -6795,6 +6922,8 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  husky@9.1.7: {}
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -6833,6 +6962,10 @@ snapshots:
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
 
   is-generator-fn@2.1.0: {}
 
@@ -7285,6 +7418,24 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.3
+      string-argv: 0.3.2
+      tinyexec: 1.3.1
+      yaml: 2.9.0
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
   load-esm@1.0.3: {}
 
   loader-runner@4.3.1: {}
@@ -7315,6 +7466,14 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   long@5.3.2: {}
 
@@ -7367,6 +7526,8 @@ snapshots:
     optional: true
 
   mimic-fn@2.1.0: {}
+
+  mimic-function@5.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -7452,6 +7613,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   ora@5.4.1:
     dependencies:
@@ -7735,6 +7900,11 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   ret@0.5.0: {}
 
   retry@0.12.0: {}
@@ -7814,6 +7984,16 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -7847,6 +8027,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-argv@0.3.2: {}
+
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -7862,6 +8044,17 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
@@ -8162,6 +8355,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   write-file-atomic@5.0.1:
@@ -8176,6 +8375,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@18.1.3:
     dependencies:


### PR DESCRIPTION
이 저장소에는 프론트(`hyunwoo-dev`)와 달리 pre-commit 훅이 없었다. 그래서 포맷이 어긋난 코드가 커밋되고 **CI의 Lint 스텝에서야 잡힌다.**

실제로 이번 작업 중 두 번 겪었다 — 테스트 파일이 biome 포맷을 어겨 CI가 빨개졌고, `style: 포맷팅` 커밋을 따로 만들어 고쳤다. 훅이 있었으면 커밋 시점에 자동으로 정리됐을 일이다.

프론트와 같은 구성(husky 9 + lint-staged 16)으로 맞춘다.

## openapi.json은 건드리지 않는다

이 파일은 생성물이고 CI의 `OpenAPI spec drift check`가 검사한다. 훅이 재포맷하면 그 검사가 깨진다.

`biome.json`의 `includes`에 이미 `!openapi.json`이 있고, **biome는 인자로 받은 파일도 그 설정을 존중한다**:

```
$ npx biome format --write --no-errors-on-unmatched openapi.json
Formatted 0 files in 1193µs. No fixes applied.
```

따라서 lint-staged 패턴을 `*.json`으로 단순하게 두어도 안전하다. 처음에 `!(openapi).json` 같은 negation 패턴을 썼다가, 그게 없어도 되는 것을 확인하고 걷어냈다 — **두 곳에서 같은 규칙을 관리하면 갈라진다.**

## 훅이 실제로 도는지 확인했다

포맷이 어긋난 파일을 커밋하면:

```
작성:  export const probe = {a:1,   b:2,
             c:3}
       ↓ 훅 7단계 수행
커밋:  export const probe = { a: 1, b: 2, c: 3 };
```

`openapi.json`을 함께 커밋해도 바이트가 그대로이고, 그 뒤 `pnpm openapi:generate` → `git diff --exit-code openapi.json`이 통과한다(= CI drift check 통과).

이 PR의 커밋 자체도 훅을 거쳤다 — 로그에 `*.json — 2 files` 처리가 찍혀 있다.

## 검증

```
$ pnpm lint:ci   → error 0
$ pnpm typecheck → exit 0
$ pnpm test      → Tests: 128 passed
$ pnpm build     → exit 0
```

## 참고

훅은 우회할 수 있다(`--no-verify`). 이건 실수를 줄이는 장치이지 게이트가 아니고, 진짜 게이트는 여전히 CI다. 다만 CI가 빨개진 뒤 고치는 것보다 커밋 시점에 정리되는 편이 낫다.
