### PR TITLE
[#136] 블로그 무인 발행용 머신 인증 경로를 추가한다

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,12 @@ R2_PUBLIC_URL=https://assets.chahyunwoo.dev
 # API Key - generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 API_KEY=your_api_key_here
 
+# 블로그 무인 발행용 머신 키. 위 API_KEY(공개 조회용)와 **다른 값**을 쓴다 —
+# 조회 키는 프런트가 들고 다니므로 새어도 발행까지 뚫리면 안 된다.
+# 비우면 머신 경로가 꺼진다(JWT 로만 발행 가능).
+# generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+BLOG_MACHINE_KEY=
+
 # Revalidation
 BLOG_REVALIDATE_URL=https://chahyunwoo.dev
 PORTFOLIO_REVALIDATE_URL=https://portfolio.chahyunwoo.dev

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ PORTFOLIO_REVALIDATE_URL=https://portfolio.chahyunwoo.dev
 REVALIDATE_SECRET=your_revalidate_secret_here
 
 # Admin IP Whitelist (comma-separated, empty = allow all)
+# ⚠️ 채울 때는 무인 발행 파이프라인의 출구 IP 도 함께 넣어야 한다.
+# AdminIpGuard 는 @Public() 이 아닌 모든 라우트에 걸리므로, 머신 키가 맞아도
+# 이 목록에 없는 IP 는 403 으로 막힌다(키 검증은 JwtAuthGuard, IP 검사는 그
+# 뒤의 AdminIpGuard 라 서로를 모른다). 비어 있으면 제한하지 않는다.
 ADMIN_IP_WHITELIST=
 
 # Mail (Gmail SMTP — use App Password, not account password)

--- a/openapi.json
+++ b/openapi.json
@@ -1308,6 +1308,9 @@
         },
         "security": [
           {
+            "machine-key": []
+          },
+          {
             "cookie": []
           },
           {
@@ -2054,6 +2057,9 @@
           }
         },
         "security": [
+          {
+            "machine-key": []
+          },
           {
             "cookie": []
           },
@@ -5164,6 +5170,11 @@
         "type": "apiKey",
         "in": "header",
         "name": "x-api-key"
+      },
+      "machine-key": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-machine-key"
       }
     },
     "schemas": {

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -24,6 +24,7 @@ import {
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { AuthService } from '../auth/auth.service';
+import { MachineKey } from '../common/decorators/machine-key.decorator';
 import { Public } from '../common/decorators/public.decorator';
 import {
   ApiBadRequest,
@@ -173,8 +174,14 @@ export class BlogController {
     return this.blogService.getRelatedPosts(slug);
   }
 
+  // 무인 발행: 파이프라인 스케줄러가 x-machine-key 로 부른다.
+  // 어드민 JWT 경로도 그대로 열려 있다 — 인증 수단이 하나 늘어난 것이다.
+  // 3주에 1회 도는 작업이라 스로틀을 아주 낮게 잡아도 충분하다.
   @ApiBearerAuth()
   @ApiCookieAuth()
+  @ApiSecurity('machine-key')
+  @MachineKey()
+  @Throttle({ default: { ttl: 3_600_000, limit: 10 } })
   @Post('posts')
   @ApiCreatedResponse({ type: PostDetailDto })
   @HttpCode(HttpStatus.CREATED)
@@ -206,8 +213,13 @@ export class BlogController {
     return this.blogService.remove(slug);
   }
 
+  // 무인 발행: 썸네일·본문 이미지를 올린다. 파이프라인은 R2 자격증명을
+  // 갖지 않고 이 엔드포인트를 통한다.
   @ApiBearerAuth()
   @ApiCookieAuth()
+  @ApiSecurity('machine-key')
+  @MachineKey()
+  @Throttle({ default: { ttl: 3_600_000, limit: 40 } })
   @Post('images')
   @ApiCreatedResponse({ type: UploadImageResponseDto })
   @ApiConsumes('multipart/form-data')

--- a/src/common/decorators/machine-key.decorator.ts
+++ b/src/common/decorators/machine-key.decorator.ts
@@ -1,0 +1,17 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * 머신(스케줄러)이 사람 로그인 없이 호출할 수 있는 라우트.
+ *
+ * 포트폴리오 파이프라인이 블로그 글을 무인 발행한다. JWT 는 로그인 + 2FA 로
+ * 발급되므로 스케줄러가 쓸 수 없어, 이 라우트들만 전용 키(`x-machine-key`)를
+ * 받는다.
+ *
+ * ⚠️ 공개 조회용 `API_KEY` 와 **다른 키**(`BLOG_MACHINE_KEY`)를 쓴다.
+ * 조회 키는 프런트가 들고 다니므로 새어도 발행까지 뚫리면 안 된다.
+ *
+ * 어드민 JWT 경로는 그대로 열려 있다 — 이 데코레이터는 인증 수단을
+ * 하나 **더** 허용할 뿐이고, 아무 인증 없이 통과시키지 않는다.
+ */
+export const MACHINE_KEY = 'machineKey';
+export const MachineKey = () => SetMetadata(MACHINE_KEY, true);

--- a/src/common/guards/api-key.guard.ts
+++ b/src/common/guards/api-key.guard.ts
@@ -40,6 +40,20 @@ export class ApiKeyGuard implements CanActivate {
     return true;
   }
 
+  /**
+   * 머신 키가 유효한가. 헤더가 없거나 틀리면 false 를 돌려준다 —
+   * 여기서 던지지 않는 이유는 JWT 라는 다른 인증 수단이 남아 있기 때문이다.
+   * 실제 401 은 두 수단이 모두 실패했을 때 JwtAuthGuard 가 던진다.
+   */
+  static hasValidMachineKey(request: FastifyRequest, expected: string): boolean {
+    const provided = request.headers['x-machine-key'];
+    if (!expected || typeof provided !== 'string') return false;
+    // 길이 비교는 바이트 기준이어야 한다(아래 validateApiKey 주석 참고).
+    const a = Buffer.from(provided, 'utf8');
+    const b = Buffer.from(expected, 'utf8');
+    return a.length === b.length && timingSafeEqual(a, b);
+  }
+
   private validateApiKey(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<FastifyRequest>();
     const apiKey = request.headers['x-api-key'];

--- a/src/common/guards/jwt-auth.guard.spec.ts
+++ b/src/common/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,95 @@
+import type { ExecutionContext } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import type { Reflector } from '@nestjs/core';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+const MACHINE_KEY_VALUE = 'm'.repeat(64);
+const OTHER_KEY = 'x'.repeat(64);
+
+/**
+ * 무인 발행용 머신 키 경로를 검사한다.
+ *
+ * 이 가드는 **인증 수단을 하나 더 허용**할 뿐이므로, 다음 둘을 다 봐야 한다.
+ *   ① 유효한 머신 키는 JWT 없이 통과한다 (그래야 스케줄러가 돈다)
+ *   ② 그 외 모든 경우는 JWT 검사로 떨어진다 (통과시켜 버리면 인증이 뚫린다)
+ *
+ * ②를 확인하려고 super.canActivate 를 가로채 '떨어졌다'를 관측한다 —
+ * true/false 반환만 보면 "머신 키로 통과"와 "JWT 로 통과"가 구별되지 않는다.
+ */
+describe('JwtAuthGuard 머신 키', () => {
+  function makeContext(headers: Record<string, unknown>): ExecutionContext {
+    return {
+      getHandler: () => () => undefined,
+      getClass: () => class {},
+      switchToHttp: () => ({ getRequest: () => ({ headers }) }),
+    } as unknown as ExecutionContext;
+  }
+
+  /** @returns [가드, JWT 검사로 떨어졌는지 알려주는 함수] */
+  function makeGuard(opts: { isPublic?: boolean; isMachine?: boolean; configured?: boolean }) {
+    const reflector = {
+      getAllAndOverride: jest.fn((key: string) =>
+        key === 'isPublic' ? !!opts.isPublic : !!opts.isMachine,
+      ),
+    } as unknown as Reflector;
+    const config = {
+      get: jest.fn(() => (opts.configured === false ? '' : MACHINE_KEY_VALUE)),
+    } as unknown as ConfigService;
+
+    const guard = new JwtAuthGuard(reflector, config);
+    let fellThrough = false;
+    // passport 의 실제 JWT 검증 대신, 여기까지 왔다는 사실만 기록한다.
+    Object.getPrototypeOf(Object.getPrototypeOf(guard)).canActivate = () => {
+      fellThrough = true;
+      return false;
+    };
+    return { guard, fellThrough: () => fellThrough };
+  }
+
+  it('유효한 머신 키는 JWT 없이 통과한다', () => {
+    const { guard, fellThrough } = makeGuard({ isMachine: true });
+    expect(guard.canActivate(makeContext({ 'x-machine-key': MACHINE_KEY_VALUE }))).toBe(true);
+    expect(fellThrough()).toBe(false);
+  });
+
+  it('머신 라우트가 아니면 키가 맞아도 JWT 검사로 간다', () => {
+    const { guard, fellThrough } = makeGuard({ isMachine: false });
+    guard.canActivate(makeContext({ 'x-machine-key': MACHINE_KEY_VALUE }));
+    expect(fellThrough()).toBe(true);
+  });
+
+  it('틀린 머신 키는 JWT 검사로 간다', () => {
+    const { guard, fellThrough } = makeGuard({ isMachine: true });
+    guard.canActivate(makeContext({ 'x-machine-key': OTHER_KEY }));
+    expect(fellThrough()).toBe(true);
+  });
+
+  it('머신 키 헤더가 없으면 JWT 검사로 간다', () => {
+    const { guard, fellThrough } = makeGuard({ isMachine: true });
+    guard.canActivate(makeContext({}));
+    expect(fellThrough()).toBe(true);
+  });
+
+  it('BLOG_MACHINE_KEY 가 비어 있으면 빈 헤더로도 뚫리지 않는다', () => {
+    const { guard, fellThrough } = makeGuard({ isMachine: true, configured: false });
+    guard.canActivate(makeContext({ 'x-machine-key': '' }));
+    expect(fellThrough()).toBe(true);
+  });
+
+  it('길이가 다른 멀티바이트 키에도 500 이 아니라 JWT 검사로 간다', () => {
+    // 문자 수는 같아도 바이트 수가 다르면 timingSafeEqual 이 RangeError 를
+    // 던진다. 바이트로 먼저 걸러야 한다(api-key.guard 에서 실제로 겪었다).
+    const { guard, fellThrough } = makeGuard({ isMachine: true });
+    const sameCharsDifferentBytes = `${'m'.repeat(63)}가`;
+    expect(() =>
+      guard.canActivate(makeContext({ 'x-machine-key': sameCharsDifferentBytes })),
+    ).not.toThrow();
+    expect(fellThrough()).toBe(true);
+  });
+
+  it('공개 라우트는 그대로 통과한다', () => {
+    const { guard, fellThrough } = makeGuard({ isPublic: true });
+    expect(guard.canActivate(makeContext({}))).toBe(true);
+    expect(fellThrough()).toBe(false);
+  });
+});

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -1,13 +1,20 @@
 import { type ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import type { FastifyRequest } from 'fastify';
 import type { Observable } from 'rxjs';
 
+import { MACHINE_KEY } from '../decorators/machine-key.decorator';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { ApiKeyGuard } from './api-key.guard';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
-  constructor(private readonly reflector: Reflector) {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly config: ConfigService,
+  ) {
     super();
   }
 
@@ -18,6 +25,22 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     ]);
 
     if (isPublic) return true;
+
+    // 머신 라우트는 전용 키로도 통과시킨다. 스케줄러가 블로그 글을 무인
+    // 발행하는데, JWT 는 로그인 + 2FA 로 발급돼 기계가 쓸 수 없다.
+    //
+    // ⚠️ 조회용 API_KEY 가 아니라 BLOG_MACHINE_KEY 다 — 프런트가 들고 다니는
+    // 조회 키가 새어도 발행까지 뚫리면 안 된다.
+    // 키가 없거나 틀리면 아래 JWT 검사로 떨어지므로, 어드민 경로는 그대로다.
+    const isMachine = this.reflector.getAllAndOverride<boolean>(MACHINE_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isMachine) {
+      const request = context.switchToHttp().getRequest<FastifyRequest>();
+      const expected = this.config.get<string>('BLOG_MACHINE_KEY', '');
+      if (ApiKeyGuard.hasValidMachineKey(request, expected)) return true;
+    }
 
     return super.canActivate(context);
   }

--- a/src/common/swagger/swagger.config.ts
+++ b/src/common/swagger/swagger.config.ts
@@ -7,12 +7,16 @@ import { DocumentBuilder } from '@nestjs/swagger';
  * 여기 한 곳에서만 만든다. 양쪽에 DocumentBuilder를 각각 두면 스펙이 조용히 갈라진다.
  */
 export function buildSwaggerConfig() {
-  return new DocumentBuilder()
-    .setTitle('Hyunwoo API')
-    .setDescription('chahyunwoo.dev blog & portfolio API')
-    .setVersion('1.0')
-    .addBearerAuth()
-    .addCookieAuth('access_token')
-    .addApiKey({ type: 'apiKey', name: 'x-api-key', in: 'header' }, 'api-key')
-    .build();
+  return (
+    new DocumentBuilder()
+      .setTitle('Hyunwoo API')
+      .setDescription('chahyunwoo.dev blog & portfolio API')
+      .setVersion('1.0')
+      .addBearerAuth()
+      .addCookieAuth('access_token')
+      .addApiKey({ type: 'apiKey', name: 'x-api-key', in: 'header' }, 'api-key')
+      // 무인 발행용. 조회용 api-key 와 다른 키다.
+      .addApiKey({ type: 'apiKey', name: 'x-machine-key', in: 'header' }, 'machine-key')
+      .build()
+  );
 }


### PR DESCRIPTION
Closes #136

## 배경

포트폴리오 파이프라인(별도 저장소)이 3주 간격으로 블로그 글을 무인 발행하는데,
쓰기 엔드포인트가 JWT 전용이라 호출할 수 없었다. JWT 는 로그인 + 2FA 로 발급돼
스케줄러가 쓸 수 없다.

기존 `ApiKeyGuard` 는 방향이 반대다 — `@Public()` 조회 API 에만 `x-api-key` 를
검증하고, 비공개 라우트는 JWT 로 넘긴다.

## 변경

- `@MachineKey()` 데코레이터 추가. `JwtAuthGuard` 가 머신 라우트에서
  `x-machine-key` 를 **대체** 인증으로 받는다. 키가 없거나 틀리면 기존 JWT
  검사로 떨어지므로 어드민 경로는 그대로다 — 수단이 하나 늘어난 것이지
  열어 준 것이 아니다.
- 키는 `BLOG_MACHINE_KEY` 로 분리. 공개 조회용 `API_KEY` 를 재사용하지 않는다.
  조회 키는 프런트가 들고 다니므로 새어도 발행까지 뚫리면 안 된다.
- 비교는 `api-key.guard` 와 같게 **바이트 길이** 확인 후 `timingSafeEqual`.
  문자 수로 비교하면 멀티바이트 헤더에서 `RangeError` → 401 이 아니라 **500** 이
  된다(그 파일 주석에 남아 있는 기존 실측 사례와 같은 함정).
- 스로틀: posts 시간당 10회, images 40회.
- swagger 에 `machine-key` 스킴 등록 + `openapi.json` 반영.

머신 경로는 `POST posts` / `POST images` 둘뿐이다. `create()` 가 이미지 확정과
revalidation 까지 내부에서 처리하므로 이 둘로 발행이 끝난다 — `PUT`/`DELETE` 는
JWT 전용으로 남겨 무인 경로의 표면을 최소로 둔다.

## 리뷰에서 잡아 고친 것

**`openapi.json` 미반영 (CI 실패 상태였다).** `swagger.config.ts` 에 스킴을
추가하고 두 라우트에 `@ApiSecurity` 를 붙였는데 생성물을 같이 커밋하지 않아,
CI 의 `OpenAPI spec drift check` 가 실패할 상태였다. 재생성 결과는 예상과 정확히
일치한다(securitySchemes 1건 + 각 라우트 security 1건, 11줄).

**`ADMIN_IP_WHITELIST` 주의사항.** `AdminIpGuard` 는 `@Public()` 이 아닌 모든
라우트에 걸리고 `JwtAuthGuard` **뒤에** 등록돼 있어(`http.module.ts`), 머신 키가
맞아도 목록에 없는 IP 는 403 이 된다. 두 가드는 서로를 모른다. 지금은 값이 비어
있어 드러나지 않지만 채우는 순간 파이프라인이 조용히 막히므로, 그 값을 채우는
사람이 보는 자리(`.env.example`)에 남겼다.

## 검증

```
pnpm lint:ci      exit=0
pnpm typecheck    exit=0
pnpm build        exit=0
pnpm test         17 suites / 181 tests 통과
pnpm openapi:generate && git diff --exit-code openapi.json   → drift 없음
```

뮤테이션 2건으로 테스트 실효성 확인 (둘 다 잡힘)
- 바이트 길이 검사를 문자 수로 되돌림 → 멀티바이트 테스트 실패
- 빈 키 가드(`!expected`) 제거 → 미설정 통과 테스트 실패

테스트는 `super.canActivate` 를 가로채 "JWT 검사로 떨어졌는가"를 관측한다.
true/false 반환만 보면 "머신 키로 통과"와 "JWT 로 통과"가 구별되지 않는다.

## 배포 시 필요한 것

`main` 병합 전에 맥미니 `~/api-server/.env.prod` 에 `BLOG_MACHINE_KEY` 를 넣어야
한다. 배포는 `.env.prod` 를 `--env-file` 로 읽을 뿐 GitHub Secrets 에서 주입하지
않으므로, 서버 파일을 직접 고친 뒤 배포해야 한다. 비워 두면 머신 경로가 꺼진다
(빈 헤더로 통과하지 않는 것은 테스트로 확인). 파이프라인 쪽에도 같은 값을 넣는다.