### PR TITLE
[#142] multipart 아닌 업로드 요청을 400 으로 돌려준다

### DIFF
--- a/src/common/utils/file-validation.util.spec.ts
+++ b/src/common/utils/file-validation.util.spec.ts
@@ -1,0 +1,54 @@
+import { BadRequestException } from '@nestjs/common';
+import type { MultipartRequest } from '../../types/fastify.d';
+import { validateAndReadFile } from './file-validation.util';
+
+/**
+ * multipart 계층이 던지는 에러가 400 으로 변환되는지 검사한다 (#142).
+ *
+ * 고친 버그: `request.file()` 은 본문이 multipart 가 아니면 null 을 주는 게 아니라
+ * `FastifyError` 를 **던진다.** 그건 HttpException 이 아니라서 예외 필터의 마지막
+ * 분기로 떨어져 **400 이 아니라 500** 이 나갔다.
+ *
+ * 왜 중요한가: 클라이언트 잘못인데 서버 오류로 보고되면, 5xx 를 재시도 대상으로
+ * 보는 호출자(무인 발행 파이프라인)가 고칠 수 없는 요청을 백오프하며 반복한다.
+ *
+ * 같은 파일 MAX_FILE_SIZE 주석의 크기 초과 사례와 **같은 형태**다 — multipart 가
+ * 던지는 에러를 감싸 주지 않으면 전부 500 이 된다. 그래서 "던지는 경우"를 여기서
+ * 고정해 둔다.
+ */
+describe('validateAndReadFile — multipart 아닌 요청', () => {
+  /** file() 이 주어진 동작을 하는 최소 요청 객체 */
+  function makeRequest(fileImpl: () => Promise<unknown>): MultipartRequest {
+    return { file: fileImpl } as unknown as MultipartRequest;
+  }
+
+  it('file() 이 던지면 500 이 아니라 BadRequest 로 바꾼다 — 이것이 #142 의 본체다', async () => {
+    // fastify-multipart 가 실제로 던지는 형태
+    const req = makeRequest(() => Promise.reject(new Error('the request is not multipart')));
+
+    await expect(validateAndReadFile(req)).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('file() 이 null 을 주면 BadRequest 다 (기존 경로 회귀 방지)', async () => {
+    const req = makeRequest(() => Promise.resolve(null));
+
+    await expect(validateAndReadFile(req)).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  /**
+   * 던지는 것을 전부 400 으로 바꾸면 안 된다. 파일을 읽는 도중의 실패(디스크·네트워크)는
+   * 클라이언트 잘못이 아니므로 500 이 맞다. try 범위가 `file()` 하나여야 하는 이유다.
+   */
+  it('toBuffer() 단계의 실패는 400 으로 삼키지 않는다', async () => {
+    const req = makeRequest(() =>
+      Promise.resolve({ toBuffer: () => Promise.reject(new Error('disk read failed')) }),
+    );
+
+    await expect(validateAndReadFile(req)).rejects.not.toBeInstanceOf(BadRequestException);
+  });
+
+  // 내용 검증(file-type) 경로는 여기서 다루지 않는다. `await import('file-type')` 이
+  // ESM 동적 import 라 jest 가 --experimental-vm-modules 없이는 TypeError 를 낸다 —
+  // 제품 코드 문제가 아니라 러너 제약이고, #142 의 검사 대상도 아니다.
+  // 그 경로는 운영에서 실제 multipart 업로드로 400 이 나오는 것을 확인했다.
+});

--- a/src/common/utils/file-validation.util.ts
+++ b/src/common/utils/file-validation.util.ts
@@ -36,7 +36,21 @@ export function safeExtension(mimeType: string): string {
 }
 
 export async function validateAndReadFile(request: MultipartRequest) {
-  const data = await request.file();
+  // `request.file()` 은 본문이 multipart 가 아니면 **null 을 주는 게 아니라 던진다**
+  // (`FastifyError: the request is not multipart`). 그건 HttpException 이 아니라서
+  // 예외 필터의 마지막 분기로 떨어져 **400 이 아니라 500** 이 나간다.
+  //
+  // 그러면 클라이언트 잘못인데 서버 오류로 보고되고, 5xx 를 재시도 대상으로 보는
+  // 호출자(무인 발행 파이프라인)가 고칠 수 없는 요청을 백오프하며 반복한다.
+  //
+  // 위 MAX_FILE_SIZE 주석의 크기 초과 사례와 **같은 형태**다 — multipart 계층이
+  // 던지는 에러를 HttpException 으로 바꿔 주지 않으면 전부 500 이 된다.
+  let data: Awaited<ReturnType<MultipartRequest['file']>>;
+  try {
+    data = await request.file();
+  } catch {
+    throw new BadRequestException('Request must be multipart/form-data');
+  }
   if (!data) throw new BadRequestException('No file provided');
 
   const buffer = await data.toBuffer();


### PR DESCRIPTION
Closes #142

## 증상

`POST /api/blog/images` 에 multipart 가 아닌 본문을 보내면 **500** 이 나갔다.

```
curl -X POST /api/blog/images -H "x-machine-key: <valid>"
  → 500 {"statusCode":500,"error":"Internal Server Error"}

로그: ERROR [HttpExceptionFilter] the request is not multipart
      FastifyError: the request is not multipart
```

정상 multipart 로 보내면 400(내용 검증)이 나오므로 **정상 경로는 살아 있었다.**

## 원인

`request.file()` 은 본문이 multipart 가 아니면 **null 을 주는 게 아니라 던진다.**
코드는 `!data`(null) 만 대비하고 있었다.

`FastifyError` 는 `HttpException` 이 아니라서 예외 필터의 마지막 분기로 떨어져
400 이 아니라 500 이 된다.

## 같은 자리에서 재발한 형태다

바로 위 `MAX_FILE_SIZE` 주석에 **정확히 같은 실패**가 이미 적혀 있다 —
"multipart가 던지는 에러는 HttpException이 아니라서 413이 아닌 500이 나갔다".
그때는 크기 초과였고 이번엔 multipart 아님이다. 원인이 같은데 한 경로만 고쳐져 있었다.

## 왜 고치나

클라이언트 잘못(400)인데 서버 오류(500)로 보고되면, **5xx 를 재시도 대상으로 보는
호출자가 고칠 수 없는 요청을 백오프하며 반복한다.** 무인 발행 파이프라인이 그렇게
동작한다(429·5xx 지수 백오프 3회 — 파이프라인 쪽 확인).

파이프라인은 항상 정상 multipart 로 보내고 있어 현재 영향은 없다. 방어 목적이다.

## try 범위를 `file()` 하나로 좁혔다

`toBuffer()` 단계의 실패(디스크·네트워크)는 클라이언트 잘못이 아니므로 500 이 맞다.
전부 감싸면 그것까지 400 으로 삼킨다. 테스트로 고정했다.

## 검증

```
pnpm lint:ci / typecheck / build   전부 exit=0
pnpm test                          19 suites / 189 tests 통과
openapi                            변경 없음 (내부 로직만)
```

**뮤테이션 1건 (잡혔다)**

| 뮤테이션 | 치환 확인 | 결과 |
|---|---|---|
| try/catch 제거해 수정 전으로 되돌림 | 1→0건 | #142 테스트만 실패 ✅ |

내용 검증(file-type) 경로는 스펙에서 다루지 않는다. `await import('file-type')` 이
ESM 동적 import 라 jest 가 `--experimental-vm-modules` 없이는 `TypeError` 를 낸다 —
러너 제약이지 제품 코드 문제가 아니다(테스트에 주석으로 남겼다). 그 경로는 운영에서
실제 multipart 업로드로 400 이 나오는 것을 확인했다.