### PR TITLE
배포: 프리뷰 토큰 slug 바인딩, 배포 롤백 경로, moduleResolution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,15 +51,8 @@ jobs:
             export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
             cd ~/api-server
 
+            # 배포 로직은 저장소의 scripts/deploy.sh 에 있다. 여기서 길게 쓰면
+            # 문법 검사도 로컬 실행도 안 되기 때문이다. 스크립트 자체를 갱신하려면
+            # 먼저 pull 해야 하므로 여기서 한 번 당긴다(스크립트 안에서도 pull 한다).
             git pull origin main
-
-            docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml build --no-cache api
-            docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml up -d
-            docker image prune -f
-
-            for i in $(seq 1 20); do
-              curl -sf http://localhost:4000/health && exit 0
-              sleep 3
-            done
-            echo "Health check failed after 60s"
-            exit 1
+            sh scripts/deploy.sh

--- a/openapi.json
+++ b/openapi.json
@@ -976,6 +976,16 @@
       "post": {
         "operationId": "AuthController_createPreviewToken",
         "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePreviewTokenDto"
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": "",
@@ -5802,6 +5812,18 @@
         },
         "required": [
           "timeout"
+        ]
+      },
+      "CreatePreviewTokenDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "my-post-slug"
+          }
+        },
+        "required": [
+          "slug"
         ]
       },
       "PreviewTokenDto": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -281,6 +281,8 @@ model PageView {
   ipAddress String?  @map("ip_address") @db.VarChar(45)
   city      String?  @db.VarChar(100)
   country   String?  @db.VarChar(10)
+  /// 항상 false 다. PageViewService.track 이 봇이면 저장 전에 return 하므로
+  /// 봇 트래픽은 이 테이블에 아예 들어오지 않는다(운영 2376행 전부 false).
   isBot     Boolean  @default(false) @map("is_bot")
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# 맥미니에서 도는 배포 스크립트. deploy.yml 이 ssh 로 이 파일을 실행한다.
+#
+# 왜 이 파일이 따로 있는가:
+#   워크플로 YAML 안의 heredoc 은 문법 검사도, 로컬 실행도 안 된다.
+#   배포 로직이 길어지면(롤백·백업·헬스체크) 거기 두는 것은 위험하다.
+#
+# 되돌리기 전략:
+#   1. 빌드 전에 현재 이미지를 :previous 로 태그해 둔다.
+#      (예전에는 `docker image prune -f` 가 빌드 직후 무조건 돌아
+#       되돌릴 이미지를 지웠다 — 그래서 롤백 자체가 불가능했다)
+#   2. 헬스체크가 실패하면 :previous 로 되돌리고 다시 띄운다.
+#   3. 되돌린 뒤 한 번 더 헬스체크해서, 롤백이 성공했는지까지 확인한다.
+#
+# ⚠️ 스키마는 되돌리지 않는다. 컨테이너 기동 시 `prisma migrate deploy` 가
+#    돌기 때문에, 이미지를 되돌려도 **DB 는 새 스키마 그대로**다. 파괴적
+#    마이그레이션(컬럼 삭제 등)이 섞인 배포는 이 스크립트로 온전히 복구되지
+#    않는다. 그래서 배포 전 pg_dump 를 남긴다 — 복원은 사람이 판단해서 한다.
+set -eu
+
+APP_DIR="${APP_DIR:-$HOME/api-server}"
+HEALTH_URL="${HEALTH_URL:-http://localhost:4000/health}"
+BACKUP_DIR="${BACKUP_DIR:-$HOME/api-server-backups}"
+IMAGE="${IMAGE:-api-server-api}"
+DB_CONTAINER="${DB_CONTAINER:-api-server-db-1}"
+KEEP_BACKUPS="${KEEP_BACKUPS:-14}"
+
+COMPOSE="docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml"
+
+cd "$APP_DIR"
+
+log() { echo "[deploy] $*"; }
+
+wait_healthy() {
+  # 20회 × 3초 = 최대 60초.
+  i=1
+  while [ "$i" -le 20 ]; do
+    if curl -sf "$HEALTH_URL" >/dev/null 2>&1; then
+      log "health OK (${i}회째)"
+      return 0
+    fi
+    i=$((i + 1))
+    sleep 3
+  done
+  return 1
+}
+
+# ─── 1. DB 백업 ──────────────────────────────────────────────────────────────
+# 운영 DB 11MB / 덤프 약 300KB 라 비용이 사실상 없다.
+mkdir -p "$BACKUP_DIR"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+DUMP="$BACKUP_DIR/hyunwoo-$STAMP.sql.gz"
+
+log "DB 백업 -> $DUMP"
+
+# 파이프로 바로 gzip 하면 안 된다. `pg_dump | gzip` 의 종료 상태는 **gzip 의 것**이라
+# pg_dump 가 죽어도 성공으로 읽힌다. 게다가 빈 입력을 gzip 하면 20바이트짜리
+# 파일이 나와서 `[ -s ]` 검사마저 통과한다(실측). 그래서 먼저 압축하지 않고 받아
+# 종료 상태와 크기를 각각 확인한 뒤 압축한다.
+RAW="$DUMP.tmp"
+# shellcheck disable=SC2016
+if ! docker exec "$DB_CONTAINER" sh -c 'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB"' > "$RAW" 2>/dev/null; then
+  log "!! pg_dump 실패 — 배포를 중단한다"
+  rm -f "$RAW"
+  exit 1
+fi
+
+if [ ! -s "$RAW" ]; then
+  log "!! 덤프가 비었다 — 배포를 중단한다"
+  rm -f "$RAW"
+  exit 1
+fi
+
+gzip -c "$RAW" > "$DUMP"
+rm -f "$RAW"
+log "백업 완료 ($(wc -c < "$DUMP" | tr -d ' ') bytes)"
+
+# 오래된 백업 정리 (최근 KEEP_BACKUPS개만 남긴다)
+ls -1t "$BACKUP_DIR"/hyunwoo-*.sql.gz 2>/dev/null | tail -n +"$((KEEP_BACKUPS + 1))" | while read -r old; do
+  log "오래된 백업 삭제: $(basename "$old")"
+  rm -f "$old"
+done
+
+# ─── 2. 현재 이미지를 :previous 로 보존 ──────────────────────────────────────
+if docker image inspect "$IMAGE:latest" >/dev/null 2>&1; then
+  docker tag "$IMAGE:latest" "$IMAGE:previous"
+  log "현재 이미지를 $IMAGE:previous 로 보존"
+  HAVE_PREVIOUS=1
+else
+  log "이전 이미지가 없다 (첫 배포로 보인다) — 롤백 대상 없음"
+  HAVE_PREVIOUS=0
+fi
+
+# ─── 3. 코드 갱신 후 빌드 ────────────────────────────────────────────────────
+git pull origin main
+$COMPOSE build --no-cache api
+$COMPOSE up -d
+
+# ─── 4. 헬스체크, 실패하면 되돌린다 ──────────────────────────────────────────
+if wait_healthy; then
+  log "배포 성공"
+  # prune 은 태그 없는(dangling) 이미지만 지운다. :previous 는 태그가 있어 남는다.
+  # 예전의 `docker image prune -f` 는 되돌릴 이미지까지 지우고 있었다.
+  docker image prune -f >/dev/null 2>&1 || true
+  exit 0
+fi
+
+log "!! 헬스체크 실패 (60초)"
+docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml logs --tail 50 api || true
+
+if [ "$HAVE_PREVIOUS" -eq 0 ]; then
+  log "!! 되돌릴 이미지가 없다 — 수동 조치가 필요하다"
+  exit 1
+fi
+
+log "이전 이미지로 되돌린다"
+docker tag "$IMAGE:previous" "$IMAGE:latest"
+$COMPOSE up -d --force-recreate api
+
+if wait_healthy; then
+  log "롤백 성공 — 이전 버전으로 서비스 중이다"
+  log "⚠️ 스키마는 되돌리지 않았다. 마이그레이션이 섞인 배포였다면 $DUMP 로 복원을 검토할 것"
+  exit 1   # 배포 자체는 실패다. 초록으로 끝내면 안 된다.
+fi
+
+log "!! 롤백까지 실패했다 — 수동 조치가 필요하다"
+log "   백업: $DUMP"
+exit 1

--- a/scripts/update-smtp-pass.sh
+++ b/scripts/update-smtp-pass.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Gmail 앱 비밀번호를 맥미니 운영 서버에 안전하게 반영한다.
+#
+# 값은 이 셸 안에서만 존재한다 — 화면에 찍히지 않고(read -s), 셸 히스토리에도
+# 남지 않으며(인자가 아니라 표준입력), 어떤 로그에도 기록되지 않는다.
+#
+# 사용법:  bash scripts/update-smtp-pass.sh
+set -euo pipefail
+
+# 배포 서버 호스트는 저장소에 두지 않는다(공개 저장소). SSH config 의 Host 별칭을
+# 환경변수로 넘긴다.  예)  SMTP_TARGET_HOST=<별칭> bash scripts/...
+HOST="${SMTP_TARGET_HOST:?SMTP_TARGET_HOST 를 지정하라 (예: SMTP_TARGET_HOST=myserver)}"
+DOCKER="/usr/local/bin/docker"
+ENVFILE="~/api-server/.env.prod"
+
+echo "대상 서버: $HOST"
+echo "Gmail 앱 비밀번호를 입력하세요 (화면에 표시되지 않습니다)."
+echo "  https://myaccount.google.com/apppasswords 에서 발급한 16자"
+echo "  공백이 포함돼 있어도 됩니다 — 자동으로 제거합니다."
+printf "앱 비밀번호: "
+read -rs RAW
+echo
+
+# 공백 제거 후 검증
+PASS="${RAW// /}"
+if [ ${#PASS} -ne 16 ]; then
+  echo "✗ 공백을 제거한 길이가 ${#PASS}자입니다. Gmail 앱 비밀번호는 16자여야 합니다." >&2
+  exit 1
+fi
+if ! printf '%s' "$PASS" | grep -qE '^[a-z]{16}$'; then
+  echo "✗ 형식이 예상과 다릅니다(소문자 16자여야 함). 오타가 없는지 확인하세요." >&2
+  exit 1
+fi
+echo "✓ 형식 확인: 16자"
+
+# 백업 (타임스탬프)
+STAMP=$(date +%Y%m%d-%H%M%S)
+echo "→ 백업 생성 중..."
+ssh "$HOST" "cp -p $ENVFILE $ENVFILE.bak-$STAMP && ls -la $ENVFILE.bak-$STAMP"
+
+# 값을 표준입력으로만 넘긴다 (ssh 명령 인자로 노출되지 않음)
+echo "→ SMTP_PASS 교체 중..."
+printf '%s' "$PASS" | ssh "$HOST" "cat > /tmp/.smtp_new && \
+  python3 - <<'PY'
+import re, os
+p = os.path.expanduser('~/api-server/.env.prod')
+new = open('/tmp/.smtp_new').read().strip()
+s = open(p, encoding='utf-8').read()
+m = re.search(r'^SMTP_PASS=(.*)\$', s, re.M)
+assert m, 'SMTP_PASS 줄을 찾지 못했다'
+old_line = m.group(0)
+assert s.count(old_line) == 1, '앵커가 유일하지 않다'
+s = s.replace(old_line, 'SMTP_PASS=' + new)
+open(p, 'w', encoding='utf-8').write(s)
+print('치환 완료: 길이', len(new))
+PY
+  rm -f /tmp/.smtp_new"
+
+# 반영 확인 (값이 아니라 길이만)
+echo "→ 파일 반영 확인..."
+ssh "$HOST" "awk -F= '/^SMTP_PASS=/{v=substr(\$0,index(\$0,\"=\")+1); print \"  파일 내 길이: \" length(v) \"자, 공백 \" gsub(/ /,\"\",v) \"개\"}' $ENVFILE"
+
+# 재시작
+echo "→ api 컨테이너 재시작..."
+ssh "$HOST" "cd ~/api-server && $DOCKER compose --env-file .env.prod \
+  -f docker-compose.yml -f docker-compose.prod.yml up -d api" 2>&1 | tail -3
+
+echo "→ 기동 대기..."
+ssh "$HOST" "for i in \$(seq 1 30); do
+  st=\$($DOCKER inspect api-server-api-1 --format '{{.State.Health.Status}}' 2>/dev/null || echo starting)
+  [ \"\$st\" = healthy ] && echo '  healthy' && exit 0
+  sleep 2
+done; echo '  ✗ healthy 되지 않음'; exit 1"
+
+echo
+echo "✓ 반영 완료. 이제 다음을 실행해 실제 메일 발송까지 확인하세요:"
+echo "    bash scripts/verify-smtp.sh"

--- a/scripts/verify-smtp.sh
+++ b/scripts/verify-smtp.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SMTP 설정이 실제로 동작하는지 확인한다.
+# 문의 1건을 보내고 서버 로그에서 535 인증 오류가 사라졌는지 본다.
+set -euo pipefail
+
+# 배포 서버 호스트는 저장소에 두지 않는다(공개 저장소). SSH config 의 Host 별칭을
+# 환경변수로 넘긴다.  예)  SMTP_TARGET_HOST=<별칭> bash scripts/...
+HOST="${SMTP_TARGET_HOST:?SMTP_TARGET_HOST 를 지정하라 (예: SMTP_TARGET_HOST=myserver)}"
+DOCKER="/usr/local/bin/docker"
+API="https://api.chahyunwoo.dev"
+
+echo "→ 포트폴리오 번들에서 API 키 추출..."
+KEY=$(curl -s -m 25 https://portfolio.chahyunwoo.dev/ \
+  | grep -oE '/_next/static/[a-zA-Z0-9./_-]+\.js' | sort -u \
+  | while read -r c; do
+      curl -s -m 20 "https://portfolio.chahyunwoo.dev$c" \
+        | grep -oE '"x-api-key":"[0-9a-f]{64}"' | head -1
+    done | head -1 | sed -E 's/.*"x-api-key":"([0-9a-f]{64})".*/\1/')
+
+if [ -z "$KEY" ]; then echo "✗ API 키를 찾지 못했다" >&2; exit 1; fi
+echo "  키 확보 (${#KEY}자)"
+
+STAMP=$(date +%s)
+echo "→ 테스트 문의 전송..."
+CODE=$(curl -s -m 25 -o /dev/null -w '%{http_code}' -X POST "$API/api/portfolio/contact" \
+  -H "x-api-key: $KEY" -H 'content-type: application/json' \
+  -H 'Origin: https://portfolio.chahyunwoo.dev' \
+  -d "{\"name\":\"SMTP 검증\",\"email\":\"smtp-check-$STAMP@example.com\",\"subject\":\"[TEST] SMTP 검증 $STAMP\",\"message\":\"앱 비밀번호 교체 후 메일 발송이 정상인지 확인하는 테스트입니다. 확인 후 삭제해 주세요.\"}")
+echo "  HTTP $CODE"
+
+echo "→ 발송 결과 대기 (10초)..."
+sleep 10
+
+echo "→ 서버 로그 확인..."
+LOG=$(ssh "$HOST" "$DOCKER logs api-server-api-1 --since 2m 2>&1 | grep -iE 'mail|535|contact' | tail -5" || true)
+if printf '%s' "$LOG" | grep -q '535'; then
+  echo "  ✗ 여전히 인증 실패:"
+  printf '%s\n' "$LOG" | sed 's/^/    /'
+  exit 1
+elif [ -z "$LOG" ]; then
+  echo "  ✓ 메일 관련 오류 로그 없음 (발송 성공으로 판단)"
+else
+  printf '%s\n' "$LOG" | sed 's/^/    /'
+fi
+
+echo "→ DB 저장 확인..."
+ssh "$HOST" "$DOCKER exec api-server-db-1 psql -U chwzp -d hyunwoo -t -c \
+  \"SELECT id || ' | ' || name || ' | ' || subject FROM portfolio.contact_messages ORDER BY id DESC LIMIT 3;\""
+
+echo
+echo "✓ 검증 끝. 받은편지함에 '[TEST] SMTP 검증 $STAMP' 메일이 왔는지 확인하세요."
+echo "  왔다면 테스트 문의 정리:"
+echo "    ssh $HOST \"$DOCKER exec api-server-db-1 psql -U chwzp -d hyunwoo -c \\\"DELETE FROM portfolio.contact_messages WHERE email LIKE 'smtp-check-%';\\\"\""

--- a/src/analytics/page-view.service.ts
+++ b/src/analytics/page-view.service.ts
@@ -61,6 +61,14 @@ export class PageViewService {
     );
   }
 
+  /**
+   * 봇은 **기록하지 않는다.** 아래에서 조기 return 하므로 저장되는 행의
+   * `isBot` 은 구조적으로 항상 false 다(운영 실측 2026-09-04: 2376행 전부 false).
+   *
+   * 즉 `is_bot` 컬럼은 "봇 여부를 가리는 플래그"가 아니다 — 봇 트래픽은
+   * 애초에 이 테이블에 없다. 컬럼만 보고 "봇도 저장되는데 플래그만 다르다"고
+   * 읽으면 안 된다. 봇까지 세고 싶다면 이 조기 return 을 걷어내야 한다.
+   */
   async track(dto: TrackPageViewInput): Promise<void> {
     const isBot = detectBot(dto.userAgent);
     if (isBot) return;

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -33,6 +33,7 @@ import {
   TwoFactorStatusDto,
   TwoFactorToggleDto,
 } from './dto/auth-response.dto';
+import { CreatePreviewTokenDto } from './dto/create-preview-token.dto';
 import { Enable2faDto } from './dto/enable-2fa.dto';
 import { LoginDto } from './dto/login.dto';
 import { Verify2faDto } from './dto/verify-2fa.dto';
@@ -211,15 +212,19 @@ export class AuthController {
   @Post('preview-token')
   @ApiCreatedResponse({ type: PreviewTokenDto })
   @HttpCode(HttpStatus.OK)
-  createPreviewToken() {
-    return this.authService.createPreviewToken();
+  createPreviewToken(@Body() dto: CreatePreviewTokenDto) {
+    return this.authService.createPreviewToken(dto.slug);
   }
 
   @Public()
   @Get('verify-preview')
   @ApiOkResponse({ type: PreviewValidDto })
-  verifyPreview(@Query('token') token: string, @Res() reply: FastifyReply) {
-    const valid = this.authService.verifyPreviewToken(token);
+  verifyPreview(
+    @Query('token') token: string,
+    @Query('slug') slug: string | undefined,
+    @Res() reply: FastifyReply,
+  ) {
+    const valid = this.authService.verifyPreviewToken(token, slug);
     if (!valid) {
       return reply.status(HttpStatus.UNAUTHORIZED).send({
         statusCode: 401,

--- a/src/auth/auth.service.preview-token.spec.ts
+++ b/src/auth/auth.service.preview-token.spec.ts
@@ -1,0 +1,86 @@
+// otplib 은 ESM 전용 의존성(@scure/base)을 끌어와 ts-jest 의 CJS 변환에서 깨진다.
+// 프리뷰 토큰 경로는 TOTP 를 전혀 쓰지 않으므로 모듈만 대체한다.
+jest.mock('otplib', () => ({
+  generateSecret: jest.fn(),
+  generateURI: jest.fn(),
+  verifySync: jest.fn(),
+}));
+
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuthService } from './auth.service';
+
+/**
+ * 프리뷰 토큰이 발급 대상 slug 에 묶여 있는지 검사한다 (#125).
+ *
+ * 고친 버그: `previewTokens` 가 `Map<string, number>`(만료시각만) 이라
+ * 토큰 하나로 **모든** 비공개 글을 열 수 있었다. 어드민 프리뷰 링크가
+ * 한 번 새면 미발행 글 전체가 노출된다.
+ */
+describe('AuthService 프리뷰 토큰 slug 바인딩', () => {
+  function createService(): AuthService {
+    const config = {
+      getOrThrow: (key: string) => {
+        if (key === 'JWT_SECRET') return 'test-secret-for-preview-token-spec';
+        throw new Error(`unexpected config key: ${key}`);
+      },
+    } as unknown as ConfigService;
+
+    return new AuthService(config, {} as JwtService, {} as PrismaService);
+  }
+
+  it('발급받은 slug 에 대해서는 통과한다', () => {
+    const service = createService();
+    const { token } = service.createPreviewToken('my-post');
+
+    expect(service.verifyPreviewToken(token, 'my-post')).toBe(true);
+  });
+
+  it('다른 글의 slug 로는 거부한다 — 이것이 #125 의 본체다', () => {
+    const service = createService();
+    const { token } = service.createPreviewToken('my-post');
+
+    expect(service.verifyPreviewToken(token, 'secret-unpublished-post')).toBe(false);
+  });
+
+  it('서로 다른 slug 로 발급한 토큰은 서로의 글을 열지 못한다', () => {
+    const service = createService();
+    const a = service.createPreviewToken('post-a');
+    const b = service.createPreviewToken('post-b');
+
+    expect(service.verifyPreviewToken(a.token, 'post-a')).toBe(true);
+    expect(service.verifyPreviewToken(a.token, 'post-b')).toBe(false);
+    expect(service.verifyPreviewToken(b.token, 'post-b')).toBe(true);
+    expect(service.verifyPreviewToken(b.token, 'post-a')).toBe(false);
+  });
+
+  it('존재하지 않는 토큰은 거부한다', () => {
+    const service = createService();
+    service.createPreviewToken('my-post');
+
+    expect(service.verifyPreviewToken('deadbeef', 'my-post')).toBe(false);
+  });
+
+  it('만료된 토큰은 slug 가 맞아도 거부한다', () => {
+    const service = createService();
+    const { token } = service.createPreviewToken('my-post');
+
+    // TTL 은 30분이다. 그 너머로 시계를 옮긴다.
+    const realNow = Date.now;
+    Date.now = () => realNow() + 31 * 60 * 1000;
+    try {
+      expect(service.verifyPreviewToken(token, 'my-post')).toBe(false);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('slug 를 넘기지 않으면 유효성만 본다 (어드민 상태 확인용 경로)', () => {
+    const service = createService();
+    const { token } = service.createPreviewToken('my-post');
+
+    expect(service.verifyPreviewToken(token)).toBe(true);
+    expect(service.verifyPreviewToken('deadbeef')).toBe(false);
+  });
+});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -257,11 +257,15 @@ export class AuthService {
 
   // ─── Preview Token ────────────────────────────────────────────────────────
 
-  private readonly previewTokens = new Map<string, number>();
+  // 토큰 -> { 만료시각, 대상 slug }
+  // slug 를 함께 담는 이유: 예전에는 만료시각만 저장해 한 번 발급된 토큰으로
+  // **모든** 비공개 글을 열 수 있었다. 토큰이 새면 피해가 그 글 하나로
+  // 그치도록 발급 시점의 slug 에 묶는다.
+  private readonly previewTokens = new Map<string, { expiresAt: number; slug: string }>();
   private static readonly PREVIEW_TOKEN_TTL = 30 * 60 * 1000; // 30 minutes
   private static readonly MAX_PREVIEW_TOKENS = 10;
 
-  createPreviewToken(): { token: string; expiresIn: number } {
+  createPreviewToken(slug: string): { token: string; expiresIn: number } {
     this.cleanupPreviewTokens();
 
     if (this.previewTokens.size >= AuthService.MAX_PREVIEW_TOKENS) {
@@ -270,7 +274,10 @@ export class AuthService {
     }
 
     const token = randomBytes(32).toString('hex');
-    this.previewTokens.set(token, Date.now() + AuthService.PREVIEW_TOKEN_TTL);
+    this.previewTokens.set(token, {
+      expiresAt: Date.now() + AuthService.PREVIEW_TOKEN_TTL,
+      slug,
+    });
 
     return { token, expiresIn: 1800 };
   }
@@ -285,12 +292,17 @@ export class AuthService {
     }
   }
 
-  verifyPreviewToken(token: string): boolean {
-    const expiresAt = this.previewTokens.get(token);
-    if (!expiresAt || expiresAt < Date.now()) {
+  /**
+   * `slug` 를 넘기면 그 글에 대해 발급된 토큰인지까지 확인한다.
+   * 넘기지 않으면 유효성(존재·만료)만 본다 — 어드민의 토큰 상태 확인용이다.
+   */
+  verifyPreviewToken(token: string, slug?: string): boolean {
+    const entry = this.previewTokens.get(token);
+    if (!entry || entry.expiresAt < Date.now()) {
       this.previewTokens.delete(token);
       return false;
     }
+    if (slug !== undefined && entry.slug !== slug) return false;
     return true;
   }
 
@@ -300,8 +312,8 @@ export class AuthService {
 
   private cleanupPreviewTokens(): void {
     const now = Date.now();
-    for (const [token, expiresAt] of this.previewTokens) {
-      if (expiresAt < now) this.previewTokens.delete(token);
+    for (const [token, entry] of this.previewTokens) {
+      if (entry.expiresAt < now) this.previewTokens.delete(token);
     }
   }
 

--- a/src/auth/dto/create-preview-token.dto.ts
+++ b/src/auth/dto/create-preview-token.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreatePreviewTokenDto {
+  /**
+   * 미리보기를 허용할 글의 slug.
+   *
+   * 토큰을 이 slug에 묶어 두면 토큰이 유출돼도 열람 범위가 그 글 하나로
+   * 제한된다. 예전에는 slug 없이 발급해 토큰 하나로 모든 비공개 글을
+   * 볼 수 있었다.
+   */
+  @ApiProperty({ example: 'my-post-slug' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  slug: string;
+}

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -156,7 +156,9 @@ export class BlogController {
   @ApiNotFound('Post')
   @ApiUnauthorized()
   async findOnePreview(@Param('slug') slug: string, @Query('token') token: string) {
-    if (!token || !this.authService.verifyPreviewToken(token)) {
+    // slug 를 함께 넘겨 "이 글에 대해 발급된 토큰인가"까지 확인한다.
+    // 넘기지 않으면 토큰 하나로 모든 비공개 글이 열린다.
+    if (!token || !this.authService.verifyPreviewToken(token, slug)) {
       throw new UnauthorizedException('Invalid or expired preview token');
     }
     return this.blogService.findBySlug(slug, true);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
`dev` → `main`. 이슈 4건.

## 담긴 것

| 이슈 | 내용 |
|---|---|
| #125 | 프리뷰 토큰을 발급 대상 slug 에 묶는다 |
| #126 | 배포 실패 시 되돌릴 수 있게 한다 |
| #117 | moduleResolution 을 node16 으로 지정 |
| #138 | is_bot 이 항상 false 인 이유 문서화 |
| — | SMTP 스크립트 (기존 dev 에 있던 것) |

## ⚠️ 배포 순서

**#125 는 hyunwoo-dev 와 동시 배포가 필요하다.** 이 PR 이 먼저 배포되면
그 사이 구버전 어드민의 프리뷰 버튼이 400 이 된다. 프론트 PR 을 바로 이어서 머지할 것.

## ⚠️ 이 배포부터 배포 스크립트가 바뀐다

`deploy.yml` 이 인라인 명령 대신 `scripts/deploy.sh` 를 실행한다(#126).
**이번 배포가 새 스크립트의 첫 실행**이므로 로그를 지켜보는 편이 좋다.
새 동작: 배포 전 pg_dump, 이전 이미지를 `:previous` 로 보존, 헬스체크 실패 시 자동 롤백.

## 검증

```
npx jest       15 suites / 166 tests 통과 (신규 6건 포함)
pnpm typecheck 통과
pnpm build     성공, 산출물 CommonJS 유지
CI             success (7291bcb)
```

되돌리기 검증:
- #125 — slug 대조를 무력화하면 교차 slug 테스트 2건이 정확히 FAIL
- #126 — 이미지 보존을 빼면 롤백 후에도 서비스가 `running=BAD` 로 남음

맥미니 실측(읽기만): `pg_dump` 313,361 bytes 유효한 덤프, 이미지·컨테이너 이름 일치.

## 참고

#117 은 **지금 깨져 있던 것을 고치는 게 아니다.** 이전 설정도 Node 22 에서는
동작한다(`file-type` 이 `module-sync` 를 내보내고 운영은 v22.23.2). 잠재 취약성 제거다.

#138 의 `is_bot` 컬럼은 삭제하지 않고 주석만 남겼다 — 운영 DB 마이그레이션이라
별도 판단이 필요하다.

Closes #125
Closes #126
Closes #117