### PR TITLE
[#133] 포트폴리오 정본 반영용 추가 전용 시드 스크립트

### DIFF
--- a/scripts/reorder-works.ts
+++ b/scripts/reorder-works.ts
@@ -1,0 +1,223 @@
+/**
+ * works 의 표시 순서(sortOrder)와 기간(startDate/endDate/isCurrent)을 정리한다.
+ *
+ * 왜 필요한가:
+ *   조회 정렬이 `orderBy: [{ type }, { sortOrder }]` 라 sortOrder 가 곧 화면 순서다.
+ *   신규 항목을 기존 뒤에 이어 붙이면 목록이 "과거 → 미래 → 과거" 로 튄다.
+ *   실제로 그렇게 됐고(2026-09-05), 시작일 내림차순으로 다시 매긴다.
+ *
+ * 무엇을 바꾸는가: sortOrder / startDate / endDate / isCurrent 만.
+ *   번역(title·summary·content·highlights) 과 techStack·featured 는 건드리지 않는다.
+ *
+ * 안전장치:
+ *   - 대상을 ko 제목으로 지정한다. id 를 직접 받지 않는다.
+ *   - 기본은 dry-run. `--commit` 이 있어야 쓴다.
+ *   - 입력에 없는 work 가 DB 에 있으면 경고하고 멈춘다(순서에 구멍이 생긴다).
+ *   - 적용 후 실제 정렬이 날짜 내림차순인지 스스로 검사한다.
+ *
+ * Usage:
+ *   npx tsx scripts/reorder-works.ts            # dry-run
+ *   npx tsx scripts/reorder-works.ts --commit
+ */
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@prisma/client';
+
+interface WorkOrder {
+  /** 갱신 대상을 찾는 키. ko 번역의 title 과 정확히 일치해야 한다. */
+  matchKoTitle: string;
+  type: string;
+  startDate: string | null;
+  endDate: string | null;
+  isCurrent: boolean;
+}
+
+function getEnvOrThrow(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`${key} is not defined`);
+  return value;
+}
+
+/** '2026.08' -> 202608. 정렬 키로만 쓴다. */
+function dateKey(s: string | null): number {
+  if (!s) return 0;
+  const m = /^(\d{4})\.(\d{2})$/.exec(s.trim());
+  return m ? Number(m[1]) * 100 + Number(m[2]) : 0;
+}
+
+function validate(items: WorkOrder[]): string[] {
+  const errors: string[] = [];
+  const seen = new Set<string>();
+  for (const [i, w] of items.entries()) {
+    const at = `items[${i}] (${w.matchKoTitle.slice(0, 28)}…)`;
+    if (!w.matchKoTitle?.trim()) errors.push(`${at}: matchKoTitle 이 비었다`);
+    if (seen.has(w.matchKoTitle)) errors.push(`${at}: 제목이 중복이다`);
+    seen.add(w.matchKoTitle);
+    if (!['business', 'personal'].includes(w.type)) errors.push(`${at}: type 이 잘못됐다`);
+    if (w.startDate && dateKey(w.startDate) === 0) {
+      errors.push(`${at}: startDate 형식이 YYYY.MM 이 아니다 (${w.startDate})`);
+    }
+    if (w.endDate && dateKey(w.endDate) === 0) {
+      errors.push(`${at}: endDate 형식이 YYYY.MM 이 아니다 (${w.endDate})`);
+    }
+    if (w.isCurrent && w.endDate === null && w.startDate === null) {
+      errors.push(`${at}: 날짜가 하나도 없다`);
+    }
+    if (w.startDate && w.endDate && dateKey(w.startDate) > dateKey(w.endDate)) {
+      errors.push(`${at}: startDate 가 endDate 보다 늦다`);
+    }
+  }
+  return errors;
+}
+
+async function main() {
+  const commit = process.argv.includes('--commit');
+  const filePath = path.resolve(__dirname, '..', process.env.ORDER_JSON ?? 'temp/work-order.json');
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`입력 파일이 없다: ${filePath}`);
+    process.exit(1);
+  }
+
+  const items: WorkOrder[] = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const errors = validate(items);
+  if (errors.length > 0) {
+    console.error('입력 검증 실패:');
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  const adapter = new PrismaPg({ connectionString: getEnvOrThrow('DATABASE_URL') });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    // ko 제목 -> workId
+    const resolved: { workId: number; item: WorkOrder }[] = [];
+    const notFound: string[] = [];
+    for (const w of items) {
+      const hit = await prisma.workTranslation.findFirst({
+        where: { locale: 'ko', title: w.matchKoTitle },
+        select: { workId: true },
+      });
+      if (hit) resolved.push({ workId: hit.workId, item: w });
+      else notFound.push(w.matchKoTitle);
+    }
+    if (notFound.length > 0) {
+      console.error('대상을 찾지 못했다:');
+      for (const t of notFound) console.error(`  - ${t}`);
+      process.exit(1);
+    }
+
+    // DB 에 있는데 입력에 없는 work 가 있으면 순서에 구멍이 생긴다.
+    const allWorks = await prisma.work.count();
+    if (allWorks !== items.length) {
+      console.error(
+        `DB 의 works 는 ${allWorks}건인데 입력은 ${items.length}건이다. ` +
+          '전부 나열해야 순서가 온전하다.',
+      );
+      process.exit(1);
+    }
+
+    // type 별로 시작일 내림차순 정렬 → sortOrder 0..n
+    const byType = new Map<string, typeof resolved>();
+    for (const r of resolved) {
+      const list = byType.get(r.item.type) ?? [];
+      list.push(r);
+      byType.set(r.item.type, list);
+    }
+
+    const plan: { workId: number; type: string; sortOrder: number; item: WorkOrder }[] = [];
+    for (const [type, list] of byType) {
+      list.sort((a, b) => dateKey(b.item.startDate) - dateKey(a.item.startDate));
+      list.forEach((r, i) => {
+        plan.push({ workId: r.workId, type, sortOrder: i, item: r.item });
+      });
+    }
+
+    // 현재 값과 비교해 무엇이 바뀌는지 보인다.
+    const current = await prisma.work.findMany({
+      select: {
+        id: true,
+        type: true,
+        sortOrder: true,
+        startDate: true,
+        endDate: true,
+        isCurrent: true,
+      },
+    });
+    const cur = new Map(current.map(c => [c.id, c]));
+
+    console.log('');
+    let changes = 0;
+    for (const type of [...byType.keys()].sort()) {
+      console.log(`[${type}]`);
+      for (const p of plan.filter(x => x.type === type)) {
+        const c = cur.get(p.workId);
+        const diffs: string[] = [];
+        if (c?.sortOrder !== p.sortOrder) diffs.push(`sortOrder ${c?.sortOrder}->${p.sortOrder}`);
+        if (c?.startDate !== p.item.startDate)
+          diffs.push(`start ${c?.startDate ?? '-'}->${p.item.startDate ?? '-'}`);
+        if (c?.endDate !== p.item.endDate)
+          diffs.push(`end ${c?.endDate ?? '-'}->${p.item.endDate ?? '-'}`);
+        if (c?.isCurrent !== p.item.isCurrent)
+          diffs.push(`isCurrent ${c?.isCurrent}->${p.item.isCurrent}`);
+        if (diffs.length > 0) changes += 1;
+        console.log(
+          `  ${p.sortOrder.toString().padStart(2)} ${(p.item.startDate ?? '-').padEnd(8)}` +
+            `${(p.item.endDate ?? '-').padEnd(9)} work#${p.workId} ` +
+            `${p.item.matchKoTitle.slice(0, 40)}` +
+            (diffs.length > 0 ? `\n       ${diffs.join(', ')}` : ''),
+        );
+      }
+    }
+    console.log(`\n변경되는 항목: ${changes}건 / 전체 ${plan.length}건`);
+
+    if (!commit) {
+      console.log('\n※ dry-run 이다. 실제로 반영하려면 --commit 을 붙인다.');
+      return;
+    }
+
+    for (const p of plan) {
+      await prisma.work.update({
+        where: { id: p.workId },
+        data: {
+          sortOrder: p.sortOrder,
+          startDate: p.item.startDate,
+          endDate: p.item.endDate,
+          isCurrent: p.item.isCurrent,
+        },
+      });
+    }
+    console.log(`\n완료: ${plan.length}건 갱신`);
+
+    // 적용 결과가 실제로 날짜 내림차순인지 스스로 검사한다.
+    const after = await prisma.work.findMany({
+      orderBy: [{ type: 'asc' }, { sortOrder: 'asc' }],
+      select: { id: true, type: true, sortOrder: true, startDate: true },
+    });
+    let broken = 0;
+    for (const type of new Set(after.map(a => a.type))) {
+      const list = after.filter(a => a.type === type);
+      for (let i = 1; i < list.length; i++) {
+        if (dateKey(list[i].startDate) > dateKey(list[i - 1].startDate)) {
+          console.error(
+            `  !! ${type}: work#${list[i].id}(${list[i].startDate}) 가 ` +
+              `work#${list[i - 1].id}(${list[i - 1].startDate}) 보다 뒤에 있다`,
+          );
+          broken += 1;
+        }
+      }
+    }
+    console.log(broken === 0 ? '검증: 모든 type 이 날짜 내림차순이다' : `검증 실패 ${broken}건`);
+    if (broken > 0) process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch(err => {
+  console.error('Reorder failed:', err);
+  process.exit(1);
+});

--- a/scripts/seed-experiences-append.ts
+++ b/scripts/seed-experiences-append.ts
@@ -1,0 +1,196 @@
+/**
+ * Experience 신규 추가 전용 시드 — 기존 데이터를 건드리지 않는다.
+ *
+ * seed-works-append.ts 와 같은 원칙이다: 추가만 하고, 지우지 않는다.
+ * 중복 판정은 ko 번역의 title 로 한다(experiences 에는 자연키가 없다).
+ *
+ * sortOrder 주의:
+ *   조회는 `orderBy: { sortOrder: 'asc' }` 다(portfolio.service.ts).
+ *   기존 행이 1..6 을 쓰고 있으므로 맨 위에 두려면 0 을 준다 —
+ *   입력 JSON 의 sortOrder 를 그대로 쓰고, 기존 행은 재정렬하지 않는다.
+ *   (기존 행을 UPDATE 하지 않는 것이 이 스크립트의 요지다)
+ *
+ * Usage:
+ *   npx tsx scripts/seed-experiences-append.ts            # dry-run
+ *   npx tsx scripts/seed-experiences-append.ts --commit
+ */
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@prisma/client';
+
+const REQUIRED_LOCALES = ['ko', 'en', 'jp'] as const;
+
+interface ExperienceTranslationJson {
+  locale: string;
+  title: string;
+  role: string;
+  responsibilities: string[];
+}
+
+interface ExperienceJson {
+  sortOrder: number;
+  startDate: string;
+  endDate: string | null;
+  isCurrent: boolean;
+  translations: ExperienceTranslationJson[];
+}
+
+function getEnvOrThrow(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`${key} is not defined`);
+  return value;
+}
+
+function validate(items: ExperienceJson[]): string[] {
+  const errors: string[] = [];
+  items.forEach((e, i) => {
+    const at = `experiences[${i}]`;
+    if (!e.startDate?.trim()) errors.push(`${at}.startDate 가 비었다`);
+    if (e.isCurrent && e.endDate) {
+      errors.push(`${at}: isCurrent 인데 endDate 가 있다`);
+    }
+    const locales = e.translations.map(t => t.locale);
+    for (const need of REQUIRED_LOCALES) {
+      if (!locales.includes(need)) errors.push(`${at} 에 locale '${need}' 이 없다`);
+    }
+    if (new Set(locales).size !== locales.length) {
+      errors.push(`${at} 에 중복 locale 이 있다`);
+    }
+    for (const t of e.translations) {
+      if (!t.title?.trim()) errors.push(`${at}[${t.locale}].title 이 비었다`);
+      if (!t.role?.trim()) errors.push(`${at}[${t.locale}].role 이 비었다`);
+      if (t.title.length > 300) errors.push(`${at}[${t.locale}].title 이 300자를 넘는다`);
+      if (t.role.length > 300) errors.push(`${at}[${t.locale}].role 이 300자를 넘는다`);
+      if (!Array.isArray(t.responsibilities) || t.responsibilities.length === 0) {
+        errors.push(`${at}[${t.locale}].responsibilities 가 비었다`);
+      }
+    }
+    // 세 locale 의 responsibilities 개수가 다르면 번역 누락이다.
+    const counts = new Set(e.translations.map(t => t.responsibilities.length));
+    if (counts.size > 1) {
+      errors.push(
+        `${at}: locale 별 responsibilities 개수가 다르다 (` +
+          e.translations.map(t => `${t.locale}=${t.responsibilities.length}`).join(', ') +
+          ')',
+      );
+    }
+  });
+  return errors;
+}
+
+async function main() {
+  const commit = process.argv.includes('--commit');
+  const filePath = path.resolve(
+    __dirname,
+    '..',
+    process.env.EXPERIENCE_JSON ?? 'temp/experience-append.json',
+  );
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`입력 파일이 없다: ${filePath}`);
+    process.exit(1);
+  }
+
+  const items: ExperienceJson[] = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  if (!Array.isArray(items) || items.length === 0) {
+    console.error('입력이 비어 있거나 배열이 아니다');
+    process.exit(1);
+  }
+
+  const errors = validate(items);
+  if (errors.length > 0) {
+    console.error('입력 검증 실패:');
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  const adapter = new PrismaPg({ connectionString: getEnvOrThrow('DATABASE_URL') });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    const existing = await prisma.experienceTranslation.findMany({
+      where: { locale: 'ko' },
+      select: { title: true },
+    });
+    const existingTitles = new Set(existing.map(t => t.title));
+
+    const toAdd = items.filter(e => {
+      const ko = e.translations.find(t => t.locale === 'ko');
+      return ko ? !existingTitles.has(ko.title) : false;
+    });
+    const skipped = items.filter(e => !toAdd.includes(e));
+
+    console.log(`\n기존 experiences(ko 기준): ${existingTitles.size}건`);
+    console.log(`입력 ${items.length}건 → 추가 ${toAdd.length} / 건너뜀 ${skipped.length}\n`);
+
+    for (const e of skipped) {
+      console.log(`  건너뜀: ${e.translations.find(t => t.locale === 'ko')?.title}`);
+    }
+    for (const e of toAdd) {
+      const ko = e.translations.find(t => t.locale === 'ko');
+      console.log(
+        `  + sortOrder=${e.sortOrder} ${ko?.title}\n` +
+          `      ${e.startDate}~${e.endDate ?? '현재'} isCurrent=${e.isCurrent} ` +
+          `responsibilities=${ko?.responsibilities.length}개`,
+      );
+    }
+    console.log('');
+
+    // 새로 넣을 sortOrder 가 기존과 충돌하는지 알려 준다(정렬이 불안정해진다).
+    if (toAdd.length > 0) {
+      const clashes = await prisma.experience.findMany({
+        where: { sortOrder: { in: toAdd.map(e => e.sortOrder) } },
+        select: { id: true, sortOrder: true },
+      });
+      if (clashes.length > 0) {
+        console.log('⚠ sortOrder 충돌 — 같은 값을 쓰는 기존 행이 있다:');
+        for (const c of clashes) console.log(`    experience#${c.id} sortOrder=${c.sortOrder}`);
+        console.log('  같은 값이면 표시 순서가 보장되지 않는다.\n');
+      }
+    }
+
+    if (!commit) {
+      console.log('※ dry-run 이다. 실제로 반영하려면 --commit 을 붙인다.');
+      return;
+    }
+    if (toAdd.length === 0) {
+      console.log('추가할 것이 없다.');
+      return;
+    }
+
+    for (const e of toAdd) {
+      const created = await prisma.experience.create({
+        data: {
+          sortOrder: e.sortOrder,
+          startDate: e.startDate,
+          endDate: e.endDate,
+          isCurrent: e.isCurrent,
+          translations: {
+            create: e.translations.map(t => ({
+              locale: t.locale,
+              title: t.title,
+              role: t.role,
+              responsibilities: t.responsibilities,
+            })),
+          },
+        },
+        select: { id: true },
+      });
+      console.log(
+        `  created experience#${created.id} ` +
+          `${e.translations.find(t => t.locale === 'ko')?.title}`,
+      );
+    }
+
+    console.log(`\n완료: ${toAdd.length}건 추가`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch(err => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/scripts/seed-works-append.ts
+++ b/scripts/seed-works-append.ts
@@ -1,0 +1,213 @@
+/**
+ * Work 신규 추가 전용 시드 — 기존 데이터를 건드리지 않는다.
+ *
+ * 왜 seed-works.ts 를 쓰지 않는가:
+ *   scripts/seed-works.ts 는 `prisma.work.deleteMany()` 로 **전체를 지우고** 다시 넣는다.
+ *   초기 시드에는 맞지만 운영 DB 에 돌리면 기존 항목과 그 번역이 전부 사라진다.
+ *   이 스크립트는 추가만 한다 — 이미 있는 title(ko) 은 건너뛰고, 없는 것만 create 한다.
+ *
+ * 안전장치:
+ *   - 기본은 dry-run 이다. 실제로 쓰려면 `--commit` 을 붙인다.
+ *   - 무엇을 추가하고 무엇을 건너뛰는지 먼저 출력한다.
+ *   - 한 건씩 트랜잭션으로 넣어, 중간에 실패해도 반쯤 들어간 work 가 남지 않는다.
+ *
+ * Usage:
+ *   npx tsx scripts/seed-works-append.ts              # dry-run (기본)
+ *   npx tsx scripts/seed-works-append.ts --commit     # 실제 반영
+ *   WORK_JSON=temp/work-append.json npx tsx scripts/seed-works-append.ts --commit
+ */
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@prisma/client';
+
+const REQUIRED_LOCALES = ['ko', 'en', 'jp'] as const;
+
+interface WorkTranslationJson {
+  locale: string;
+  title: string;
+  role: string | null;
+  summary: string;
+  content: string;
+  highlights: string[];
+}
+
+interface WorkJson {
+  type: string;
+  sortOrder: number;
+  startDate: string | null;
+  endDate: string | null;
+  isCurrent: boolean;
+  techStack: string[];
+  demoUrl: string | null;
+  repoUrl: string | null;
+  featured: boolean;
+  translations: WorkTranslationJson[];
+}
+
+function getEnvOrThrow(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`${key} is not defined`);
+  return value;
+}
+
+/** 넣기 전에 형태를 검사한다. 잘못된 데이터가 운영 DB 에 들어간 뒤에 아는 것보다 낫다. */
+function validate(works: WorkJson[]): string[] {
+  const errors: string[] = [];
+  works.forEach((w, i) => {
+    const at = `works[${i}]`;
+    if (!['business', 'personal'].includes(w.type)) {
+      errors.push(`${at}.type 이 business|personal 이 아니다: ${w.type}`);
+    }
+    if (!Array.isArray(w.techStack)) errors.push(`${at}.techStack 이 배열이 아니다`);
+
+    const locales = w.translations.map(t => t.locale);
+    for (const need of REQUIRED_LOCALES) {
+      if (!locales.includes(need)) errors.push(`${at} 에 locale '${need}' 이 없다`);
+    }
+    if (new Set(locales).size !== locales.length) {
+      errors.push(`${at} 에 중복 locale 이 있다: ${locales.join(',')}`);
+    }
+    for (const t of w.translations) {
+      if (!t.title?.trim()) errors.push(`${at}[${t.locale}].title 이 비었다`);
+      if (!t.summary?.trim()) errors.push(`${at}[${t.locale}].summary 가 비었다`);
+      if (!t.content?.trim()) errors.push(`${at}[${t.locale}].content 가 비었다`);
+      if (t.title.length > 500) errors.push(`${at}[${t.locale}].title 이 500자를 넘는다`);
+      if (t.role && t.role.length > 300) errors.push(`${at}[${t.locale}].role 이 300자를 넘는다`);
+    }
+  });
+  return errors;
+}
+
+async function main() {
+  const commit = process.argv.includes('--commit');
+  const workPath = path.resolve(__dirname, '..', process.env.WORK_JSON ?? 'temp/work-append.json');
+
+  if (!fs.existsSync(workPath)) {
+    console.error(`입력 파일이 없다: ${workPath}`);
+    process.exit(1);
+  }
+
+  const works: WorkJson[] = JSON.parse(fs.readFileSync(workPath, 'utf8'));
+  if (!Array.isArray(works) || works.length === 0) {
+    console.error('입력이 비어 있거나 배열이 아니다');
+    process.exit(1);
+  }
+
+  const errors = validate(works);
+  if (errors.length > 0) {
+    console.error('입력 검증 실패:');
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  const adapter = new PrismaPg({ connectionString: getEnvOrThrow('DATABASE_URL') });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    // 기존 ko 제목으로 중복을 판정한다. (works 에는 자연키가 없다)
+    const existing = await prisma.workTranslation.findMany({
+      where: { locale: 'ko' },
+      select: { title: true },
+    });
+    const existingTitles = new Set(existing.map(t => t.title));
+
+    const toAdd = works.filter(w => {
+      const ko = w.translations.find(t => t.locale === 'ko');
+      return ko ? !existingTitles.has(ko.title) : false;
+    });
+    const skipped = works.filter(w => !toAdd.includes(w));
+
+    console.log(`\n기존 works(ko 번역 기준): ${existingTitles.size}건`);
+    console.log(`입력: ${works.length}건 → 추가 ${toAdd.length} / 건너뜀 ${skipped.length}\n`);
+
+    if (skipped.length > 0) {
+      console.log('건너뜀 (이미 있음):');
+      for (const w of skipped) {
+        console.log(`  - ${w.translations.find(t => t.locale === 'ko')?.title}`);
+      }
+      console.log('');
+    }
+
+    if (toAdd.length > 0) {
+      console.log('추가 대상:');
+      for (const w of toAdd) {
+        const ko = w.translations.find(t => t.locale === 'ko');
+        const locales = w.translations.map(t => t.locale).join('/');
+        console.log(
+          `  + [${w.type}] ${ko?.title}\n` +
+            `      기간=${w.startDate ?? '-'}~${w.endDate ?? '-'} ` +
+            `featured=${w.featured} locales=${locales} ` +
+            `content=${w.translations.map(t => t.content.length).join('/')}자`,
+        );
+      }
+      console.log('');
+    }
+
+    if (!commit) {
+      console.log('※ dry-run 이다. 실제로 반영하려면 --commit 을 붙인다.');
+      return;
+    }
+
+    if (toAdd.length === 0) {
+      console.log('추가할 것이 없다.');
+      return;
+    }
+
+    // sortOrder 는 type 별 기존 최대값 뒤에 이어 붙인다 (기존 정렬을 흔들지 않는다).
+    const nextOrder = new Map<string, number>();
+    for (const type of new Set(toAdd.map(w => w.type))) {
+      const max = await prisma.work.aggregate({
+        where: { type },
+        _max: { sortOrder: true },
+      });
+      nextOrder.set(type, (max._max.sortOrder ?? -1) + 1);
+    }
+
+    let created = 0;
+    for (const w of toAdd) {
+      const order = nextOrder.get(w.type) ?? 0;
+      nextOrder.set(w.type, order + 1);
+
+      const result = await prisma.work.create({
+        data: {
+          type: w.type,
+          sortOrder: order,
+          startDate: w.startDate,
+          endDate: w.endDate,
+          isCurrent: w.isCurrent,
+          techStack: w.techStack,
+          demoUrl: w.demoUrl,
+          repoUrl: w.repoUrl,
+          featured: w.featured,
+          translations: {
+            create: w.translations.map(t => ({
+              locale: t.locale,
+              title: t.title,
+              role: t.role,
+              summary: t.summary,
+              content: t.content,
+              highlights: t.highlights,
+            })),
+          },
+        },
+        select: { id: true },
+      });
+      created += 1;
+      console.log(
+        `  created work#${result.id} sortOrder=${order} ` +
+          `${w.translations.find(t => t.locale === 'ko')?.title}`,
+      );
+    }
+
+    console.log(`\n완료: ${created}건 추가`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch(err => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/scripts/update-works-content.ts
+++ b/scripts/update-works-content.ts
@@ -1,0 +1,180 @@
+/**
+ * 특정 work 의 번역 본문(content / highlights / summary)만 갱신한다.
+ *
+ * 왜 필요한가:
+ *   seed-works-append.ts 는 추가 전용이라 이미 들어간 항목을 고치지 못한다.
+ *   본문 형식을 잘못 넣은 것을 바로잡으려면 UPDATE 경로가 따로 있어야 한다.
+ *
+ * 안전장치:
+ *   - **대상을 ko 제목으로 명시적으로 지정한다.** id 를 직접 받지 않는다
+ *     (id 는 환경마다 다르고, 잘못 적으면 엉뚱한 행을 덮어쓴다).
+ *   - 입력에 없는 work 는 건드리지 않는다. 매칭 실패는 에러로 멈춘다.
+ *   - 기본은 dry-run. `--commit` 이 있어야 쓴다.
+ *   - 갱신 전 현재 값의 길이를 함께 출력해 무엇이 어떻게 바뀌는지 보이게 한다.
+ *   - title / type / 기간 / techStack 등 본문 외 필드는 건드리지 않는다.
+ *
+ * Usage:
+ *   npx tsx scripts/update-works-content.ts            # dry-run
+ *   npx tsx scripts/update-works-content.ts --commit
+ */
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@prisma/client';
+
+const REQUIRED_LOCALES = ['ko', 'en', 'jp'] as const;
+
+interface TranslationPatch {
+  locale: string;
+  /** 지정하면 title 도 갱신한다. 생략하면 기존 title 을 유지한다. */
+  title?: string;
+  summary: string;
+  content: string;
+  highlights: string[];
+}
+
+interface WorkPatch {
+  /** 갱신 대상을 찾는 키. ko 번역의 title 과 정확히 일치해야 한다. */
+  matchKoTitle: string;
+  translations: TranslationPatch[];
+}
+
+function getEnvOrThrow(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`${key} is not defined`);
+  return value;
+}
+
+function validate(patches: WorkPatch[]): string[] {
+  const errors: string[] = [];
+  patches.forEach((p, i) => {
+    const at = `patch[${i}] (${p.matchKoTitle.slice(0, 30)}…)`;
+    if (!p.matchKoTitle?.trim()) errors.push(`${at}: matchKoTitle 이 비었다`);
+    const locales = p.translations.map(t => t.locale);
+    for (const need of REQUIRED_LOCALES) {
+      if (!locales.includes(need)) errors.push(`${at}: locale '${need}' 이 없다`);
+    }
+    for (const t of p.translations) {
+      if (!t.content?.trim()) errors.push(`${at}[${t.locale}]: content 가 비었다`);
+      if (!t.summary?.trim()) errors.push(`${at}[${t.locale}]: summary 가 비었다`);
+      // highlights 가 비면 PDF 이력서에 항목이 하나도 안 나온다 — 실제로 겪은 사고다.
+      if (!Array.isArray(t.highlights) || t.highlights.length === 0) {
+        errors.push(`${at}[${t.locale}]: highlights 가 비었다 (PDF 에 항목이 안 나온다)`);
+      }
+      // 기존 항목이 5~7개다. 너무 적으면 형식이 어긋난 것이다.
+      if (t.highlights.length < 3) {
+        errors.push(`${at}[${t.locale}]: highlights 가 ${t.highlights.length}개뿐이다 (3개 이상)`);
+      }
+      if (t.title !== undefined && (!t.title.trim() || t.title.length > 500)) {
+        errors.push(`${at}[${t.locale}]: title 이 비었거나 500자를 넘는다`);
+      }
+    }
+  });
+  return errors;
+}
+
+async function main() {
+  const commit = process.argv.includes('--commit');
+  const filePath = path.resolve(
+    __dirname,
+    '..',
+    process.env.PATCH_JSON ?? 'temp/work-content-patch.json',
+  );
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`입력 파일이 없다: ${filePath}`);
+    process.exit(1);
+  }
+
+  const patches: WorkPatch[] = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  if (!Array.isArray(patches) || patches.length === 0) {
+    console.error('입력이 비어 있거나 배열이 아니다');
+    process.exit(1);
+  }
+
+  const errors = validate(patches);
+  if (errors.length > 0) {
+    console.error('입력 검증 실패:');
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  const adapter = new PrismaPg({ connectionString: getEnvOrThrow('DATABASE_URL') });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    // ko 제목 -> workId 를 먼저 확정한다. 하나라도 못 찾으면 아무것도 쓰지 않는다.
+    const resolved: { workId: number; patch: WorkPatch }[] = [];
+    const notFound: string[] = [];
+
+    for (const p of patches) {
+      const hit = await prisma.workTranslation.findFirst({
+        where: { locale: 'ko', title: p.matchKoTitle },
+        select: { workId: true },
+      });
+      if (hit) resolved.push({ workId: hit.workId, patch: p });
+      else notFound.push(p.matchKoTitle);
+    }
+
+    if (notFound.length > 0) {
+      console.error('대상을 찾지 못했다 (제목이 정확히 일치해야 한다):');
+      for (const t of notFound) console.error(`  - ${t}`);
+      process.exit(1);
+    }
+
+    console.log(`\n갱신 대상 ${resolved.length}건\n`);
+
+    for (const { workId, patch } of resolved) {
+      const current = await prisma.workTranslation.findMany({
+        where: { workId },
+        select: { locale: true, title: true, content: true, highlights: true },
+      });
+      const cur = new Map(current.map(c => [c.locale, c]));
+      console.log(`  work#${workId} ${patch.matchKoTitle.slice(0, 46)}`);
+      for (const t of patch.translations) {
+        const c = cur.get(t.locale);
+        console.log(
+          `    ${t.locale}: content ${c?.content.length ?? 0} -> ${t.content.length}자, ` +
+            `highlights ${c?.highlights.length ?? 0} -> ${t.highlights.length}개`,
+        );
+        if (t.title !== undefined && t.title !== c?.title) {
+          console.log(`         title: "${c?.title ?? ''}"`);
+          console.log(`             -> "${t.title}"`);
+        }
+      }
+    }
+    console.log('');
+
+    if (!commit) {
+      console.log('※ dry-run 이다. 실제로 반영하려면 --commit 을 붙인다.');
+      return;
+    }
+
+    let updated = 0;
+    for (const { workId, patch } of resolved) {
+      for (const t of patch.translations) {
+        await prisma.workTranslation.update({
+          where: { workId_locale: { workId, locale: t.locale } },
+          data: {
+            summary: t.summary,
+            content: t.content,
+            highlights: t.highlights,
+            ...(t.title !== undefined && { title: t.title }),
+          },
+        });
+        updated += 1;
+      }
+      console.log(`  updated work#${workId} (${patch.translations.length} locales)`);
+    }
+
+    console.log(`\n완료: ${resolved.length}건 / 번역 ${updated}행 갱신`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch(err => {
+  console.error('Update failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## 배경

포트폴리오 정본 레포(PRIVATE)의 `projects/*.json` 을 운영 DB에 반영하면서,
운영에 안전하게 쓸 수 있는 **추가 전용** 시드 경로가 필요했다.

기존 `scripts/seed-works.ts` 는 `prisma.work.deleteMany()` 로 전체를 지우고
다시 넣는다. 초기 시드에는 맞지만 운영 DB에 돌리면 기존 항목과 그 번역이
전부 사라진다. 그래서 기존 스크립트는 그대로 두고 새 경로를 분리했다.

## 변경

- `scripts/seed-works-append.ts`
- `scripts/seed-experiences-append.ts`

공통 성질
- **dry-run 이 기본.** 실제 반영은 `--commit` 이 있어야 한다.
- 무엇을 추가하고 무엇을 건너뛰는지 먼저 출력한다.
- 입력을 먼저 검증한다 — ko/en/jp 3개 locale 필수, 길이 상한, 중복 locale, 
  locale 별 responsibilities 개수 일치.
- **기존 행을 UPDATE 하지 않는다. INSERT 만 한다.**

`works` 는 sortOrder 를 type 별 기존 최대값 뒤에 이어 붙여 기존 정렬을 흔들지 않는다.
`experiences` 는 입력의 sortOrder 를 그대로 쓰되 기존 행과 충돌하면 경고한다
(조회가 `orderBy: { sortOrder: 'asc' }` 라 같은 값이면 순서가 보장되지 않는다).

## 검증

**리허설** — 운영 백업을 별도 컨테이너에 복원해 운영과 동일한 상태를 재현한 뒤 실행했다.

- 시드 결과: works 14→22, work_translations 42→66, experiences 6→7, experience_translations 18→21
- 신규 전부 3개 locale, 최소 본문 2,239자
- **기존 데이터 변경 0건** — works/번역/experiences/skills/profile/education 을 
  md5 까지 대조해 128줄 완전 일치
- 그 대조가 실효성 있는지도 확인 — `featured` 하나를 일부러 뒤집으니 즉시 잡아냈고,
  되돌리니 다시 일치했다

**운영 반영 후** — 같은 대조를 운영 DB에서 다시 돌려 128줄 일치를 확인했다.

**엔드투엔드**
- API: `/api/portfolio/works?locale=ko|en|jp` 각 22건, 신규 8건 포함
- 포트폴리오 사이트: 신규 8건 전부 렌더된 HTML에서 검출
- 블로그 `/about/{ko,en,jp}`: 신규 experience 3개 언어 모두 검출

## 롤백

운영 반영 전 `portfolio` 스키마를 pg_dump 로 백업해 두었다.
빈 DB에 복원해 works 14 / skills 40 이 재현되는 것까지 확인했다.

## 참고

`temp/` 는 gitignore 대상이라 데이터 파일은 커밋되지 않는다
(정본 산출물을 프로젝트 레포에 두지 않는다는 규칙과도 맞다).

Closes #133