### PR TITLE
[#138] 머신 키로 글 수정(PUT)을 허용한다

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1705,6 +1705,9 @@
         },
         "security": [
           {
+            "machine-key": []
+          },
+          {
             "cookie": []
           },
           {

--- a/src/blog/blog.controller.machine-key.spec.ts
+++ b/src/blog/blog.controller.machine-key.spec.ts
@@ -1,0 +1,49 @@
+// AuthService 는 otplib(ESM)을 끌어와 이 스펙의 트랜스폼을 깨뜨린다. 여기서
+// 보는 것은 컨트롤러의 메타데이터뿐이라 실제 구현이 필요 없다.
+jest.mock('../auth/auth.service', () => ({ AuthService: class {} }));
+
+import { Reflector } from '@nestjs/core';
+import { MACHINE_KEY } from '../common/decorators/machine-key.decorator';
+import { BlogController } from './blog.controller';
+
+/**
+ * 어느 라우트가 머신 키를 받는가.
+ *
+ * 가드 자체의 동작은 jwt-auth.guard.spec.ts 가 검사한다. 여기서 보는 것은
+ * **배선**이다 — `@MachineKey()` 가 의도한 라우트에만 붙어 있는지.
+ *
+ * 이 테스트가 필요한 이유: 데코레이터는 붙이거나 빼기가 한 줄이라, 나중에
+ * "수정도 되는데 삭제는 왜 안 되지"라며 DELETE 에 무심코 붙일 수 있다.
+ * 무인 발행이 글을 지울 이유는 없고, 지우는 것은 사람이 판단할 일이다.
+ * 열린 것뿐 아니라 **닫힌 것도** 검사해야 그 경계가 지켜진다.
+ */
+describe('BlogController 머신 키 배선', () => {
+  const reflector = new Reflector();
+
+  /** 라우트 핸들러에 @MachineKey() 가 붙어 있는가 */
+  function allowsMachineKey(method: keyof BlogController): boolean {
+    const handler = BlogController.prototype[method];
+    return reflector.get<boolean>(MACHINE_KEY, handler) === true;
+  }
+
+  describe('머신 키로 열려 있어야 하는 것', () => {
+    it('create — 무인 발행의 본체다', () => {
+      expect(allowsMachineKey('create')).toBe(true);
+    });
+
+    it('update — 발행한 글을 파이프라인이 고칠 수 있어야 한다', () => {
+      // 이게 닫혀 있어서 운영 DB 를 직접 UPDATE 하는 일이 실제로 있었다.
+      expect(allowsMachineKey('update')).toBe(true);
+    });
+
+    it('uploadImage — 파이프라인은 R2 자격증명을 갖지 않는다', () => {
+      expect(allowsMachineKey('uploadImage')).toBe(true);
+    });
+  });
+
+  describe('머신 키로 닫혀 있어야 하는 것', () => {
+    it('remove — 삭제는 사람이 판단한다', () => {
+      expect(allowsMachineKey('remove')).toBe(false);
+    });
+  });
+});

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -192,8 +192,20 @@ export class BlogController {
     return this.blogService.create(dto);
   }
 
+  // 무인 발행: 파이프라인이 자기가 발행한 글을 고친다. 이게 없으면 운영 DB 를
+  // 직접 UPDATE 하게 된다(실제로 그런 일이 있었다) — 그러면 파이프라인이 DB
+  // 스키마에 의존하고, 이미지 확정·재검증 같은 서버 처리를 통째로 우회한다.
+  //
+  // DELETE 는 열지 않는다. 지우는 것은 사람이 판단할 일이다.
+  //
+  // 전체 교체가 아니라 **부분 갱신**이라 안전하다. UpdatePostDto 는
+  // PartialType 이고 service.update() 가 `dto.X !== undefined` 로 보낸 필드만
+  // 갱신하므로, 파이프라인이 title 만 보내도 publishedAt·viewCount 는 남는다.
   @ApiBearerAuth()
   @ApiCookieAuth()
+  @ApiSecurity('machine-key')
+  @MachineKey()
+  @Throttle({ default: { ttl: 3_600_000, limit: 20 } })
   @Put('posts/:slug')
   @ApiOkResponse({ type: PostDetailDto })
   @ApiUnauthorized()


### PR DESCRIPTION
Closes #138

## 배경

무인 발행이 돌기 시작했는데(첫 글 id 53) **발행만 되고 수정이 안 됐다.**
`PUT /api/blog/posts/:slug` 가 어드민 JWT 전용이라 파이프라인이 자기가 발행한
글을 못 고쳤고, 그래서 **운영 DB 를 직접 UPDATE** 하는 일이 실제로 있었다.

그 방식의 문제:
- 파이프라인이 DB 스키마에 직접 의존한다
- 이미지 확정·재검증 같은 서버 처리를 통째로 우회한다
- 태그는 `tags` / `post_tags` 두 테이블을 손으로 맞춰야 한다

## 변경

`PUT /api/blog/posts/:slug` 에 `@MachineKey()` 를 붙였다. 스로틀은 시간당 20회.

**`DELETE` 는 열지 않았다.** 지우는 것은 사람이 판단할 일이고 무인 발행이 글을
지울 이유가 없다.

## 전체 교체가 아니라 부분 갱신이다 (필드 소실 없음)

열어주기 전에 확인했다.

- `UpdatePostDto extends PartialType(CreatePostDto)` — 전 필드 optional
- `service.update()` 가 `dto.X !== undefined && { X: ... }` 로 **보낸 필드만** 갱신
- `viewCount` 는 DTO 에 아예 없어 API 로 건드릴 수 없다
- `publishedAt` 은 안 보내면 유지된다 (`published: true` 로 바꿀 때만 자동 세팅)

즉 파이프라인이 `title` 만 보내도 나머지는 그대로 남는다.

## 테스트

라우트별 **배선**을 검사한다. 가드 동작 자체는 `jwt-auth.guard.spec.ts` 가 이미
보므로, 여기서는 `@MachineKey()` 가 의도한 라우트에만 붙었는지를 본다.
열린 것뿐 아니라 **닫힌 것(DELETE)도** 검사한다 — 데코레이터는 한 줄이라
나중에 "수정이 되는데 삭제는 왜 안 되지"라며 무심코 붙일 수 있다.

뮤테이션 2건으로 실효성 확인 (둘 다 잡혔다):

| 뮤테이션 | 치환 확인 | 결과 |
|---|---|---|
| PUT 의 `@MachineKey()` 제거 | 3→2건 | `update` 테스트만 실패 ✅ |
| DELETE 에 `@MachineKey()` 추가 | 3→4건 | `remove` 테스트만 실패 ✅ |

`AuthService` 를 모킹한다 — `otplib`(ESM)을 끌어와 트랜스폼이 깨졌고, 그대로
두면 테스트가 검사 대상에 **도달조차 못 한다**(처음에 실제로 그랬다).

## 검증

```
pnpm lint:ci      exit=0
pnpm typecheck    exit=0
pnpm build        exit=0
pnpm test         18 suites / 185 tests 통과
openapi 재생성    PUT 에 machine-key 3줄, 2회 생성 결과 동일 → drift 없음
```

## 범위 밖 — 태그 대소문자

`upsert({ update: {} })` 라 기존 태그가 있으면 `name` 을 유지한다. **현행 유지로
결정**했다.

실측(운영 DB): 소문자 태그는 101건 중 8건인데 `npm`·`pnpm`·`yarn`·`dotfiles`·
`next-mdx-remote` 는 소문자가 정식 표기이고, 한글 2건(`폴링`·`백오프`)은 대소문자가
없다. 실제 문제는 `code server` 1건뿐이라 수동 정정한다.

요청 `name` 으로 갱신하면 마지막 요청이 이겨서, 파이프라인이 `NPM` 을 한 번
잘못 보내면 그 태그를 쓰는 **기존 글 전체에 소급 적용**된다. 그 위험이 더 크다.