### PR TITLE
부분 수정이 필드를 지우던 버그 수정 (#131)

### DIFF
--- a/src/blog/dto/create-post.dto.ts
+++ b/src/blog/dto/create-post.dto.ts
@@ -46,7 +46,7 @@ export class CreatePostDto {
   @ApiPropertyOptional({ default: false })
   @IsOptional()
   @IsBoolean()
-  published?: boolean = false;
+  published?: boolean;
 
   @ApiPropertyOptional({ example: '2026-03-21', description: '발행일 (미입력 시 발행 시점 자동)' })
   @IsOptional()
@@ -57,5 +57,5 @@ export class CreatePostDto {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  tags?: string[] = [];
+  tags?: string[];
 }

--- a/src/dto/update-dto-defaults.spec.ts
+++ b/src/dto/update-dto-defaults.spec.ts
@@ -1,0 +1,74 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { UpdatePostDto } from '../blog/dto/update-post.dto';
+import { UpdateEducationDto } from '../portfolio/dto/update-education.dto';
+import { UpdateExperienceDto } from '../portfolio/dto/update-experience.dto';
+import { UpdateProjectDto } from '../portfolio/dto/update-project.dto';
+import { UpdateSkillDto } from '../portfolio/dto/update-skill.dto';
+import { UpdateWorkDto } from '../portfolio/dto/update-work.dto';
+
+/**
+ * `PartialType(CreateXxxDto)` 로 만든 Update DTO 가 **원본의 필드 기본값을
+ * 물려받지 않는지** 검사한다 (#131).
+ *
+ * 고친 버그: `CreatePostDto` 에 `published?: boolean = false` 같은 기본값이
+ * 있으면, `PartialType` 으로 상속해도 그 기본값이 살아남는다. class-transformer
+ * 가 요청에 없는 필드를 기본값으로 채워 넣으므로, 서비스의
+ * `...(dto.published !== undefined && { published: dto.published })` 같은
+ * 부분 업데이트 가드가 **뚫린다**.
+ *
+ * 실제 피해(운영 실측 2026-09-04): 제목만 수정했는데 발행 글이 비공개가 되고
+ * 태그가 지워졌다. 포트폴리오에서는 정렬 순서가 0으로, isCurrent/featured 가
+ * false 로 리셋된다.
+ *
+ * 서비스는 create 시 `dto.sortOrder ?? 0` 로 이미 방어하고 있으므로
+ * DTO 기본값은 불필요한 중복이었다.
+ */
+describe('Update DTO 가 기본값을 주입하지 않는다 (#131)', () => {
+  const cases: Array<[string, new () => object]> = [
+    ['UpdatePostDto', UpdatePostDto],
+    ['UpdateEducationDto', UpdateEducationDto],
+    ['UpdateSkillDto', UpdateSkillDto],
+    ['UpdateExperienceDto', UpdateExperienceDto],
+    ['UpdateWorkDto', UpdateWorkDto],
+    ['UpdateProjectDto', UpdateProjectDto],
+  ];
+
+  it.each(cases)('%s: 빈 body 를 변환해도 아무 필드도 채워지지 않는다', (_name, cls) => {
+    const dto = plainToInstance(cls, {}) as Record<string, unknown>;
+    const injected = Object.entries(dto).filter(([, v]) => v !== undefined);
+
+    expect(injected).toEqual([]);
+  });
+
+  /**
+   * 이 케이스가 #131 의 본체다. 부분 업데이트에서 보내지 않은 필드는
+   * `undefined` 로 남아야 서비스의 가드가 그 필드를 건너뛴다.
+   */
+  it('제목만 보내면 published/tags 가 undefined 로 남는다', () => {
+    const dto = plainToInstance(UpdatePostDto, { title: '제목만 수정' });
+
+    expect(dto.title).toBe('제목만 수정');
+    expect(dto.published).toBeUndefined();
+    expect(dto.tags).toBeUndefined();
+  });
+
+  /**
+   * 기본값을 없앤다고 **명시적으로 보낸 false/0 까지** 무시하면 안 된다.
+   * 비공개 전환과 정렬 맨 앞 배치가 실제로 동작해야 한다.
+   */
+  it('명시적으로 보낸 false/0 은 그대로 보존된다', () => {
+    const post = plainToInstance(UpdatePostDto, { published: false, tags: [] });
+    expect(post.published).toBe(false);
+    expect(post.tags).toEqual([]);
+
+    const work = plainToInstance(UpdateWorkDto, {
+      sortOrder: 0,
+      isCurrent: false,
+      featured: false,
+    });
+    expect(work.sortOrder).toBe(0);
+    expect(work.isCurrent).toBe(false);
+    expect(work.featured).toBe(false);
+  });
+});

--- a/src/portfolio/dto/create-education.dto.ts
+++ b/src/portfolio/dto/create-education.dto.ts
@@ -37,7 +37,7 @@ export class CreateEducationDto {
   @IsOptional()
   @IsInt()
   @Min(0)
-  sortOrder?: number = 0;
+  sortOrder?: number;
 
   @ApiProperty({ type: [EducationTranslationDto] })
   @IsArray()

--- a/src/portfolio/dto/create-experience.dto.ts
+++ b/src/portfolio/dto/create-experience.dto.ts
@@ -38,7 +38,7 @@ export class CreateExperienceDto {
   @IsOptional()
   @IsInt()
   @Min(0)
-  sortOrder?: number = 0;
+  sortOrder?: number;
 
   @ApiProperty()
   @IsString()
@@ -53,7 +53,7 @@ export class CreateExperienceDto {
   @ApiPropertyOptional({ default: false })
   @IsOptional()
   @IsBoolean()
-  isCurrent?: boolean = false;
+  isCurrent?: boolean;
 
   @ApiProperty({ type: [ExperienceTranslationDto] })
   @IsArray()

--- a/src/portfolio/dto/create-project.dto.ts
+++ b/src/portfolio/dto/create-project.dto.ts
@@ -34,7 +34,7 @@ export class CreateProjectDto {
   @IsOptional()
   @IsInt()
   @Min(0)
-  sortOrder?: number = 0;
+  sortOrder?: number;
 
   @ApiPropertyOptional()
   @IsOptional()
@@ -54,7 +54,7 @@ export class CreateProjectDto {
   @ApiPropertyOptional({ default: false })
   @IsOptional()
   @IsBoolean()
-  featured?: boolean = false;
+  featured?: boolean;
 
   @ApiProperty({ type: [ProjectTranslationDto] })
   @IsArray()

--- a/src/portfolio/dto/create-skill.dto.ts
+++ b/src/portfolio/dto/create-skill.dto.ts
@@ -16,14 +16,14 @@ export class CreateSkillDto {
   @IsOptional()
   @IsInt()
   @Min(0)
-  sortOrder?: number = 0;
+  sortOrder?: number;
 
   @ApiPropertyOptional({ default: 0, minimum: 0, maximum: 100 })
   @IsOptional()
   @IsInt()
   @Min(0)
   @Max(100)
-  proficiency?: number = 0;
+  proficiency?: number;
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/src/portfolio/dto/create-work.dto.ts
+++ b/src/portfolio/dto/create-work.dto.ts
@@ -25,7 +25,7 @@ export class CreateWorkDto {
   @IsOptional()
   @IsInt()
   @Min(0)
-  sortOrder?: number = 0;
+  sortOrder?: number;
 
   @ApiPropertyOptional()
   @IsOptional()
@@ -40,7 +40,7 @@ export class CreateWorkDto {
   @ApiPropertyOptional({ default: false })
   @IsOptional()
   @IsBoolean()
-  isCurrent?: boolean = false;
+  isCurrent?: boolean;
 
   @ApiProperty({ type: [String] })
   @IsArray()
@@ -60,7 +60,7 @@ export class CreateWorkDto {
   @ApiPropertyOptional({ default: false })
   @IsOptional()
   @IsBoolean()
-  featured?: boolean = false;
+  featured?: boolean;
 
   @ApiProperty({ type: [WorkTranslationDto] })
   @IsArray()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,10 @@
   "compilerOptions": {
     "module": "node16",
     "moduleResolution": "node16",
+    // node16 모듈 방식에서 ts-jest 가 요구한다(TS151002). 없으면 테스트 실행마다
+    // 파일 수만큼 경고가 뜬다(#117 로 moduleResolution 을 지정한 뒤 생겼다).
+    // 켜도 컴파일 에러 0건인 것을 확인했다: tsc --noEmit --isolatedModules
+    "isolatedModules": true,
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
`dev` → `main`.

## 담긴 것

| 이슈 | 내용 |
|---|---|
| #131 | PUT 부분 수정이 보내지 않은 필드를 초기화하던 것 |
| — | `isolatedModules` 로 ts-jest 경고 정리 (#117 부작용) |

## #131 — 실사용 버그다

제목만 고쳐도 **발행 글이 조용히 비공개**가 되고 태그가 지워졌다.

```
PUT /api/blog/posts/{slug}  body: {"title":"...","thumbnailUrl":"..."}
결과: published true -> false,  tags ["x"] -> []
```

그 뒤 상태가 헷갈린다 — API 는 404 인데 블로그 페이지는 **HTTP 200 에
본문만 "포스트를 찾을 수 없습니다"**. 어드민에서 저장했더니 "링크는 생기는데
404" 라던 증상이 이것이다.

원인은 `CreateXxxDto` 의 필드 기본값이 `PartialType` 상속 후에도 살아남는 것:
```
plainToInstance(UpdatePostDto, { title: "제목만 수정" })
-> {"published":false,"tags":[],"title":"제목만 수정"}
```

**전수 조사 결과 Update DTO 6개가 전부 같은 상태**였다. 포트폴리오는 항목
하나만 고쳐도 정렬 순서가 0 으로 리셋되고 `isCurrent`(재직중)·`featured`(대표작)
가 꺼진다 — 화면에 그대로 드러나는 값이다.

서비스는 잘못이 없다(`dto.sortOrder ?? 0` 로 이미 방어). DTO 기본값 12개만
걷어냈고 서비스는 손대지 않았다.

## 검증

```
npx jest        16 suites / 174 tests 통과 (신규 8건)
pnpm typecheck  통과
pnpm build      성공, 산출물 형태 유지 (await import / CJS)
CI              success (e89b116)
```

되돌리기 검증 — `published?: boolean = false` 를 되살리면 해당 2건만 FAIL,
나머지 6건은 통과. 명시적으로 보낸 `false`/`0` 이 보존되는지도 테스트에 넣었다.

## 배포 후 확인

어드민에서 글 제목만 수정 → `published`/태그가 유지되는지.