### PR TITLE
[#140] 미리보기 토큰을 DB 로 옮기고 TTL 을 24시간으로 늘린다

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1000,6 +1000,9 @@
         },
         "security": [
           {
+            "machine-key": []
+          },
+          {
             "cookie": []
           },
           {

--- a/prisma/migrations/20260906140000_add_preview_tokens/migration.sql
+++ b/prisma/migrations/20260906140000_add_preview_tokens/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "auth"."preview_tokens" (
+    "token" VARCHAR(64) NOT NULL,
+    "slug" VARCHAR(500) NOT NULL,
+    "expires_at" TIMESTAMPTZ(6) NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "preview_tokens_pkey" PRIMARY KEY ("token")
+);
+
+-- CreateIndex
+CREATE INDEX "preview_tokens_expires_at_idx" ON "auth"."preview_tokens"("expires_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,24 @@ model RefreshToken {
   @@schema("auth")
 }
 
+/// 비공개(초안) 글 미리보기 링크용 토큰.
+///
+/// DB 에 두는 이유: 예전에는 프로세스 메모리(Map)에 있어 **배포·재시작마다 전부
+/// 사라졌다.** 무인 발행 파이프라인이 초안을 올리고 사람이 다음 날 승인하는 흐름에서는
+/// 그 사이 배포가 한 번만 있어도 승인 링크가 죽는다.
+///
+/// slug 에 묶어 둔다 — 토큰이 새도 열리는 것은 그 글 하나뿐이다.
+model PreviewToken {
+  token     String   @id @db.VarChar(64)
+  slug      String   @db.VarChar(500)
+  expiresAt DateTime @map("expires_at") @db.Timestamptz(6)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@index([expiresAt])
+  @@map("preview_tokens")
+  @@schema("auth")
+}
+
 // ─── Blog ────────────────────────────────────────────────────────────────────
 
 model Category {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,10 +6,12 @@ import {
   ApiCreatedResponse,
   ApiExtraModels,
   ApiOkResponse,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import type { FastifyReply, FastifyRequest } from 'fastify';
+import { MachineKey } from '../common/decorators/machine-key.decorator';
 import { Public } from '../common/decorators/public.decorator';
 import { SkipApiKey } from '../common/decorators/skip-api-key.decorator';
 import { ApiBadRequest, ApiUnauthorized } from '../common/swagger/error-responses';
@@ -207,8 +209,15 @@ export class AuthController {
 
   // ─── Preview ──────────────────────────────────────────────────────────────
 
+  // 무인 발행: 파이프라인이 초안을 올린 뒤 승인용 미리보기 링크를 만든다.
+  // 어드민 JWT 전용이면 사람이 로그인해 줘야 링크가 생겨 무인 흐름이 끊긴다.
+  //
+  // 이 토큰은 slug 에 묶여 있고 미발행 글만 연다 — 새어도 범위가 그 글 하나다.
   @ApiBearerAuth()
   @ApiCookieAuth()
+  @ApiSecurity('machine-key')
+  @MachineKey()
+  @Throttle({ default: { ttl: 3_600_000, limit: 20 } })
   @Post('preview-token')
   @ApiCreatedResponse({ type: PreviewTokenDto })
   @HttpCode(HttpStatus.OK)
@@ -219,12 +228,12 @@ export class AuthController {
   @Public()
   @Get('verify-preview')
   @ApiOkResponse({ type: PreviewValidDto })
-  verifyPreview(
+  async verifyPreview(
     @Query('token') token: string,
     @Query('slug') slug: string | undefined,
     @Res() reply: FastifyReply,
   ) {
-    const valid = this.authService.verifyPreviewToken(token, slug);
+    const valid = await this.authService.verifyPreviewToken(token, slug);
     if (!valid) {
       return reply.status(HttpStatus.UNAUTHORIZED).send({
         statusCode: 401,

--- a/src/auth/auth.service.preview-token.spec.ts
+++ b/src/auth/auth.service.preview-token.spec.ts
@@ -8,7 +8,7 @@ jest.mock('otplib', () => ({
 
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import { PrismaService } from '../prisma/prisma.service';
+import type { PrismaService } from '../prisma/prisma.service';
 import { AuthService } from './auth.service';
 
 /**
@@ -17,8 +17,47 @@ import { AuthService } from './auth.service';
  * 고친 버그: `previewTokens` 가 `Map<string, number>`(만료시각만) 이라
  * 토큰 하나로 **모든** 비공개 글을 열 수 있었다. 어드민 프리뷰 링크가
  * 한 번 새면 미발행 글 전체가 노출된다.
+ *
+ * #140 에서 저장소가 인메모리 Map → DB 로 바뀌었다(배포마다 토큰이 전부
+ * 사라져 승인 흐름이 깨졌기 때문). 저장소가 바뀌어도 **slug 바인딩은 그대로
+ * 지켜져야 하므로** 이 스펙은 남는다. 아래 fake 는 Prisma 대신 Map 을 쓰지만,
+ * 검사 대상은 여전히 AuthService 의 판정 로직이다.
  */
 describe('AuthService 프리뷰 토큰 slug 바인딩', () => {
+  type Row = { token: string; slug: string; expiresAt: Date };
+
+  /** previewToken 델리게이트만 흉내내는 최소 fake */
+  function createFakePrisma() {
+    const rows = new Map<string, Row>();
+    return {
+      rows,
+      previewToken: {
+        create: async ({ data }: { data: Row }) => {
+          rows.set(data.token, data);
+          return data;
+        },
+        findUnique: async ({ where }: { where: { token: string } }) =>
+          rows.get(where.token) ?? null,
+        delete: async ({ where }: { where: { token: string } }) => {
+          const row = rows.get(where.token);
+          if (!row) throw new Error('not found');
+          rows.delete(where.token);
+          return row;
+        },
+        deleteMany: async ({ where }: { where: { expiresAt: { lt: Date } } }) => {
+          let count = 0;
+          for (const [token, row] of rows) {
+            if (row.expiresAt < where.expiresAt.lt) {
+              rows.delete(token);
+              count++;
+            }
+          }
+          return { count };
+        },
+      },
+    };
+  }
+
   function createService(): AuthService {
     const config = {
       getOrThrow: (key: string) => {
@@ -27,60 +66,84 @@ describe('AuthService 프리뷰 토큰 slug 바인딩', () => {
       },
     } as unknown as ConfigService;
 
-    return new AuthService(config, {} as JwtService, {} as PrismaService);
+    const prisma = createFakePrisma() as unknown as PrismaService;
+    return new AuthService(config, {} as JwtService, prisma);
   }
 
-  it('발급받은 slug 에 대해서는 통과한다', () => {
+  it('발급받은 slug 에 대해서는 통과한다', async () => {
     const service = createService();
-    const { token } = service.createPreviewToken('my-post');
+    const { token } = await service.createPreviewToken('my-post');
 
-    expect(service.verifyPreviewToken(token, 'my-post')).toBe(true);
+    await expect(service.verifyPreviewToken(token, 'my-post')).resolves.toBe(true);
   });
 
-  it('다른 글의 slug 로는 거부한다 — 이것이 #125 의 본체다', () => {
+  it('다른 글의 slug 로는 거부한다 — 이것이 #125 의 본체다', async () => {
     const service = createService();
-    const { token } = service.createPreviewToken('my-post');
+    const { token } = await service.createPreviewToken('my-post');
 
-    expect(service.verifyPreviewToken(token, 'secret-unpublished-post')).toBe(false);
+    await expect(service.verifyPreviewToken(token, 'secret-unpublished-post')).resolves.toBe(false);
   });
 
-  it('서로 다른 slug 로 발급한 토큰은 서로의 글을 열지 못한다', () => {
+  it('서로 다른 slug 로 발급한 토큰은 서로의 글을 열지 못한다', async () => {
     const service = createService();
-    const a = service.createPreviewToken('post-a');
-    const b = service.createPreviewToken('post-b');
+    const a = await service.createPreviewToken('post-a');
+    const b = await service.createPreviewToken('post-b');
 
-    expect(service.verifyPreviewToken(a.token, 'post-a')).toBe(true);
-    expect(service.verifyPreviewToken(a.token, 'post-b')).toBe(false);
-    expect(service.verifyPreviewToken(b.token, 'post-b')).toBe(true);
-    expect(service.verifyPreviewToken(b.token, 'post-a')).toBe(false);
+    await expect(service.verifyPreviewToken(a.token, 'post-a')).resolves.toBe(true);
+    await expect(service.verifyPreviewToken(a.token, 'post-b')).resolves.toBe(false);
+    await expect(service.verifyPreviewToken(b.token, 'post-b')).resolves.toBe(true);
+    await expect(service.verifyPreviewToken(b.token, 'post-a')).resolves.toBe(false);
   });
 
-  it('존재하지 않는 토큰은 거부한다', () => {
+  it('존재하지 않는 토큰은 거부한다', async () => {
     const service = createService();
-    service.createPreviewToken('my-post');
+    await service.createPreviewToken('my-post');
 
-    expect(service.verifyPreviewToken('deadbeef', 'my-post')).toBe(false);
+    await expect(service.verifyPreviewToken('deadbeef', 'my-post')).resolves.toBe(false);
   });
 
-  it('만료된 토큰은 slug 가 맞아도 거부한다', () => {
+  it('만료된 토큰은 slug 가 맞아도 거부한다', async () => {
     const service = createService();
-    const { token } = service.createPreviewToken('my-post');
+    const { token } = await service.createPreviewToken('my-post');
 
-    // TTL 은 30분이다. 그 너머로 시계를 옮긴다.
+    // TTL 은 24시간이다(#140 이전에는 30분). 그 너머로 시계를 옮긴다.
     const realNow = Date.now;
-    Date.now = () => realNow() + 31 * 60 * 1000;
+    Date.now = () => realNow() + 25 * 60 * 60 * 1000;
     try {
-      expect(service.verifyPreviewToken(token, 'my-post')).toBe(false);
+      await expect(service.verifyPreviewToken(token, 'my-post')).resolves.toBe(false);
     } finally {
       Date.now = realNow;
     }
   });
 
-  it('slug 를 넘기지 않으면 유효성만 본다 (어드민 상태 확인용 경로)', () => {
+  it('slug 를 넘기지 않으면 유효성만 본다 (어드민 상태 확인용 경로)', async () => {
     const service = createService();
-    const { token } = service.createPreviewToken('my-post');
+    const { token } = await service.createPreviewToken('my-post');
 
-    expect(service.verifyPreviewToken(token)).toBe(true);
-    expect(service.verifyPreviewToken('deadbeef')).toBe(false);
+    await expect(service.verifyPreviewToken(token)).resolves.toBe(true);
+    await expect(service.verifyPreviewToken('deadbeef')).resolves.toBe(false);
+  });
+
+  /**
+   * #140 에서 TTL 을 30분 → 24시간으로 늘렸다. 예전에는 `expiresIn: 1800` 이
+   * 하드코딩돼 있어 상수를 고쳐도 응답은 30분 그대로였다 — 파이프라인이 그 값으로
+   * 디스코드에 만료 시각을 안내하면 거짓말이 된다.
+   *
+   * 그래서 "응답값이 실제 만료와 같은가"를 본다. 상수를 직접 읽어 비교하면
+   * 하드코딩 회귀를 못 잡으므로, 저장된 expiresAt 과 대조한다.
+   */
+  it('expiresIn 이 실제 저장된 만료 시각과 일치한다', async () => {
+    const service = createService();
+    const fake = createFakePrisma();
+    Object.assign(service, { prisma: fake });
+
+    const before = Date.now();
+    const { token, expiresIn } = await service.createPreviewToken('my-post');
+    const row = fake.rows.get(token);
+
+    if (!row) throw new Error('토큰이 저장되지 않았다');
+    const actualSeconds = Math.round((row.expiresAt.getTime() - before) / 1000);
+    expect(expiresIn).toBe(actualSeconds);
+    expect(expiresIn).toBe(24 * 60 * 60);
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -237,49 +237,62 @@ export class AuthService {
     return { accessToken, refreshToken: newRefreshToken };
   }
 
+  // 로그아웃은 미리보기 토큰을 건드리지 않는다.
+  //
+  // 예전에는 여기서 revokeAllPreviewTokens() 를 불렀다. 어드민만 발급하던 시절에는
+  // 말이 됐지만, 지금은 무인 발행 파이프라인도 발급한다 — 사람이 로그아웃할 때마다
+  // 파이프라인이 만든 승인 링크가 죽으면 안 된다. 미리보기 토큰은 어드민 세션과
+  // 수명이 무관하고, slug 에 묶여 미발행 글 하나만 여는 별개의 자격이다.
   async logout(refreshToken: string): Promise<void> {
     const tokenHash = this.hashToken(refreshToken);
     await this.prisma.refreshToken.deleteMany({ where: { tokenHash } });
-    this.revokeAllPreviewTokens();
   }
 
   async logoutAll(username: string): Promise<void> {
     await this.prisma.refreshToken.deleteMany({ where: { username } });
-    this.revokeAllPreviewTokens();
   }
 
+  /**
+   * 만료된 토큰을 치운다. 리프레시 토큰과 미리보기 토큰 **둘 다** 본다 —
+   * 미리보기 토큰은 개수 상한이 없으므로 이 정리가 유일한 회수 경로다.
+   */
   async cleanupExpiredTokens(): Promise<number> {
-    const result = await this.prisma.refreshToken.deleteMany({
-      where: { expiresAt: { lt: new Date() } },
-    });
-    return result.count;
+    const [refresh, preview] = await Promise.all([
+      this.prisma.refreshToken.deleteMany({ where: { expiresAt: { lt: new Date() } } }),
+      this.cleanupPreviewTokens(),
+    ]);
+    return refresh.count + preview;
   }
 
   // ─── Preview Token ────────────────────────────────────────────────────────
 
-  // 토큰 -> { 만료시각, 대상 slug }
-  // slug 를 함께 담는 이유: 예전에는 만료시각만 저장해 한 번 발급된 토큰으로
-  // **모든** 비공개 글을 열 수 있었다. 토큰이 새면 피해가 그 글 하나로
-  // 그치도록 발급 시점의 slug 에 묶는다.
-  private readonly previewTokens = new Map<string, { expiresAt: number; slug: string }>();
-  private static readonly PREVIEW_TOKEN_TTL = 30 * 60 * 1000; // 30 minutes
-  private static readonly MAX_PREVIEW_TOKENS = 10;
+  private static readonly PREVIEW_TOKEN_TTL_SECONDS = 24 * 60 * 60; // 24시간
 
-  createPreviewToken(slug: string): { token: string; expiresIn: number } {
-    this.cleanupPreviewTokens();
-
-    if (this.previewTokens.size >= AuthService.MAX_PREVIEW_TOKENS) {
-      const oldest = this.previewTokens.keys().next().value;
-      if (oldest) this.previewTokens.delete(oldest);
-    }
-
+  /**
+   * 미리보기 토큰을 발급한다.
+   *
+   * slug 에 묶는 이유: 예전에는 만료시각만 저장해 한 번 발급된 토큰으로 **모든**
+   * 비공개 글을 열 수 있었다. 토큰이 새면 피해가 그 글 하나로 그치게 한다.
+   *
+   * DB 에 저장하는 이유: 예전에는 프로세스 메모리(Map)라 **배포·재시작마다 전부
+   * 사라졌다.** 파이프라인이 초안을 올리고 사람이 다음 날 승인하는 흐름에서는
+   * 그 사이 배포가 한 번만 있어도 링크가 죽는다.
+   *
+   * 개수 상한을 두지 않는다. 예전의 MAX 10 + FIFO 축출은 `keys().next().value` 로
+   * **가장 먼저 삽입된 것**을 버려서, 초안이 쌓이면 아직 몇 시간 남은 토큰이 방금
+   * 만든 것 때문에 밀려났다. 만료분은 cleanupExpiredTokens 가 치운다.
+   */
+  async createPreviewToken(slug: string): Promise<{ token: string; expiresIn: number }> {
     const token = randomBytes(32).toString('hex');
-    this.previewTokens.set(token, {
-      expiresAt: Date.now() + AuthService.PREVIEW_TOKEN_TTL,
-      slug,
+    const ttl = AuthService.PREVIEW_TOKEN_TTL_SECONDS;
+
+    await this.prisma.previewToken.create({
+      data: { token, slug, expiresAt: new Date(Date.now() + ttl * 1000) },
     });
 
-    return { token, expiresIn: 1800 };
+    // TTL 에서 유도한다. 예전에는 1800 이 하드코딩돼 있어 상수를 고쳐도 응답값이
+    // 30분 그대로였다 — 파이프라인이 그 값으로 만료 시각을 안내하면 거짓말이 된다.
+    return { token, expiresIn: ttl };
   }
 
   isAuthenticated(token?: string): boolean {
@@ -296,25 +309,28 @@ export class AuthService {
    * `slug` 를 넘기면 그 글에 대해 발급된 토큰인지까지 확인한다.
    * 넘기지 않으면 유효성(존재·만료)만 본다 — 어드민의 토큰 상태 확인용이다.
    */
-  verifyPreviewToken(token: string, slug?: string): boolean {
-    const entry = this.previewTokens.get(token);
-    if (!entry || entry.expiresAt < Date.now()) {
-      this.previewTokens.delete(token);
+  async verifyPreviewToken(token: string, slug?: string): Promise<boolean> {
+    if (!token) return false;
+
+    const entry = await this.prisma.previewToken.findUnique({ where: { token } });
+    if (!entry) return false;
+
+    // Date.now() 로 읽는다 — new Date() 를 쓰면 테스트가 시계를 못 옮겨
+    // 만료 검사가 사실상 검증되지 않는다(실제로 그래서 한 번 놓쳤다).
+    if (entry.expiresAt.getTime() < Date.now()) {
+      await this.prisma.previewToken.delete({ where: { token } }).catch(() => undefined); // 동시 요청이 이미 지웠을 수 있다
       return false;
     }
+
     if (slug !== undefined && entry.slug !== slug) return false;
     return true;
   }
 
-  private revokeAllPreviewTokens(): void {
-    this.previewTokens.clear();
-  }
-
-  private cleanupPreviewTokens(): void {
-    const now = Date.now();
-    for (const [token, entry] of this.previewTokens) {
-      if (entry.expiresAt < now) this.previewTokens.delete(token);
-    }
+  private async cleanupPreviewTokens(): Promise<number> {
+    const result = await this.prisma.previewToken.deleteMany({
+      where: { expiresAt: { lt: new Date(Date.now()) } },
+    });
+    return result.count;
   }
 
   // ─── Private ──────────────────────────────────────────────────────────────

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -159,7 +159,7 @@ export class BlogController {
   async findOnePreview(@Param('slug') slug: string, @Query('token') token: string) {
     // slug 를 함께 넘겨 "이 글에 대해 발급된 토큰인가"까지 확인한다.
     // 넘기지 않으면 토큰 하나로 모든 비공개 글이 열린다.
-    if (!token || !this.authService.verifyPreviewToken(token, slug)) {
+    if (!token || !(await this.authService.verifyPreviewToken(token, slug))) {
       throw new UnauthorizedException('Invalid or expired preview token');
     }
     return this.blogService.findBySlug(slug, true);


### PR DESCRIPTION
Closes #140

파이프라인이 초안을 올리고 디스코드로 승인 요청을 보내는 흐름이 생겼는데, 자정에
알림을 받고 아침에 승인하면 TTL 30분이라 이미 만료였다.

## TTL 만 늘리면 안 되는 것이 네 가지였다

**① 토큰이 인메모리라 배포마다 사라졌다.** `auth.service.ts` 의 `new Map()` 이라
서버 재시작에 전부 없어진다 — 오늘만 배포로 컨테이너가 두 번 재시작됐다. TTL 을
24시간으로 늘려도 **실질 수명은 "다음 배포까지"**라 승인 흐름이 여전히 깨진다.
→ `PreviewToken` 테이블로 옮겼다.

**② `expiresIn: 1800` 하드코딩.** TTL 과 무관하게 30분을 고정 반환했다. 상수만
고쳤으면 실제 수명과 응답이 어긋나, 파이프라인이 그 값으로 디스코드에 만료를
안내하면 거짓말이 된다. → TTL 에서 유도한다.

**③ MAX 10 + FIFO 축출.** `keys().next().value` 는 **가장 먼저 삽입된 것**을 버린다 —
만료 임박한 게 아니다. 초안이 11개 쌓이면 아직 몇 시간 남은 토큰이 방금 만든 것
때문에 밀려났다. → 상한 제거, 만료분은 `cleanupExpiredTokens` 가 치운다.

**④ 로그아웃이 미리보기 토큰을 전부 지웠다.** `logout()`/`logoutAll()` 이
`revokeAllPreviewTokens()` 를 불렀다. 어드민만 발급하던 시절엔 말이 됐지만 이제
파이프라인도 발급한다 — **사람이 로그아웃할 때마다 파이프라인 승인 링크가 죽는다.**
→ 분리했다. 미리보기 토큰은 어드민 세션과 수명이 무관하고 slug 에 묶여 미발행 글
하나만 여는 별개의 자격이다.

## 발급을 머신 키로 연다

`POST /api/auth/preview-token` 에 `@MachineKey()`. slug 바인딩과 미발행 전용은
그대로라 새어도 범위는 그 글 하나다.

## 검증

```
pnpm lint:ci / typecheck / build   전부 exit=0
pnpm test                          18 suites / 186 tests 통과
openapi 재생성                     drift 없음
```

**마이그레이션을 실제로 돌려봤다.** 손으로 쓴 SQL 이라 스키마와 일치하는지 확인이
필요했다. 운영 DB 가 아닌 임시 DB(`migtest`)를 만들어 적용하고, 생성된 테이블 구조가
Prisma 스키마와 같은지 대조한 뒤 삭제했다. 운영 DB 는 건드리지 않았다.

**뮤테이션 3건 (전부 잡혔다)**

| 뮤테이션 | 결과 |
|---|---|
| slug 바인딩 검사 제거 | #125 회귀 테스트 2건 실패 ✅ |
| `expiresIn` 을 1800 으로 복원 | 만료 시각 일치 테스트 실패 ✅ |
| 만료 검사 제거 | 만료 거부 테스트 실패 ✅ |

## 고쳐야 했던 함정 둘

**시계를 주입할 수 없어 만료 테스트가 통과해버렸다.** `verifyPreviewToken` 이
`new Date()` 를 쓰는데 테스트는 `Date.now` 를 가로채서, 시계 조작이 안 먹혀
**검사 대상에 도달조차 못 한 채 초록**이 나왔다. `Date.now()` 로 통일했다.

**async 전환 파급을 전수 확인했다.** `blog.controller` 의 미리보기 조회가 특히
중요한데, `await` 없이 Promise 를 `!` 로 검사하면 항상 truthy 라 **인증이 통째로
뚫린다.** 호출부 3곳을 모두 고쳤다.

## 배포 시 주의

마이그레이션이 포함된 첫 배포다(`prisma migrate deploy` 가 컨테이너 시작 시 자동
실행). 테이블 생성만 하는 비파괴 마이그레이션이라 롤백 위험은 낮지만,
`deploy.sh` 는 스키마를 되돌리지 않는다는 점은 그대로다.