### PR TITLE
fix: 운영 장애 및 배포 게이트 수정 8건 (Critical 2 + High 4 + Medium 2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,18 @@
 name: Deploy
 
+# `push: [main]`으로 두면 안 된다. CI와 **병렬로** 돌아 검사가 끝나기 전에
+# 프로덕션 배포가 완료된다. 실측(2026-09-04, 커밋 11a3e27):
+#   CI      시작 02:20:48  종료 02:29:07
+#   Deploy  시작 02:20:48  종료 02:21:51   ← CI보다 7분 16초 먼저 끝남
+# 즉 타입 에러가 있는 커밋도 1분 만에 맥미니에 올라가고, 8분 뒤에야 CI가 빨개진다.
+# 그때는 되돌릴 이전 이미지도 `docker image prune -f`가 이미 지운 뒤다.
+#
+# 그래서 CI가 **성공으로 끝난 뒤에만** 돈다. CI도 `push: [main]` 트리거를
+# 갖고 있으므로 같은 커밋의 CI 실행을 그대로 기다리게 된다.
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -9,7 +20,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    # workflow_run은 CI가 **실패로** 끝나도 발화하므로 결론을 직접 확인한다.
+    # 수동 실행(workflow_dispatch)에는 선행 CI가 없으니 그 경우는 통과시킨다.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+
     steps:
+      - name: 배포 대상 확인
+        run: |
+          echo "trigger: ${{ github.event_name }}"
+          echo "CI conclusion: ${{ github.event.workflow_run.conclusion || 'n/a (manual)' }}"
+          echo "commit: ${{ github.event.workflow_run.head_sha || 'n/a (manual)' }}"
+
       - name: Connect via Tailscale
         uses: tailscale/github-action@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,12 +106,21 @@ pnpm openapi:generate    # scripts/generate-openapi.ts → 루트 openapi.json
 | `ALLOWED_ORIGINS` | CORS 허용 오리진 (콤마 구분) |
 
 ## 현재 남은 작업
-- [ ] 포트폴리오 어드민 CRUD (나중에)
+
+**2026-09-04 전수 실측으로 정리함.** 아래 완료 항목들은 실제로는 끝나 있었는데 체크박스만 남아 있었다 —
+이 목록을 근거로 판단하기 전에 재현 명령을 한 번 돌려볼 것.
+
 - [ ] 검색 성능 개선: pg_trgm 인덱스 마이그레이션 (필요 시)
+      확인: `grep -rl trgm prisma/ | wc -l` → 0 (2026-09-04 기준 미적용, 마이그레이션 14개 중 없음)
+
+### 완료 (2026-09-04 실측)
+- [x] 포트폴리오 어드민 CRUD — 8개 리소스(locales/profile/experiences/projects/skills/education/works/contacts)
+      전부 변경 라우트 보유, 총 23개.
+      확인: `grep -cE "@(Post|Put|Patch|Delete)\(" src/portfolio/*.controller.ts` → 23
 - [x] 프론트 연동 후 openapi-typescript 타입 생성 설정 — 파이프라인 구축 완료 (#102)
-- [ ] **나머지 라우트의 Response DTO** — 72개 오퍼레이션 중 성공 응답 스키마가 있는 건
-      `GET /api/blog/posts` 1개뿐이다. 나머지는 프론트가 타입을 생성해도 응답이 비어 쓸 수 없다.
-      단, 본문이 원래 없는 204 라우트(`POST /api/auth/logout` 등)는 대상이 아니다.
-      확인 (프론트 헬퍼가 200 다음 201도 보므로 둘 다 센다):
-      `jq -r '[.paths|to_entries[]|.key as $p|.value|to_entries[]|select((.value.responses["200"].content["application/json"]//.value.responses["201"].content["application/json"])!=null)|"\($p) \(.key)"]|.[]' openapi.json`
-- [ ] 테스트 0건 — `pnpm test`가 `--passWithNoTests`라 CI Test 스텝이 항상 초록인데 아무것도 검사하지 않는다
+- [x] 나머지 라우트의 Response DTO — 72개 오퍼레이션 중 60개가 200/201 JSON 스키마 선언,
+      12개가 본문 없는 204 → **미선언 0건**. (이 항목은 한때 "1개뿐"으로 적혀 있었다.)
+      확인: `jq -r '[.paths|to_entries[]|.key as $p|.value|to_entries[]|select((.value.responses["200"].content["application/json"]//.value.responses["201"].content["application/json"])!=null)|"\($p) \(.key)"]|.[]' openapi.json | wc -l` → 60
+- [x] 테스트 — spec 파일 14개 / 1,789줄, 160건 통과. `pnpm test`도 `jest`이며 `--passWithNoTests`가 아니다.
+      (이 항목은 한때 "테스트 0건 / passWithNoTests라 CI가 항상 초록"으로 적혀 있었다.)
+      확인: `find src -name '*.spec.ts' | wc -l` → 14 / `pnpm jest 2>&1 | grep '^Tests:'` → 160 passed

--- a/openapi.json
+++ b/openapi.json
@@ -5162,7 +5162,13 @@
         "properties": {
           "status": {
             "type": "string",
-            "example": "ok"
+            "example": "ok",
+            "description": "DB까지 정상이면 'ok', 아니면 'error'"
+          },
+          "database": {
+            "type": "string",
+            "example": "ok",
+            "description": "DB 연결 확인 결과. 'ok' | 'error'"
           },
           "timestamp": {
             "type": "string",
@@ -5171,6 +5177,7 @@
         },
         "required": [
           "status",
+          "database",
           "timestamp"
         ]
       },

--- a/openapi.json
+++ b/openapi.json
@@ -2331,7 +2331,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProfileWithTranslationsDto"
+                  "$ref": "#/components/schemas/ProfileDto"
                 }
               }
             }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
+import { TokenCleanupTask } from './token-cleanup.task';
 
 @Module({
   imports: [
@@ -18,7 +19,7 @@ import { JwtStrategy } from './jwt.strategy';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, TokenCleanupTask],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/auth/token-cleanup.task.ts
+++ b/src/auth/token-cleanup.task.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { AuthService } from './auth.service';
+
+/**
+ * 만료된 리프레시 토큰을 주기적으로 지운다.
+ *
+ * `AuthService.cleanupExpiredTokens()`는 구현돼 있었지만 **호출부가 0개**였다.
+ * 그 결과 운영 DB의 `auth.refresh_tokens` 25건이 전부 만료 상태로 쌓여 있었다
+ * (2026-09-04 실측: total 25 / expired 25).
+ *
+ * `refresh()`가 만료 토큰도 조회 즉시 삭제하므로 기능은 정상이지만,
+ * 로그인만 하고 갱신하지 않은 세션의 토큰은 아무도 지우지 않아 단조 증가한다.
+ *
+ * StorageCleanupTask와 같은 시각대를 피해 4시로 둔다 — 둘 다 새벽에 도는
+ * 정리 작업이라 겹칠 이유가 없다.
+ */
+@Injectable()
+export class TokenCleanupTask {
+  private readonly logger = new Logger(TokenCleanupTask.name);
+
+  constructor(private readonly auth: AuthService) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  async handleCleanup(): Promise<void> {
+    try {
+      const deleted = await this.auth.cleanupExpiredTokens();
+      if (deleted > 0) {
+        this.logger.log(`Expired refresh tokens deleted: ${deleted}`);
+      }
+    } catch (error) {
+      // 크론이 죽으면 다음 실행까지 정리가 멈춘다. 삼키되 남긴다.
+      this.logger.error('Refresh token cleanup failed', error);
+    }
+  }
+}

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -22,6 +22,7 @@ import {
   ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { AuthService } from '../auth/auth.service';
 import { Public } from '../common/decorators/public.decorator';
 import {
@@ -134,8 +135,22 @@ export class BlogController {
     return this.blogService.findBySlug(slug, isAdmin);
   }
 
+  /**
+   * 미발행 글 미리보기.
+   *
+   * 이 라우트는 `findBySlug(slug, isAdmin = true)`를 불러 `published` 검사를
+   * 건너뛴다. 즉 유효한 토큰 하나면 **임의의 slug**로 미발행 글을 읽을 수 있다.
+   * 토큰은 어드민 화면 진입 시점에 slug 없이 발급되므로(프론트가 글을 저장하기
+   * 전에 미리 받는다) 특정 글에 묶을 수가 없다.
+   *
+   * 그래서 최소한 **전수 대입은 막는다.** 스로틀이 없으면 토큰이 URL·Referer로
+   * 한 번 새는 순간 30분 동안 slug를 무제한 대입해 미발행 글을 전부 긁어낼 수
+   * 있다. 분당 10회면 정상적인 미리보기(한 글을 열고 새로고침 몇 번)에는
+   * 걸리지 않으면서 대입 속도는 실효적으로 죽인다.
+   */
   @Public()
   @ApiSecurity('api-key')
+  @Throttle({ default: { ttl: 60_000, limit: 10 } })
   @Get('posts/:slug/preview')
   @ApiOkResponse({ type: PostDetailDto })
   @ApiNotFound('Post')

--- a/src/blog/blog.service.duplicate-images.spec.ts
+++ b/src/blog/blog.service.duplicate-images.spec.ts
@@ -1,0 +1,187 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import { AdminLogService } from '../analytics/admin-log.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { RevalidationService } from '../revalidation/revalidation.service';
+import { StorageService } from '../storage/storage.service';
+import { BlogService } from './blog.service';
+
+const PUBLIC_URL = 'https://assets.example.test';
+const TEMP = `${PUBLIC_URL}/blog/temp`;
+
+/**
+ * 같은 이미지를 본문에서 **두 번 참조한** 글이 저장되는지 검사한다.
+ *
+ * 기존 `blog.service.images.spec.ts`가 이 버그를 못 잡았던 이유가 핵심이다 —
+ * 그 스펙의 `move` 스텁은 **상태가 없어서** 같은 원본을 두 번 옮겨도 성공을
+ * 돌려줬다. 실제 R2의 `move`는 Copy → Head → **Delete(원본)** 이라
+ * 두 번째 호출은 원본이 없어 NoSuchKey로 터진다.
+ *
+ * 그래서 여기서는 스텁이 실제 시맨틱을 흉내낸다(옮긴 원본을 장부에서 지운다).
+ * 이 스텁이 없으면 dedupe를 되돌려도 테스트가 초록으로 남는다.
+ */
+describe('BlogService 본문 내 이미지 중복 참조', () => {
+  function build() {
+    const updates: Array<Record<string, unknown>> = [];
+    const deletedKeys: string[] = [];
+    const moveCalls: string[] = [];
+
+    // R2에 존재하는 오브젝트 장부. move가 원본을 실제로 지운다.
+    const existing = new Set<string>(['blog/temp/dup.png', 'blog/temp/other.png']);
+
+    let stored = {
+      id: 1,
+      slug: 'test-slug',
+      title: '제목',
+      content: '',
+      thumbnailUrl: null as string | null,
+      postTags: [],
+    };
+
+    const prisma = {
+      post: {
+        create: jest.fn(async ({ data }: { data: Record<string, unknown> }) => {
+          const { postTags: _ignored, ...scalar } = data as Record<string, unknown>;
+          stored = { ...stored, ...scalar } as typeof stored;
+          return stored;
+        }),
+        update: jest.fn(async ({ data }: { data: Record<string, unknown> }) => {
+          updates.push(data);
+          // postTags는 include로 따라오는 관계 필드다. data를 그대로 덮으면
+          // undefined가 되어 formatPost가 터진다(제품 버그가 아니라 스텁 문제).
+          const { postTags: _ignored, ...scalar } = data as Record<string, unknown>;
+          stored = { ...stored, ...scalar } as typeof stored;
+          return stored;
+        }),
+        delete: jest.fn(async () => stored),
+        findUnique: jest.fn(async () => stored),
+      },
+      postTag: { findMany: jest.fn(async () => []) },
+      tag: { upsert: jest.fn(async () => ({ id: 1 })), deleteMany: jest.fn(async () => ({})) },
+    };
+
+    const storage = {
+      getPublicUrl: () => PUBLIC_URL,
+      move: jest.fn(async (sourceUrl: string, destKey: string) => {
+        moveCalls.push(sourceUrl);
+        const sourceKey = sourceUrl.replace(`${PUBLIC_URL}/`, '');
+        // 실제 move의 Copy 단계. 원본이 없으면 여기서 터진다.
+        if (!existing.has(sourceKey)) {
+          throw new Error(`NoSuchKey: ${sourceKey}`);
+        }
+        existing.delete(sourceKey); // Delete(원본)
+        existing.add(destKey);
+        return `${PUBLIC_URL}/${destKey}`;
+      }),
+      upload: jest.fn(),
+      delete: jest.fn(async () => undefined),
+      deleteByKey: jest.fn(async (key: string) => {
+        deletedKeys.push(key);
+      }),
+    };
+
+    return { prisma, storage, updates, deletedKeys, moveCalls, getStored: () => stored };
+  }
+
+  async function makeService(deps: ReturnType<typeof build>) {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        BlogService,
+        { provide: PrismaService, useValue: deps.prisma },
+        { provide: StorageService, useValue: deps.storage },
+        { provide: RevalidationService, useValue: { trigger: jest.fn(async () => undefined) } },
+        { provide: AdminLogService, useValue: { log: jest.fn(async () => undefined) } },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn(() => 'admin'), getOrThrow: jest.fn(() => 'admin') },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: {
+            get: jest.fn(async () => undefined),
+            set: jest.fn(async () => undefined),
+            del: jest.fn(async () => undefined),
+            keys: jest.fn(async () => []),
+          },
+        },
+      ],
+    }).compile();
+    return moduleRef.get(BlogService);
+  }
+
+  it('같은 이미지를 두 번 참조해도 저장에 성공한다', async () => {
+    const deps = build();
+    const service = await makeService(deps);
+
+    await expect(
+      service.create({
+        title: '제목',
+        content: `![a](${TEMP}/dup.png) 중간 문단 ![again](${TEMP}/dup.png)`,
+      } as Parameters<typeof service.create>[0]),
+    ).resolves.toBeDefined();
+  });
+
+  it('중복 URL에 move를 한 번만 호출한다 — 두 번 부르면 원본이 이미 지워져 터진다', async () => {
+    const deps = build();
+    const service = await makeService(deps);
+
+    await service.create({
+      title: '제목',
+      content: `![a](${TEMP}/dup.png) 그리고 ![b](${TEMP}/dup.png)`,
+    } as Parameters<typeof service.create>[0]);
+
+    expect(deps.moveCalls.filter(u => u.endsWith('dup.png'))).toHaveLength(1);
+  });
+
+  it('본문의 중복 참조가 모두 확정 URL로 치환된다 — 하나라도 temp가 남으면 다음날 깨진다', async () => {
+    const deps = build();
+    const service = await makeService(deps);
+
+    await service.create({
+      title: '제목',
+      content: `![a](${TEMP}/dup.png) 중간 ![b](${TEMP}/dup.png)`,
+    } as Parameters<typeof service.create>[0]);
+
+    // create()는 슬러그를 무작위 생성하므로 슬러그를 고정해 비교하지 않는다.
+    expect(deps.getStored().content).not.toContain('/blog/temp/');
+    expect(deps.getStored().content.match(/\/blog\/posts\/[^/]+\/dup\.png/g)).toHaveLength(2);
+  });
+
+  it('서로 다른 이미지는 각각 옮긴다', async () => {
+    const deps = build();
+    const service = await makeService(deps);
+
+    await service.create({
+      title: '제목',
+      content: `![a](${TEMP}/dup.png) ![b](${TEMP}/other.png)`,
+    } as Parameters<typeof service.create>[0]);
+
+    expect(deps.moveCalls).toHaveLength(2);
+    expect(deps.getStored().content).not.toContain('/blog/temp/');
+  });
+
+  it('롤백은 이번에 옮긴 것만 지운다 — 아직 못 옮긴 temp 원본까지 지우면 재시도가 영구 실패한다', async () => {
+    const deps = build();
+    // other.png를 R2에서 미리 없애 두 번째 이미지의 move가 실패하게 만든다.
+    deps.storage.move = jest.fn(async (sourceUrl: string, destKey: string) => {
+      deps.moveCalls.push(sourceUrl);
+      if (sourceUrl.includes('other.png')) throw new Error('R2 move failed');
+      return `${PUBLIC_URL}/${destKey}`;
+    });
+    const service = await makeService(deps);
+
+    await expect(
+      service.create({
+        title: '제목',
+        content: `![a](${TEMP}/dup.png) ![b](${TEMP}/other.png)`,
+      } as Parameters<typeof service.create>[0]),
+    ).rejects.toThrow();
+
+    // 성공한 dup.png의 목적지만 정리 대상이다.
+    expect(deps.deletedKeys).toHaveLength(1);
+    expect(deps.deletedKeys[0]).toMatch(/^blog\/posts\/[^/]+\/dup\.png$/);
+    // 실패한 other.png의 temp 원본은 건드리지 않는다 — 재시도에 필요하다.
+    expect(deps.deletedKeys.some(k => k.includes('temp'))).toBe(false);
+  });
+});

--- a/src/blog/blog.service.tags.spec.ts
+++ b/src/blog/blog.service.tags.spec.ts
@@ -1,0 +1,143 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import { AdminLogService } from '../analytics/admin-log.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { RevalidationService } from '../revalidation/revalidation.service';
+import { StorageService } from '../storage/storage.service';
+import { BlogService } from './blog.service';
+
+/**
+ * 태그 슬러그 생성과 중복 처리를 검사한다.
+ *
+ * 관측 대상은 `prisma.tag.upsert`에 전달된 `where.slug`와 호출 횟수다.
+ * 슬러그 함수는 private이므로 소스를 들여다보지 않고 **실제 전달된 값**을 본다.
+ *
+ * 배경: `[^\w-]`로 지우던 시절에는 "C++"와 "C#"가 둘 다 "c"가 되어 서로 다른
+ * 태그가 같은 행에 연결됐고, 한글 태그는 전부 빈 슬러그로 합쳐졌다.
+ */
+describe('BlogService 태그 슬러그', () => {
+  function build() {
+    const upsertArgs: Array<{ slug: string; name: string }> = [];
+    let nextId = 1;
+    const idBySlug = new Map<string, number>();
+
+    const stored = {
+      id: 1,
+      slug: 'post-slug',
+      title: '제목',
+      content: '본문',
+      thumbnailUrl: null as string | null,
+      postTags: [],
+    };
+
+    const prisma = {
+      post: {
+        create: jest.fn(async () => stored),
+        update: jest.fn(async () => stored),
+        delete: jest.fn(async () => stored),
+        findUnique: jest.fn(async () => stored),
+      },
+      postTag: { findMany: jest.fn(async () => []) },
+      tag: {
+        upsert: jest.fn(
+          async ({
+            where,
+            create,
+          }: {
+            where: { slug: string };
+            create: { name: string; slug: string };
+          }) => {
+            upsertArgs.push({ slug: where.slug, name: create.name });
+            let id = idBySlug.get(where.slug);
+            if (id === undefined) {
+              id = nextId++;
+              idBySlug.set(where.slug, id);
+            }
+            return { id, name: create.name, slug: where.slug };
+          },
+        ),
+        deleteMany: jest.fn(async () => ({ count: 0 })),
+      },
+    };
+
+    const storage = {
+      getPublicUrl: () => 'https://assets.example.test',
+      move: jest.fn(async (_u: string, k: string) => `https://assets.example.test/${k}`),
+      upload: jest.fn(),
+      delete: jest.fn(async () => undefined),
+      deleteByKey: jest.fn(async () => undefined),
+    };
+
+    return { prisma, storage, upsertArgs };
+  }
+
+  async function makeService(deps: ReturnType<typeof build>) {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        BlogService,
+        { provide: PrismaService, useValue: deps.prisma },
+        { provide: StorageService, useValue: deps.storage },
+        { provide: RevalidationService, useValue: { trigger: jest.fn(async () => undefined) } },
+        { provide: AdminLogService, useValue: { log: jest.fn(async () => undefined) } },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn(() => 'admin'), getOrThrow: jest.fn(() => 'admin') },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: {
+            get: jest.fn(async () => undefined),
+            set: jest.fn(async () => undefined),
+            del: jest.fn(async () => undefined),
+            keys: jest.fn(async () => []),
+          },
+        },
+      ],
+    }).compile();
+    return moduleRef.get(BlogService);
+  }
+
+  async function createWithTags(tags: string[]) {
+    const deps = build();
+    const service = await makeService(deps);
+    await service.create({ title: '제목', content: '본문', tags } as Parameters<
+      typeof service.create
+    >[0]);
+    return deps.upsertArgs;
+  }
+
+  it('C++와 C#이 서로 다른 슬러그를 갖는다 — 같으면 두 태그가 한 행으로 합쳐진다', async () => {
+    const args = await createWithTags(['C++', 'C#']);
+
+    const slugs = args.map(a => a.slug);
+    expect(new Set(slugs).size).toBe(2);
+    expect(slugs).not.toContain('');
+  });
+
+  it('한글 태그가 빈 슬러그가 되지 않는다', async () => {
+    const args = await createWithTags(['노드', '리액트']);
+
+    expect(args.map(a => a.slug)).not.toContain('');
+    expect(new Set(args.map(a => a.slug)).size).toBe(2);
+  });
+
+  it('ASCII 태그의 슬러그는 기존과 동일하다 — 기존 75개 태그가 고아가 되면 안 된다', async () => {
+    const args = await createWithTags(['React', 'HTTP Client', 'TypeScript']);
+
+    expect(args.map(a => a.slug)).toEqual(['react', 'http-client', 'typescript']);
+  });
+
+  it('대소문자만 다른 중복은 한 번만 upsert한다 — 안 그러면 복합 PK 중복으로 409가 난다', async () => {
+    const args = await createWithTags(['React', 'react', 'REACT']);
+
+    expect(args).toHaveLength(1);
+    expect(args[0].slug).toBe('react');
+  });
+
+  it('기호뿐인 이름은 태그로 만들지 않는다 — 빈 슬러그는 서로 다른 태그를 한 행으로 만든다', async () => {
+    const args = await createWithTags(['!!!', '???', 'React']);
+
+    expect(args.map(a => a.slug)).toEqual(['react']);
+  });
+});

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -349,14 +349,33 @@ export class BlogService {
 
   // ─── Category CRUD ─────────────────────────────────────────────────────────
 
+  /**
+   * 카테고리 변경의 부수효과.
+   *
+   * 프론트는 카테고리 목록을 `BLOG_CATEGORIES` 태그로 캐싱하고
+   * `DEFAULT_REVALIDATE = false`라 시간 만료가 없다. 통보하지 않으면
+   * 아이콘·정렬 변경이 사이드바에 **영구히** 반영되지 않는다.
+   *
+   * 이름 변경만 무효화 대상으로 보면 안 된다 — 아이콘과 정렬 순서도
+   * 화면에 그대로 드러나는 값이다.
+   */
+  private async triggerCategorySideEffects(): Promise<void> {
+    await this.cache.invalidate();
+    this.revalidation
+      .trigger('blog')
+      .catch(err => this.logger.warn('blog revalidation failed', err));
+  }
+
   async createCategory(dto: { name: string; icon?: string; sortOrder?: number }) {
-    return this.prisma.category.create({
+    const result = await this.prisma.category.create({
       data: {
         name: dto.name,
         icon: dto.icon ?? DEFAULT_CATEGORY_ICON,
         sortOrder: dto.sortOrder ?? 0,
       },
     });
+    await this.triggerCategorySideEffects();
+    return result;
   }
 
   async updateCategory(id: number, dto: { name?: string; icon?: string; sortOrder?: number }) {
@@ -386,9 +405,7 @@ export class BlogService {
         return result;
       });
 
-      if (dto.name !== undefined) {
-        await this.cache.invalidate();
-      }
+      await this.triggerCategorySideEffects();
 
       return updated;
     } catch (error) {
@@ -411,6 +428,7 @@ export class BlogService {
 
       await tx.category.delete({ where: { id } });
     });
+    await this.triggerCategorySideEffects();
   }
 
   // ─── Write ────────────────────────────────────────────────────────────────

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -820,26 +820,69 @@ export class BlogService {
     });
   }
 
+  /**
+   * 태그 이름 목록을 postTags 연결로 바꾼다.
+   *
+   * 두 단계의 중복 제거가 필요하다:
+   *  1) **슬러그 기준 입력 dedupe.** `["React", "react"]`처럼 이름은 다른데
+   *     슬러그가 같은 값이 한 요청에 들어오면 같은 tagId가 두 번 나오고,
+   *     복합 PK `(post_id, tag_id)` 중복으로 P2002가 난다. 그 P2002를 호출부가
+   *     "Slug collision. Please retry."로 오역해, 사용자는 재시도해도 영원히
+   *     같은 실패를 본다.
+   *  2) **빈 슬러그 거부.** 이름이 기호뿐이면 슬러그가 비는데, 그대로 두면
+   *     서로 다른 태그가 전부 슬러그 "" 한 행으로 합쳐진다.
+   *
+   * upsert를 병렬로 돌리지 않는 이유: 같은 슬러그가 동시에 들어오면 upsert가
+   * 원자적이지 않아 경합한다. 태그 수는 글당 한 자릿수라 순차로 돌아도 비용이
+   * 무시할 만하다.
+   */
   private async resolveTagConnections(tagNames: string[]) {
-    return Promise.all(
-      tagNames.map(async name => {
-        const slug = this.slugifyTag(name);
-        const tag = await this.prisma.tag.upsert({
-          where: { slug },
-          create: { name, slug },
-          update: {},
-        });
-        return { tagId: tag.id };
-      }),
-    );
+    const bySlug = new Map<string, string>();
+    for (const name of tagNames) {
+      const slug = this.slugifyTag(name);
+      if (!slug) continue; // 기호뿐인 이름은 태그로 만들지 않는다
+      if (!bySlug.has(slug)) bySlug.set(slug, name);
+    }
+
+    const connections: Array<{ tagId: number }> = [];
+    for (const [slug, name] of bySlug) {
+      const tag = await this.prisma.tag.upsert({
+        where: { slug },
+        create: { name, slug },
+        update: {},
+      });
+      connections.push({ tagId: tag.id });
+    }
+    return connections;
   }
 
+  /**
+   * 태그 이름을 슬러그로 바꾼다.
+   *
+   * `[^\w-]`로 지우면 안 된다 — `\w`는 ASCII만 인정하므로:
+   *   "C++" → "c",  "C#" → "c"    (서로 다른 태그가 같은 슬러그로 충돌)
+   *   "노드" → "",  "리액트" → ""  (한글 태그가 전부 빈 슬러그 하나로 합쳐짐)
+   * `resolveTagConnections`가 `upsert({ where: { slug } })`를 쓰므로 충돌하면
+   * 두 번째 태그가 **첫 번째 태그의 행에 조용히 연결**되어 화면에 엉뚱한
+   * 이름이 뜬다.
+   *
+   * 유니코드 문자/숫자를 보존하고, 기술 이름에서 의미를 지니는 `+`/`#`은
+   * 지우지 않고 `-plus`/`-sharp`로 옮긴다 — 그냥 지우면 "C++"와 "C#"가 둘 다
+   * "c"가 되어 (그리고 "C"와도) 충돌한다.
+   *
+   * 기존 데이터 영향 없음: 운영 태그 75개는 전부 ASCII라 새 규칙에서도 슬러그가
+   * 그대로다(2026-09-04 전수 대조, 변경 0건). 그래서 마이그레이션이 필요 없다.
+   */
   private slugifyTag(name: string): string {
     return name
       .toLowerCase()
       .trim()
+      .replace(/\+/g, '-plus')
+      .replace(/#/g, '-sharp')
       .replace(/[\s_]+/g, '-')
-      .replace(/[^\w-]/g, '');
+      .replace(/[^\p{L}\p{N}-]/gu, '')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
   }
 
   private formatPost(post: PostWithTags, withContent = false) {

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -39,6 +39,14 @@ type PostWithTags = Post & {
 type FinalizeImagesResult = {
   content: string;
   thumbnailUrl?: string | null;
+  /**
+   * 이번 호출에서 실제로 R2에 옮긴 목적지 키.
+   *
+   * 롤백할 때 본문을 다시 파싱해 지울 대상을 유추하면 안 된다 — 부분 실패 시
+   * 본문에는 확정 URL과 아직 못 옮긴 temp URL이 섞여 있어서, 파싱 기반으로
+   * 지우면 재시도에 필요한 temp 원본까지 날아간다.
+   */
+  movedKeys: string[];
   error?: Error;
 };
 
@@ -470,9 +478,23 @@ export class BlogService {
       })) as PostWithTags;
 
       if (finalized.error) {
-        // 이미 옮겨진 이미지의 새 위치는 위에서 DB에 반영했다. 그 뒤에 글을 지운다 —
-        // 순서가 반대면 옮겨진 파일을 가리킬 레코드가 없어져 R2에 고아 파일만 남는다.
         this.logger.error('Image finalization failed, rolling back post', finalized.error);
+
+        // 글을 지우면 옮겨진 파일을 가리킬 레코드가 사라진다. cleanupTempFiles는
+        // `blog/temp/` prefix만 훑으므로 그 파일들은 영원히 회수되지 않는다.
+        // 그래서 레코드를 지우기 **전에** 이번에 옮긴 것만 정리한다.
+        //
+        // 지울 대상을 본문에서 파싱하면 안 된다 — 부분 실패 시 본문에는
+        // 아직 못 옮긴 temp URL도 섞여 있어서, 그것까지 지우면 사용자가
+        // "다시 저장"을 눌러도 원본이 없어 영구히 실패한다.
+        await Promise.all(
+          finalized.movedKeys.map(key =>
+            this.storage
+              .deleteByKey(key)
+              .catch(err => this.logger.warn(`Rollback cleanup failed: ${key}`, err)),
+          ),
+        );
+
         await this.prisma.post
           .delete({ where: { slug } })
           .catch(deleteErr =>
@@ -505,6 +527,20 @@ export class BlogService {
               })
             ).map(pt => pt.tagId)
           : [];
+
+      // 교체당할 옛 썸네일 URL을 미리 확보한다. update 이후에는 알 수 없고,
+      // 지우지 않으면 R2에 영구 고아로 남는다 — cleanupTempFiles는
+      // `blog/temp/` prefix만 훑으므로 `blog/thumbnails/`는 회수 대상이 아니다.
+      // remove()와 updateProfile()은 이미 옛 파일을 지우는데 여기만 빠져 있었다.
+      const previousThumbnailUrl =
+        dto.thumbnailUrl !== undefined
+          ? (
+              await this.prisma.post.findUnique({
+                where: { slug },
+                select: { thumbnailUrl: true },
+              })
+            )?.thumbnailUrl
+          : null;
 
       // DB에 먼저 저장 (temp URL 그대로)
       const post = (await this.prisma.post.update({
@@ -560,11 +596,26 @@ export class BlogService {
           // 매일 3시 StorageCleanupTask가 24시간 뒤 지우므로 다음 날 이미지가 깨진다.
           // 저장 시점에는 정상으로 보여 원인 추적이 어렵다.
           this.logger.error('Image finalization failed during update', finalized.error);
-          await this.triggerPostSideEffects('update', slug, updated.title);
+          // 부분 확정 결과가 이미 커밋됐으므로 캐시 무효화와 revalidation은
+          // 반드시 해야 한다. 다만 action을 'update'로 남기면 어드민 로그에서
+          // 실패한 요청과 성공한 수정이 구별되지 않는다.
+          await this.triggerPostSideEffects('update_partial_failure', slug, updated.title);
           throw new InternalServerErrorException(
             '이미지 확정에 실패했습니다. 글 내용은 저장됐습니다. 이미지를 다시 저장해 주세요.',
           );
         }
+      }
+
+      // 확정까지 성공한 뒤에 옛 썸네일을 지운다. 실패 경로에서 지우면
+      // 사용자가 재시도할 때 되돌아갈 이미지가 없다.
+      if (
+        previousThumbnailUrl &&
+        previousThumbnailUrl !== updated.thumbnailUrl &&
+        !previousThumbnailUrl.startsWith(`${this.storage.getPublicUrl()}/${BLOG_TEMP_PREFIX}/`)
+      ) {
+        this.storage
+          .delete(previousThumbnailUrl)
+          .catch(err => this.logger.warn('Old thumbnail cleanup failed', err));
       }
 
       const result = this.formatPost(updated, true);
@@ -667,21 +718,41 @@ export class BlogService {
     let finalContent = content;
     let finalThumbnail = thumbnailUrl;
 
-    const tempUrls =
-      content.match(
-        new RegExp(`${tempPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"\\s)]+`, 'g'),
-      ) ?? [];
+    // `match(/g)`는 같은 URL이 본문에 두 번 나오면 **두 번 다** 배열에 넣는다.
+    // 중복을 제거하지 않으면 같은 원본에 move가 두 번 불리는데, move는
+    // Copy → Head → Delete(원본)라서 1회차에 원본이 사라지고 2회차 Copy가
+    // NoSuchKey로 터진다. 즉 도입부와 정리 섹션에 같은 이미지를 넣은 글은
+    // 정상 입력인데도 저장이 실패했다.
+    //
+    // 중복 제거가 `replaceAll`보다 **먼저**다. replaceAll만 넣으면 치환은
+    // 양쪽 다 되지만 move는 여전히 두 번 불려 같은 예외가 난다.
+    const tempUrls = [
+      ...new Set(
+        content.match(
+          new RegExp(`${tempPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"\\s)]+`, 'g'),
+        ) ?? [],
+      ),
+    ];
+
+    // 실제로 옮긴 목적지를 기록한다. 호출부가 롤백할 때 이 목록만 지우면 되고,
+    // 본문을 다시 파싱해 유추하지 않아도 된다 — 유추하면 아직 옮기지 않은
+    // temp 원본까지 지워서 재시도 가능하던 실패가 복구 불가능해진다.
+    const movedKeys: string[] = [];
 
     for (const tempUrl of tempUrls) {
       const filename = tempUrl.slice(tempPrefix.length);
       const destKey = `blog/posts/${slug}/${filename}`;
       try {
         const newUrl = await this.storage.move(tempUrl, destKey);
-        finalContent = finalContent.replace(tempUrl, newUrl);
+        // 같은 URL이 본문에 여러 번 있으면 전부 바꿔야 한다. `replace`에
+        // 문자열을 넘기면 첫 번째만 치환되어 나머지가 temp를 가리킨 채 남는다.
+        finalContent = finalContent.replaceAll(tempUrl, newUrl);
+        movedKeys.push(destKey);
       } catch (error) {
         return {
           content: finalContent,
           thumbnailUrl: finalThumbnail,
+          movedKeys,
           error: error instanceof Error ? error : new Error(String(error)),
         };
       }
@@ -692,16 +763,18 @@ export class BlogService {
       const destKey = `blog/thumbnails/${generateSlug()}${ext}`;
       try {
         finalThumbnail = await this.storage.move(thumbnailUrl, destKey);
+        movedKeys.push(destKey);
       } catch (error) {
         return {
           content: finalContent,
           thumbnailUrl: finalThumbnail,
+          movedKeys,
           error: error instanceof Error ? error : new Error(String(error)),
         };
       }
     }
 
-    return { content: finalContent, thumbnailUrl: finalThumbnail };
+    return { content: finalContent, thumbnailUrl: finalThumbnail, movedKeys };
   }
 
   private async triggerPostSideEffects(action: string, slug: string, title?: string) {

--- a/src/common/filters/http-exception.filter.spec.ts
+++ b/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,71 @@
+import type { ArgumentsHost } from '@nestjs/common';
+import { BadRequestException, HttpStatus } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { MAX_FILE_SIZE } from '../utils/file-validation.util';
+import { HttpExceptionFilter } from './http-exception.filter';
+
+/**
+ * 예외 필터가 응답으로 내보내는 **상태 코드**를 검사한다.
+ *
+ * 특히 파일 크기 초과: @fastify/multipart가 던지는 에러는 HttpException이
+ * 아니라서 기본 분기(500)로 떨어지고 있었다. 관리자는 큰 이미지를 올리고
+ * "Internal server error"만 봤다. 필터에는 413 문구가 준비돼 있었는데
+ * 그 코드를 만들어 주는 곳이 없었다.
+ */
+describe('HttpExceptionFilter', () => {
+  function run(exception: unknown) {
+    const sent: { status?: number; body?: Record<string, unknown> } = {};
+    const reply = {
+      status: (code: number) => {
+        sent.status = code;
+        return {
+          send: (body: Record<string, unknown>) => {
+            sent.body = body;
+          },
+        };
+      },
+    };
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => reply,
+        getRequest: () => ({ url: '/api/blog/posts/x/thumbnail' }),
+      }),
+    } as unknown as ArgumentsHost;
+
+    new HttpExceptionFilter().catch(exception, host);
+    return sent;
+  }
+
+  it('HttpException은 자기 상태 코드를 유지한다', () => {
+    const result = run(new BadRequestException('bad input'));
+    expect(result.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('Prisma P2025는 404로 매핑된다', () => {
+    const err = new Prisma.PrismaClientKnownRequestError('not found', {
+      code: 'P2025',
+      clientVersion: '6.0.0',
+    });
+    expect(run(err).status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('파일 크기 초과는 413이다 — 500이면 원인을 알 수 없는 에러가 된다', () => {
+    // @fastify/multipart가 실제로 던지는 형태(code로 식별한다).
+    const err = Object.assign(new Error('request file too large'), {
+      code: 'FST_REQ_FILE_TOO_LARGE',
+      statusCode: 413,
+    });
+
+    const result = run(err);
+
+    expect(result.status).toBe(HttpStatus.PAYLOAD_TOO_LARGE);
+    expect(result.body?.message).toContain(`${MAX_FILE_SIZE / 1024 / 1024} MB`);
+  });
+
+  it('알 수 없는 예외는 500이고 내부 정보를 흘리지 않는다', () => {
+    const result = run(new Error('DB password is hunter2'));
+
+    expect(result.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(JSON.stringify(result.body)).not.toContain('hunter2');
+  });
+});

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import type { FastifyReply, FastifyRequest } from 'fastify';
+import { MAX_FILE_SIZE } from '../utils/file-validation.util';
 
 interface ErrorResponse {
   statusCode: number;
@@ -27,6 +28,22 @@ const HTTP_STATUS_MESSAGES: Record<number, string> = {
   429: 'Too Many Requests',
   500: 'Internal Server Error',
 };
+
+/**
+ * @fastify/multipart의 파일 크기 초과 에러인지 판정한다.
+ *
+ * instanceof로 보지 않는 이유: 이 에러 클래스는 플러그인 내부에서 만들어지고
+ * pnpm 구조상 모듈 사본이 갈릴 수 있어 instanceof가 조용히 false가 될 수 있다.
+ * `code`는 플러그인이 공개적으로 보장하는 식별자다
+ * (@fastify/multipart index.js: createError('FST_REQ_FILE_TOO_LARGE', ..., 413)).
+ */
+function isFileTooLargeError(exception: unknown): boolean {
+  return (
+    typeof exception === 'object' &&
+    exception !== null &&
+    (exception as { code?: unknown }).code === 'FST_REQ_FILE_TOO_LARGE'
+  );
+}
 
 const PRISMA_ERROR_MAP: Record<string, { status: number; message: string }> = {
   P2002: { status: HttpStatus.CONFLICT, message: 'Resource already exists' },
@@ -75,6 +92,18 @@ export class HttpExceptionFilter implements ExceptionFilter {
     if (exception instanceof Prisma.PrismaClientKnownRequestError) {
       const mapped = PRISMA_ERROR_MAP[exception.code];
       if (mapped) return { status: mapped.status, message: mapped.message };
+    }
+
+    // @fastify/multipart가 파일 크기 한도를 넘겼을 때 던지는 에러.
+    // HttpException이 아니라서 아래 기본 분기로 떨어져 500이 나갔다 —
+    // 관리자는 6MB 이미지를 올리고 원인을 알 수 없는 500만 봤다.
+    // 위 HTTP_STATUS_MESSAGES에 413 문구가 준비돼 있었는데 그 코드를
+    // 만들어 주는 곳이 없었다.
+    if (isFileTooLargeError(exception)) {
+      return {
+        status: HttpStatus.PAYLOAD_TOO_LARGE,
+        message: `File too large (max ${MAX_FILE_SIZE / 1024 / 1024} MB)`,
+      };
     }
 
     return { status: HttpStatus.INTERNAL_SERVER_ERROR, message: 'Internal server error' };

--- a/src/common/guards/api-key.guard.spec.ts
+++ b/src/common/guards/api-key.guard.spec.ts
@@ -1,0 +1,89 @@
+import type { ExecutionContext } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ApiKeyGuard } from './api-key.guard';
+
+const VALID_KEY = 'a'.repeat(32);
+
+/**
+ * API 키 검증이 **모든 실패를 401로** 처리하는지 검사한다.
+ *
+ * 예전 구현은 길이 비교에 `String.length`(문자 수)를 썼다. 멀티바이트 문자가
+ * 섞이면 문자 수는 같은데 바이트 수가 달라져 `timingSafeEqual`이 RangeError를
+ * 던졌고, 그건 HttpException이 아니라서 예외 필터에서 **500**이 됐다.
+ * 즉 인증 없이 500과 에러 스택 로그를 임의 횟수 유발할 수 있었다.
+ */
+describe('ApiKeyGuard', () => {
+  function makeContext(headerValue: unknown): ExecutionContext {
+    return {
+      getHandler: () => () => undefined,
+      getClass: () => class {},
+      switchToHttp: () => ({
+        getRequest: () => ({ headers: { 'x-api-key': headerValue } }),
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  function makeGuard(isPublic = true, skipApiKey = false) {
+    const reflector = {
+      getAllAndOverride: jest.fn((key: string) => {
+        if (key === 'skipApiKey') return skipApiKey;
+        return isPublic;
+      }),
+    } as unknown as Reflector;
+    const config = { getOrThrow: jest.fn(() => VALID_KEY) } as never;
+    return new ApiKeyGuard(reflector, config);
+  }
+
+  it('올바른 키는 통과한다', () => {
+    expect(makeGuard().canActivate(makeContext(VALID_KEY))).toBe(true);
+  });
+
+  it('틀린 키는 401', () => {
+    expect(() => makeGuard().canActivate(makeContext('b'.repeat(32)))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('키가 없으면 401', () => {
+    expect(() => makeGuard().canActivate(makeContext(undefined))).toThrow(UnauthorizedException);
+  });
+
+  /**
+   * 핵심 회귀 테스트.
+   * 'a'*31 + 'é' 는 문자 수 32(= 유효 키와 같음)이지만 바이트는 33이다.
+   * 문자 수로만 거르면 timingSafeEqual까지 도달해 RangeError → 500이 된다.
+   */
+  it('멀티바이트가 섞여 문자 수만 같은 키도 401이어야 한다 (500이 아니라)', () => {
+    const sameLengthDifferentBytes = `${'a'.repeat(31)}é`;
+    expect(sameLengthDifferentBytes).toHaveLength(VALID_KEY.length);
+    expect(Buffer.byteLength(sameLengthDifferentBytes)).not.toBe(Buffer.byteLength(VALID_KEY));
+
+    expect(() => makeGuard().canActivate(makeContext(sameLengthDifferentBytes))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('멀티바이트 키에서 RangeError가 새어 나오지 않는다', () => {
+    try {
+      makeGuard().canActivate(makeContext(`${'a'.repeat(31)}é`));
+      throw new Error('예외가 발생해야 한다');
+    } catch (e) {
+      // RangeError가 그대로 올라오면 예외 필터가 500으로 처리한다.
+      expect(e).toBeInstanceOf(UnauthorizedException);
+      expect(e).not.toBeInstanceOf(RangeError);
+    }
+  });
+
+  it('배열 헤더처럼 문자열이 아닌 값도 401', () => {
+    expect(() => makeGuard().canActivate(makeContext(['a', 'b']))).toThrow(UnauthorizedException);
+  });
+
+  it('@SkipApiKey가 붙으면 검사하지 않는다', () => {
+    expect(makeGuard(true, true).canActivate(makeContext(undefined))).toBe(true);
+  });
+
+  it('비공개(JWT) 라우트는 API 키를 요구하지 않는다', () => {
+    expect(makeGuard(false).canActivate(makeContext(undefined))).toBe(true);
+  });
+});

--- a/src/common/guards/api-key.guard.ts
+++ b/src/common/guards/api-key.guard.ts
@@ -45,11 +45,22 @@ export class ApiKeyGuard implements CanActivate {
     const apiKey = request.headers['x-api-key'];
     const expectedKey = this.config.getOrThrow<string>('API_KEY');
 
-    if (
-      typeof apiKey !== 'string' ||
-      apiKey.length !== expectedKey.length ||
-      !timingSafeEqual(Buffer.from(apiKey), Buffer.from(expectedKey))
-    ) {
+    if (typeof apiKey !== 'string') {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    // 길이 비교는 **바이트** 기준이어야 한다.
+    //
+    // `apiKey.length`(문자 수)로 거르면 멀티바이트 문자가 섞인 헤더가 이 가드를
+    // 통과한다. 예: 32자 ASCII 키에 대해 "31자 ASCII + 2바이트 문자 1개"는
+    // 문자 수가 32로 같지만 바이트는 33이다. 그 상태로 timingSafeEqual에 넘기면
+    // RangeError를 던지는데, 이건 HttpException이 아니라 예외 필터의 마지막
+    // 분기로 떨어져 **401이 아니라 500**이 나간다. 즉 인증 없이 임의 횟수로
+    // 500과 에러 스택 로그를 유발할 수 있었다.
+    const provided = Buffer.from(apiKey, 'utf8');
+    const expected = Buffer.from(expectedKey, 'utf8');
+
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
       throw new UnauthorizedException('Invalid API key');
     }
 

--- a/src/common/utils/file-validation.util.ts
+++ b/src/common/utils/file-validation.util.ts
@@ -9,7 +9,19 @@ export const ALLOWED_MIME_TYPES = new Set([
   'image/avif',
 ]);
 
-export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+/**
+ * 업로드 허용 최대 크기.
+ *
+ * **`main.ts`의 multipart `limits.fileSize`와 반드시 같은 값을 써야 한다.**
+ * 예전에는 여기가 10MB, multipart가 5MB였다. multipart가 먼저 걸러버려서
+ * 아래 `buffer.length > MAX_FILE_SIZE` 검사는 **어떤 입력으로도 참이 될 수 없는
+ * 죽은 코드**였고, "File too large (max 10 MB)" 메시지도 절대 표시되지 않았다.
+ * 게다가 multipart가 던지는 에러는 HttpException이 아니라서 413이 아닌 500이
+ * 나갔다 — 6MB 이미지를 올린 관리자는 원인 모를 500만 봤다.
+ *
+ * 그래서 이 상수를 유일한 출처로 삼고 main.ts가 이 값을 가져다 쓴다.
+ */
+export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
 
 const MIME_TO_EXT: Record<string, string> = {
   'image/jpeg': '.jpg',

--- a/src/dto/health-response.dto.ts
+++ b/src/dto/health-response.dto.ts
@@ -1,9 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-/** `GET /health` — 배포 파이프라인(deploy.yml)의 헬스체크가 이 200을 본다. */
+/**
+ * `GET /health` — 배포 파이프라인(deploy.yml)의 헬스체크가 이 200을 본다.
+ *
+ * **이 응답이 배포의 유일한 게이트다.** 그래서 정적 객체를 돌려주면 안 된다 —
+ * DATABASE_URL이 틀려도 200이 나가서 "배포 성공"으로 보이고, 실제로는 모든
+ * 요청이 실패하는 상태로 서비스가 올라간다. `database` 필드는 실제 DB에
+ * 쿼리를 한 번 던진 결과다.
+ */
 export class HealthResponseDto {
-  @ApiProperty({ example: 'ok' })
+  @ApiProperty({ example: 'ok', description: "DB까지 정상이면 'ok', 아니면 'error'" })
   status: string;
+
+  @ApiProperty({ example: 'ok', description: "DB 연결 확인 결과. 'ok' | 'error'" })
+  database: string;
 
   @ApiProperty({ type: String, format: 'date-time' })
   timestamp: string;

--- a/src/dto/openapi-coverage.spec.ts
+++ b/src/dto/openapi-coverage.spec.ts
@@ -14,8 +14,9 @@ import { join } from 'node:path';
 describe('OpenAPI 응답 스키마 커버리지', () => {
   const spec = JSON.parse(readFileSync(join(__dirname, '../../openapi.json'), 'utf8'));
 
+  type MediaType = { schema?: Record<string, unknown> };
   type Operation = {
-    responses?: Record<string, { content?: Record<string, unknown> }>;
+    responses?: Record<string, { content?: Record<string, MediaType> }>;
   };
 
   const operations: Array<{ path: string; method: string; op: Operation }> = [];
@@ -27,16 +28,36 @@ describe('OpenAPI 응답 스키마 커버리지', () => {
     }
   }
 
+  /**
+   * 성공 응답에 **비어 있지 않은 스키마**가 있는지 본다.
+   *
+   * `application/json` 키의 존재만 보면 안 된다. `content: { 'application/json': {} }`
+   * 처럼 스키마가 빈 상태도 통과하는데, 프론트의 `ApiOkJson` 헬퍼는 그때
+   * `MissingResponseSchema`를 돌려줘 **컴파일이 터진다**. 즉 이 파일이 막겠다고
+   * 선언한 바로 그 상태가 초록으로 지나가고 있었다(뮤테이션으로 확인).
+   */
   function hasSuccessBody(op: Operation) {
     const r = op.responses ?? {};
-    return Boolean(
-      r['200']?.content?.['application/json'] ?? r['201']?.content?.['application/json'],
-    );
+    const media =
+      r['200']?.content?.['application/json'] ?? r['201']?.content?.['application/json'];
+    if (!media) return false;
+    const schema = media.schema;
+    return Boolean(schema && Object.keys(schema).length > 0);
   }
   const hasNoContent = (op: Operation) => Boolean(op.responses?.['204']);
 
-  it('스펙에 오퍼레이션이 있다', () => {
-    expect(operations.length).toBeGreaterThan(0);
+  /**
+   * 오퍼레이션 **총 개수**를 고정한다.
+   *
+   * `> 0`만 보면 라우트를 통째로 지웠을 때 순회 대상에서 빠져 아무 검사도
+   * 걸리지 않는다(뮤테이션으로 확인: 72→71이어도 전부 통과했다).
+   * 라우트를 의도적으로 추가/삭제했다면 이 숫자를 함께 고친다 —
+   * 그 순간이 "스펙이 실제로 바뀌었다"를 리뷰에서 드러내는 지점이다.
+   */
+  const EXPECTED_OPERATION_COUNT = 72;
+
+  it(`스펙에 오퍼레이션이 정확히 ${EXPECTED_OPERATION_COUNT}개 있다`, () => {
+    expect(operations).toHaveLength(EXPECTED_OPERATION_COUNT);
   });
 
   /**

--- a/src/health.controller.spec.ts
+++ b/src/health.controller.spec.ts
@@ -1,0 +1,68 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+import { PrismaService } from './prisma/prisma.service';
+
+/**
+ * 헬스체크가 **DB까지** 확인하는지 검사한다.
+ *
+ * 이게 중요한 이유: `deploy.yml`의 헬스체크 루프가 배포의 유일한 게이트다.
+ * 정적 객체를 돌려주던 때에는 DATABASE_URL이 틀려도 200이 나가서
+ * "배포 성공"으로 끝나고, 실제로는 모든 요청이 실패하는 상태로 서비스가 떴다.
+ *
+ * 특히 실패 경로는 **HTTP 상태 코드**를 봐야 한다. deploy.yml은 `curl -sf`를
+ * 쓰므로 본문이 아니라 상태 코드만 본다 — 200에 status:'error'를 실어 보내면
+ * 배포는 그대로 초록으로 끝난다.
+ */
+describe('HealthController', () => {
+  async function build(queryImpl: () => Promise<unknown>) {
+    const prisma = { $queryRaw: jest.fn(queryImpl) };
+    const moduleRef = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [{ provide: PrismaService, useValue: prisma }],
+    }).compile();
+    return { controller: moduleRef.get(HealthController), prisma };
+  }
+
+  it('DB가 정상이면 ok를 돌려준다', async () => {
+    const { controller, prisma } = await build(async () => [{ '?column?': 1 }]);
+
+    const result = await controller.check();
+
+    expect(result.status).toBe('ok');
+    expect(result.database).toBe('ok');
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('실제로 DB에 쿼리를 던진다 — 안 던지면 프로세스 생존만 확인하는 셈이다', async () => {
+    const { controller, prisma } = await build(async () => []);
+
+    await controller.check();
+
+    // 호출 자체가 없으면 정적 응답으로 되돌아간 것이다.
+    expect(prisma.$queryRaw).toHaveBeenCalled();
+  });
+
+  it('DB가 죽으면 503을 던진다 — 200을 내면 curl -sf가 통과해 배포가 초록으로 끝난다', async () => {
+    const { controller } = await build(async () => {
+      throw new Error('connection refused');
+    });
+
+    await expect(controller.check()).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+
+  it('503 본문에도 원인이 담긴다', async () => {
+    const { controller } = await build(async () => {
+      throw new Error('connection refused');
+    });
+
+    try {
+      await controller.check();
+      throw new Error('예외가 발생해야 한다');
+    } catch (e) {
+      const body = (e as ServiceUnavailableException).getResponse() as Record<string, string>;
+      expect(body.database).toBe('error');
+      expect(body.status).toBe('error');
+    }
+  });
+});

--- a/src/health.controller.ts
+++ b/src/health.controller.ts
@@ -1,17 +1,44 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Logger, ServiceUnavailableException } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from './common/decorators/public.decorator';
 import { SkipApiKey } from './common/decorators/skip-api-key.decorator';
 import { HealthResponseDto } from './dto/health-response.dto';
+import { PrismaService } from './prisma/prisma.service';
 
 @ApiTags('health')
 @Controller()
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * deploy.yml이 배포 직후 이 엔드포인트를 20회 폴링해 성공하면 배포 완료로 본다.
+   *
+   * 정적 객체를 돌려주던 때에는 그 검사가 "프로세스가 떠 있다"까지만 확인했다.
+   * DB에 못 붙는 상태로 올라와도 200이 나가서 배포가 초록으로 끝났다.
+   * 실제 쿼리를 한 번 던져 DB까지 확인한다.
+   */
   @Public()
   @SkipApiKey()
   @Get('health')
   @ApiOkResponse({ type: HealthResponseDto })
-  check() {
-    return { status: 'ok', timestamp: new Date().toISOString() };
+  async check(): Promise<HealthResponseDto> {
+    const timestamp = new Date().toISOString();
+
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return { status: 'ok', database: 'ok', timestamp };
+    } catch (error) {
+      // 200에 status:'error'를 실어 보내면 안 된다 — deploy.yml은 `curl -sf`로
+      // **HTTP 상태만** 보므로 본문이 무엇이든 배포가 초록으로 끝난다.
+      // 503을 내야 헬스체크 루프가 실제로 실패하고 배포가 멈춘다.
+      this.logger.error('Health check failed: database unreachable', error);
+      throw new ServiceUnavailableException({
+        status: 'error',
+        database: 'error',
+        timestamp,
+      });
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { SwaggerModule } from '@nestjs/swagger';
 
 import { AppModule } from './app.module';
 import { buildSwaggerConfig } from './common/swagger/swagger.config';
+import { MAX_FILE_SIZE } from './common/utils/file-validation.util';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -17,8 +18,11 @@ async function bootstrap() {
 
   await app.register(import('@fastify/cookie'));
   await app.register(helmet);
+  // 한도는 file-validation.util의 MAX_FILE_SIZE 하나만 쓴다. 두 곳에 따로 적으면
+  // 작은 쪽이 먼저 걸러서 큰 쪽 검사가 죽은 코드가 되고, 사용자에게는 표시되지
+  // 않는 메시지만 남는다(실제로 그랬다).
   await app.register(multipart, {
-    limits: { fileSize: 5 * 1024 * 1024 },
+    limits: { fileSize: MAX_FILE_SIZE },
   });
 
   const config = app.get(ConfigService);

--- a/src/portfolio/portfolio.constants.ts
+++ b/src/portfolio/portfolio.constants.ts
@@ -10,3 +10,12 @@ export const PORTFOLIO_CACHE_TTL = 300_000; // 5 minutes
  * 반영되기까지의 공백이 그대로 길어진다.
  */
 export const LOCALE_CACHE_TTL_MS = 30_000; // 30 seconds
+
+/**
+ * 포트폴리오 콘텐츠가 바뀌었을 때 revalidate를 통보할 프론트 앱 목록.
+ *
+ * `blog`가 들어 있는 것이 핵심이다 — 블로그 앱의 `/about/[locale]`이
+ * 포트폴리오 API를 직접 소비하므로, 포트폴리오만 통보하면 블로그의 소개 페이지가
+ * 영구 stale로 남는다(`DEFAULT_REVALIDATE = false`라 시간 만료가 없다).
+ */
+export const PORTFOLIO_REVALIDATION_TARGETS = ['portfolio', 'blog'] as const;

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -211,10 +211,22 @@ export class PortfolioController {
     return this.portfolioService.deleteLocale(id);
   }
 
+  /**
+   * 응답 타입은 `ProfileDto`다 — `ProfileWithTranslationsDto`가 아니다.
+   *
+   * 서비스가 `getProfile(DEFAULT_LOCALE)`를 돌려주므로 실제 응답에는
+   * `jobTitle`/`introduction`이 있고 `translations`는 **없다**. 예전에는
+   * `ProfileWithTranslationsDto`로 선언돼 있어 스펙이 거짓말을 하고 있었다.
+   *
+   * 지금 프론트가 안 깨지는 이유는 이 라우트만 생성 타입을 쓰지 않고 손으로
+   * 타이핑해 뒀기 때문이다(admin `portfolio.queries.ts`의 `PortfolioProfile`).
+   * 그 손 타이핑이 런타임과 일치해서 가려져 있었고, 생성 타입으로 옮기는
+   * 순간 컴파일은 통과하는데 런타임에 `translations`가 undefined가 됐을 것이다.
+   */
   @ApiBearerAuth()
   @ApiCookieAuth()
   @Put('profile')
-  @ApiOkResponse({ type: ProfileWithTranslationsDto })
+  @ApiOkResponse({ type: ProfileDto })
   @ApiUnauthorized()
   updateProfile(@Body() dto: UpdateProfileDto) {
     return this.portfolioService.updateProfile(dto);

--- a/src/portfolio/portfolio.service.revalidation.spec.ts
+++ b/src/portfolio/portfolio.service.revalidation.spec.ts
@@ -1,0 +1,161 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Test } from '@nestjs/testing';
+import { MailService } from '../common/mail/mail.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { RevalidationService } from '../revalidation/revalidation.service';
+import { StorageService } from '../storage/storage.service';
+import { ValidateLocalePipe } from './pipes/validate-locale.pipe';
+import { PORTFOLIO_REVALIDATION_TARGETS } from './portfolio.constants';
+import { PortfolioService } from './portfolio.service';
+
+/**
+ * 포트폴리오 뮤테이션이 **블로그 앱에도** revalidate를 통보하는지 검사한다.
+ *
+ * 왜 헬퍼가 아니라 서비스 메서드를 부르는가:
+ *   헬퍼(`triggerPortfolioSideEffects`)만 직접 호출해 검사하면 "헬퍼는 옳지만
+ *   호출부가 안 부른다"는 상태를 못 본다. 실제로 이 버그가 그 형태였다 —
+ *   블로그 앱의 revalidate 라우트에 처리 로직이 **이미 다 있었는데**
+ *   부르는 쪽이 없어서 `/about/*`이 영구 stale이었다.
+ *   그래서 공개 메서드를 실제로 실행하고, RevalidationService가 받은 인자를 관측한다.
+ *
+ * 기대값은 상수가 아니라 **리터럴**로 고정한다 — 이유는 `expectNotifiesBothApps`
+ * 주석에 적었다(상수에서 기대값을 끌어오면 상수를 망가뜨리는 뮤테이션을 못 잡는다).
+ */
+describe('PortfolioService revalidation 배선', () => {
+  function build() {
+    const triggered: string[] = [];
+
+    const profile = {
+      id: 1,
+      name: '이름',
+      location: '서울',
+      imageUrl: null,
+      iconUrl: null,
+      socialLinks: [],
+      translations: [{ locale: 'ko', jobTitle: '직함', introduction: ['소개'] }],
+    };
+
+    const prisma = {
+      profile: {
+        findFirst: jest.fn(async () => profile),
+        update: jest.fn(async () => profile),
+        create: jest.fn(async () => profile),
+      },
+      profileTranslation: { upsert: jest.fn(async () => ({})) },
+      experience: {
+        create: jest.fn(async () => ({ id: 1, translations: [] })),
+        update: jest.fn(async () => ({ id: 1, translations: [] })),
+        delete: jest.fn(async () => ({ id: 1 })),
+        findUnique: jest.fn(async () => ({ id: 1, translations: [] })),
+      },
+      locale: {
+        create: jest.fn(async () => ({ id: 1, code: 'en', label: 'English' })),
+        delete: jest.fn(async () => ({ id: 1 })),
+      },
+      experienceTranslation: { deleteMany: jest.fn(async () => ({ count: 0 })) },
+    };
+
+    const revalidation = {
+      trigger: jest.fn(async (type: string) => {
+        triggered.push(type);
+      }),
+    };
+
+    // cache-manager 인터페이스. NamespacedCache가 감싸므로 store 동작만 흉내낸다.
+    const cache = {
+      get: jest.fn(async () => undefined),
+      set: jest.fn(async () => undefined),
+      del: jest.fn(async () => undefined),
+      keys: jest.fn(async () => []),
+    };
+
+    return { prisma, revalidation, cache, triggered };
+  }
+
+  async function makeService(deps: ReturnType<typeof build>) {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        PortfolioService,
+        { provide: PrismaService, useValue: deps.prisma },
+        { provide: RevalidationService, useValue: deps.revalidation },
+        { provide: StorageService, useValue: { delete: jest.fn(), upload: jest.fn() } },
+        { provide: MailService, useValue: { sendContactNotification: jest.fn() } },
+        { provide: ValidateLocalePipe, useValue: { invalidateCache: jest.fn() } },
+        { provide: CACHE_MANAGER, useValue: deps.cache },
+      ],
+    }).compile();
+
+    return moduleRef.get(PortfolioService);
+  }
+
+  /**
+   * 기대값을 상수에서 끌어오지 않고 **리터럴로 고정**한다.
+   *
+   * 처음엔 `toEqual([...PORTFOLIO_REVALIDATION_TARGETS])`로 썼는데,
+   * 상수에서 'blog'를 지우는 뮤테이션에 6건 중 1건만 빨개졌다 —
+   * 기대값이 상수를 따라 같이 움직여서 검사가 무력해진 것이다.
+   * "블로그에도 통보한다"는 건 상수가 마음대로 바꿀 수 있는 값이 아니라
+   * 이 시스템이 지켜야 할 사실이므로, 여기서 직접 못박는다.
+   */
+  function expectNotifiesBothApps(triggered: string[]) {
+    expect(triggered).toEqual(['portfolio', 'blog']);
+  }
+
+  it('상수에 blog가 들어 있다 — 빠지면 블로그 /about/*이 영구 stale이 된다', () => {
+    expect(PORTFOLIO_REVALIDATION_TARGETS).toContain('blog');
+    expect(PORTFOLIO_REVALIDATION_TARGETS).toContain('portfolio');
+  });
+
+  it('updateProfile이 두 앱 모두에 통보한다', async () => {
+    const deps = build();
+    const service = await makeService(deps);
+
+    await service.updateProfile({ name: '새 이름' });
+
+    expectNotifiesBothApps(deps.triggered);
+  });
+
+  it('createExperience가 두 앱 모두에 통보한다', async () => {
+    const deps = build();
+    const service = await makeService(deps);
+
+    await service.createExperience({
+      startDate: '2020-01',
+      translations: [{ locale: 'ko', title: 'T', role: 'R', responsibilities: [] }],
+    } as Parameters<typeof service.createExperience>[0]);
+
+    expectNotifiesBothApps(deps.triggered);
+  });
+
+  it('deleteExperience가 두 앱 모두에 통보한다', async () => {
+    const deps = build();
+    const service = await makeService(deps);
+
+    await service.deleteExperience(1);
+
+    expectNotifiesBothApps(deps.triggered);
+  });
+
+  it('로케일 추가/삭제도 통보한다 — 서버 파이프 캐시만 비우면 프론트에 안 나타난다', async () => {
+    const deps = build();
+    const service = await makeService(deps);
+
+    await service.createLocale({ code: 'en', label: 'English' });
+    expectNotifiesBothApps(deps.triggered);
+
+    deps.triggered.length = 0;
+    await service.deleteLocale(1);
+    expectNotifiesBothApps(deps.triggered);
+  });
+
+  it('revalidation이 실패해도 뮤테이션 자체는 성공한다', async () => {
+    const deps = build();
+    deps.revalidation.trigger = jest.fn(async (_type: string) => {
+      throw new Error('Vercel down');
+    });
+    const service = await makeService(deps);
+
+    // fire-and-forget이므로 예외가 호출자에게 올라오면 안 된다.
+    await expect(service.updateProfile({ name: '새 이름' })).resolves.toBeDefined();
+  });
+});

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -29,7 +29,12 @@ import type {
   UpdateWorkDto,
 } from './dto';
 import { ValidateLocalePipe } from './pipes/validate-locale.pipe';
-import { DEFAULT_LOCALE, PORTFOLIO_CACHE_PREFIX, PORTFOLIO_CACHE_TTL } from './portfolio.constants';
+import {
+  DEFAULT_LOCALE,
+  PORTFOLIO_CACHE_PREFIX,
+  PORTFOLIO_CACHE_TTL,
+  PORTFOLIO_REVALIDATION_TARGETS,
+} from './portfolio.constants';
 import { generateGradientColors } from './portfolio.utils';
 
 @Injectable()
@@ -48,6 +53,32 @@ export class PortfolioService {
   private readonly logger = new Logger(PortfolioService.name);
   private readonly cache: NamespacedCache;
 
+  /**
+   * 포트폴리오 콘텐츠 변경 후의 부수효과를 한 곳에서 처리한다.
+   *
+   * **블로그 앱도 함께 revalidate해야 한다.** 블로그의 `/about/[locale]`은
+   * 포트폴리오 API(profile·experiences·projects·skills·education)를 직접 가져와
+   * 서빙하기 때문이다. `trigger('portfolio')`만 부르면 `PORTFOLIO_REVALIDATE_URL`
+   * 한 곳으로만 POST가 나가고, 블로그 앱은 통보를 받지 못한다.
+   *
+   * 그 결과가 단순한 지연이 아니라 **영구 stale**이라는 점이 중요하다 —
+   * `DEFAULT_REVALIDATE = false`라 시간 기반 만료가 없어서, 통보가 안 가면
+   * 그 내용은 다음 배포까지 영원히 옛것으로 남는다.
+   *
+   * 블로그 앱의 revalidate 라우트에는 `ABOUT_PATHS` 순회와 `PORTFOLIO_*` 태그
+   * 무효화가 이미 전부 구현돼 있었다. 부르는 쪽만 없었다.
+   *
+   * 판정을 이 헬퍼 한 곳으로 모으는 이유: 호출부가 대상 목록을 풀어 쓰면
+   * 새 대상이 생겼을 때 그 호출부만 조용히 빠진다.
+   */
+  private triggerPortfolioSideEffects(): void {
+    for (const target of PORTFOLIO_REVALIDATION_TARGETS) {
+      this.revalidation
+        .trigger(target)
+        .catch(err => this.logger.warn(`${target} revalidation failed`, err));
+    }
+  }
+
   // ─── Locales ────────────────────────────────────────────────────────────────
 
   async getLocales() {
@@ -59,7 +90,12 @@ export class PortfolioService {
       const result = await this.prisma.locale.create({
         data: { code: dto.code, label: dto.label },
       });
+      // 서버 파이프 캐시만 비우면 안 된다. 두 프론트 앱이 로케일 목록을
+      // PORTFOLIO_LOCALES 태그로 캐싱하므로, 통보하지 않으면 새 로케일이
+      // 화면에 영영 나타나지 않는다.
       this.localePipe.invalidateCache();
+      await this.cache.invalidate();
+      this.triggerPortfolioSideEffects();
       return result;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
@@ -73,6 +109,8 @@ export class PortfolioService {
     try {
       await this.prisma.locale.delete({ where: { id } });
       this.localePipe.invalidateCache();
+      await this.cache.invalidate();
+      this.triggerPortfolioSideEffects();
     } catch (error) {
       this.handleNotFound(error, 'Locale');
     }
@@ -175,9 +213,7 @@ export class PortfolioService {
     }
 
     await this.cache.invalidate();
-    this.revalidation
-      .trigger('portfolio')
-      .catch(err => this.logger.warn('revalidation failed', err));
+    this.triggerPortfolioSideEffects();
     return this.getProfile(DEFAULT_LOCALE);
   }
 
@@ -275,9 +311,7 @@ export class PortfolioService {
       include: { translations: true },
     });
     await this.cache.invalidate();
-    this.revalidation
-      .trigger('portfolio')
-      .catch(err => this.logger.warn('revalidation failed', err));
+    this.triggerPortfolioSideEffects();
     return result;
   }
 
@@ -305,9 +339,7 @@ export class PortfolioService {
         include: { translations: true },
       });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
       return result;
     } catch (error) {
       this.handleNotFound(error, 'Experience');
@@ -318,9 +350,7 @@ export class PortfolioService {
     try {
       await this.prisma.experience.delete({ where: { id } });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
     } catch (error) {
       this.handleNotFound(error, 'Experience');
     }
@@ -384,9 +414,7 @@ export class PortfolioService {
       include: { translations: true },
     });
     await this.cache.invalidate();
-    this.revalidation
-      .trigger('portfolio')
-      .catch(err => this.logger.warn('revalidation failed', err));
+    this.triggerPortfolioSideEffects();
     return result;
   }
 
@@ -414,9 +442,7 @@ export class PortfolioService {
         include: { translations: true },
       });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
       return result;
     } catch (error) {
       this.handleNotFound(error, 'Project');
@@ -427,9 +453,7 @@ export class PortfolioService {
     try {
       await this.prisma.project.delete({ where: { id } });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
     } catch (error) {
       this.handleNotFound(error, 'Project');
     }
@@ -513,9 +537,7 @@ export class PortfolioService {
       include: { translations: true },
     });
     await this.cache.invalidate();
-    this.revalidation
-      .trigger('portfolio')
-      .catch(err => this.logger.warn('revalidation failed', err));
+    this.triggerPortfolioSideEffects();
     return result;
   }
 
@@ -550,9 +572,7 @@ export class PortfolioService {
         include: { translations: true },
       });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
       return result;
     } catch (error) {
       this.handleNotFound(error, 'Work');
@@ -563,9 +583,7 @@ export class PortfolioService {
     try {
       await this.prisma.work.delete({ where: { id } });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
     } catch (error) {
       this.handleNotFound(error, 'Work');
     }
@@ -613,9 +631,7 @@ export class PortfolioService {
       },
     });
     await this.cache.invalidate();
-    this.revalidation
-      .trigger('portfolio')
-      .catch(err => this.logger.warn('revalidation failed', err));
+    this.triggerPortfolioSideEffects();
     return result;
   }
 
@@ -632,9 +648,7 @@ export class PortfolioService {
         },
       });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
       return result;
     } catch (error) {
       this.handleNotFound(error, 'Skill');
@@ -645,9 +659,7 @@ export class PortfolioService {
     try {
       await this.prisma.skill.delete({ where: { id } });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
     } catch (error) {
       this.handleNotFound(error, 'Skill');
     }
@@ -704,9 +716,7 @@ export class PortfolioService {
       include: { translations: true },
     });
     await this.cache.invalidate();
-    this.revalidation
-      .trigger('portfolio')
-      .catch(err => this.logger.warn('revalidation failed', err));
+    this.triggerPortfolioSideEffects();
     return result;
   }
 
@@ -731,9 +741,7 @@ export class PortfolioService {
         include: { translations: true },
       });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
       return result;
     } catch (error) {
       this.handleNotFound(error, 'Education');
@@ -744,9 +752,7 @@ export class PortfolioService {
     try {
       await this.prisma.education.delete({ where: { id } });
       await this.cache.invalidate();
-      this.revalidation
-        .trigger('portfolio')
-        .catch(err => this.logger.warn('revalidation failed', err));
+      this.triggerPortfolioSideEffects();
     } catch (error) {
       this.handleNotFound(error, 'Education');
     }

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -82,6 +82,19 @@ export class StorageService {
     await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
   }
 
+  /**
+   * 버킷 키로 직접 삭제한다.
+   *
+   * `delete(url)`은 공개 URL을 키로 되돌리는 과정을 거치는데, 롤백 경로에서는
+   * `move()`가 이미 목적지 **키**를 알고 있으므로 URL로 조립했다가 다시 파싱하는
+   * 왕복이 불필요하다. 그 왕복에서 prefix가 어긋나면 `urlToKey`가 null을 돌려
+   * 삭제가 조용히 no-op이 되는데, 롤백에서 그건 고아 파일로 남는다는 뜻이다.
+   */
+  async deleteByKey(key: string): Promise<void> {
+    if (!key) return;
+    await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
+  }
+
   async cleanupTempFiles(maxAgeMs = 24 * 60 * 60 * 1000): Promise<number> {
     const cutoff = new Date(Date.now() - maxAgeMs);
     let deleted = 0;


### PR DESCRIPTION
2026-09-04 전수 검토에서 나온 발견 중 **운영에 영향 있는 것**을 고쳤다.
각 커밋에 되돌리기 검증 결과를 적어 뒀다.

## Critical

**1. 포트폴리오·카테고리·로케일 변경이 프론트에 영구 반영 안 됨** (`8b75b00`)
- 포트폴리오 뮤테이션 16곳이 `trigger('portfolio')`만 호출 → 블로그 `/about/*`이 영구 stale
- 블로그 앱에는 `ABOUT_PATHS` 처리가 **이미 다 구현돼 있었고 부르는 쪽만 없었다**
- 카테고리 CRUD 3개는 revalidation이 아예 없었고, 이름 변경 시에만 캐시를 비워 아이콘/정렬 변경은 무효화조차 안 됐다
- `DEFAULT_REVALIDATE = false`라 시간 만료가 없어서 지연이 아니라 **영구** stale

**2. Deploy가 CI를 앞질러 배포** (`a75c3ca`)
- 실측(커밋 `11a3e27`): CI 02:20:48~02:29:07 / Deploy 02:20:48~**02:21:51**
- 프로덕션이 검사 종료보다 7분 16초 먼저 라이브
- `workflow_run`(CI 성공 후)으로 변경
- 헬스체크가 정적 객체라 DB에 못 붙어도 200이 나가던 것도 함께 수정 — 이게 배포의 유일한 게이트였다

## High

**3. 같은 이미지를 두 번 참조하면 저장 실패** (`56ca4c7`)
- `match(/g)`가 중복 URL을 두 번 반환 → 같은 원본에 `move` 두 번 → 2회차 `NoSuchKey`
- **dedupe가 `replaceAll`보다 먼저**다. `replaceAll`만 넣으면 증상이 "설명 안 되는 500"으로 바뀔 뿐
- `create()` 롤백이 옮긴 파일을 R2에 영구 방치하던 것도 수정 (본문 파싱이 아니라 실제 옮긴 키만 정리 — 파싱하면 재시도에 필요한 temp 원본까지 지운다)
- `update()`가 교체된 옛 썸네일을 안 지우던 것도 수정

**4. 무인증으로 500 유발 가능** (`0b57177`)
- API 키 길이를 문자 수로 비교 → 멀티바이트 섞인 헤더가 가드를 통과 → `timingSafeEqual`이 RangeError → 401이 아니라 **500**
- 업로드 한도가 두 곳에 5MB/10MB로 달라 10MB 검사가 죽은 코드였고, 초과 시 413이 아니라 500

**5. 만료 리프레시 토큰 무한 누적** (`7b2e3b6`)
- `cleanupExpiredTokens` 호출부 **0개**. 운영 25건이 전부 만료 상태
- 매일 4시 크론으로 배선

## Medium

**6. 태그 슬러그 충돌** (`7b2e3b6`) — `C++`/`C#` 둘 다 `c`, 한글은 전부 빈 슬러그. 기존 75개 태그는 전부 ASCII라 **마이그레이션 불필요**(전수 대조 변경 0건)
**7. 프리뷰 토큰 전수 대입** (`7b2e3b6`) — 분당 10회 스로틀
**8. PUT /profile 스펙 거짓말 + 커버리지 게이트** (`0a196e9`) — 선언은 `translations`, 실제는 `jobTitle/introduction`. 게이트가 빈 스키마와 라우트 삭제를 둘 다 통과시키던 것도 수정

## 검증

- 테스트 128 → **160건** 통과, typecheck/lint 통과
- 격리 컨테이너(5436/`hyunwoo_test`)에서 실제 API 기동해 CRUD 전부 확인:
  - 글 생성/수정/삭제, 카테고리 CRUD, 경력 CRUD, 프로필 수정, 로케일 추가/삭제 — 전부 정상 응답
  - 태그 `["React","리액트","C++","C#","react","!!!"]` → 4개로 정리(중복 dedupe, 기호 거부, 충돌 없음)
  - 이미지 확정 실패 시 롤백 확인 — 고아 글 0건
  - 스펙 ↔ 실제 응답 22개 라우트 **불일치 0건**
- 운영 DB는 SELECT만 사용, 검증용 컨테이너는 제거

## 남긴 것

프리뷰 토큰을 slug에 묶는 것은 프론트가 slug를 알기 전에 토큰을 받는 구조라 이번 범위에서 제외했다(프론트 변경 필요).